### PR TITLE
pam_exec: fix null pointer dereference when pam_prompt returns a NULL response

### DIFF
--- a/modules/pam_exec/pam_exec.8.xml
+++ b/modules/pam_exec/pam_exec.8.xml
@@ -22,7 +22,7 @@
 	debug
       </arg>
       <arg choice="opt">
-         expose_authtok
+         expose_authtok[=ask|get]
       </arg>
       <arg choice="opt">
         seteuid
@@ -99,7 +99,7 @@
 
         <varlistentry>
           <term>
-            <option>expose_authtok</option>
+            <option>expose_authtok[=ask|get]</option>
           </term>
           <listitem>
             <para>
@@ -107,7 +107,10 @@
               the password from <citerefentry>
               <refentrytitle>stdin</refentrytitle><manvolnum>3</manvolnum>
               </citerefentry>. Only first <emphasis>PAM_MAX_RESP_SIZE</emphasis>
-              bytes of a password are provided to the command.
+              bytes of a password are provided to the command. If expose_authtok=ask
+              is specified, pam_exec asks for a password. If expose_authtok=get
+              is specified, pam_exec assums another module has already set the password.
+              expose_authtok can be specified without an argument to maintain backward compatibility.
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
I fixed a null pointer dereference when pam_prompt is aborted with ctrl-d, in which case the return value is PAM_SUCCESS but resp was set to NULL, which caused a segfault in the following strndupa.

I also added the options authtok=get, which assumes that authtok is already set and will never ask for a password, and authtok=ask which always asks for the password, because I use pam_exec in a place where another module already asked for the password, and when I abort that password prompt with ctrl-d, PAM_AUTHTOK is set to null and pam_exec would ask for the password again.
