### PR TITLE
Fix pam_xauth when using pam_mktemp.

### DIFF
--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -478,7 +478,7 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 	   *                 if .xauth/export does not exist
 	   * import(user=*): if <ruser> is listed in .xauth/import, or
 	   *                 if .xauth/import does not exist */
-	  i = (getuid() != 0 || tpwd->pw_uid == 0) ? PAM_SUCCESS : PAM_PERM_DENIED;
+	  i = (rpwd->pw_uid != 0 || tpwd->pw_uid == 0) ? PAM_SUCCESS : PAM_PERM_DENIED;
 	  i = check_acl(pamh, "export", rpwd->pw_name, user, i, debug);
 	  if (i != PAM_SUCCESS) {
 	    retval = PAM_SESSION_ERR;
@@ -521,10 +521,10 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 		pam_syslog(pamh, LOG_DEBUG,
 			   "running \"%s %s %s %s %s\" as %lu/%lu",
 			   xauth, "-f", cookiefile, "nlist", display,
-			   (unsigned long) getuid(), (unsigned long) getgid());
+			   (unsigned long) rpwd->pw_uid, (unsigned long) rpwd->pw_gid);
 	}
 	if (run_coprocess(pamh, NULL, &cookie,
-			  getuid(), getgid(),
+			  rpwd->pw_uid, rpwd->pw_gid,
 			  xauth, "-f", cookiefile, "nlist", display,
 			  NULL) == 0) {
 #ifdef WITH_SELINUX
@@ -579,11 +579,11 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 						       cookiefile,
 						       "nlist",
 						       t,
-						       (unsigned long) getuid(),
-						       (unsigned long) getgid());
+						       (unsigned long) rpwd->pw_uid,
+						       (unsigned long) rpwd->pw_gid);
 					}
 					run_coprocess(pamh, NULL, &cookie,
-						      getuid(), getgid(),
+						      rpwd->pw_uid, rpwd->pw_gid,
 						      xauth, "-f", cookiefile,
 						      "nlist", t, NULL);
 				}


### PR DESCRIPTION
For some reason when using su, getgid won't return the calling user's gid but 0 (root).
pam_mktemp will cause the xauthority file to be created on a folder where either uid 0 or the user's gid are required to access it.
As a result of those two conditions, xauth will be run with the user's uid but gid 0 and therefore fail acquiring the magic cookies locking the call to su for 30 seconds.

In this commit we replace all calls to getuid and getgid to accesses to the cached structure from pam_modutil_getpwuid which is used at the beggining.
This will make xauth run using both the user's uid and gid and fix this issue.

As a side effect, having less syscalls may speed up loging slightly (but to a nearly unnoticeable level).

For more information, see https://bugs.gentoo.org/show_bug.cgi?id=585550