### PR TITLE
Fixed a null pointer dereference when pam_prompt returns PAM_SUCCESS but response is set to NULL

### DIFF
--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -178,8 +178,11 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 		}
 
 	      pam_set_item (pamh, PAM_AUTHTOK, resp);
-	      authtok = strndupa (resp, PAM_MAX_RESP_SIZE);
-	      _pam_drop (resp);
+	      if (resp)
+		{
+		  authtok = strndupa (resp, PAM_MAX_RESP_SIZE);
+		  _pam_drop (resp);
+		}
 	    }
 	  else
 	    authtok = strndupa (void_pass, PAM_MAX_RESP_SIZE);


### PR DESCRIPTION
Here is just the bugfix.
