### PR TITLE
strtoX() does not set endptr to NULL

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -727,7 +727,7 @@ network_netmask_match (pam_handle_t *pamh,
 	  { /* netmask as integre value */
 	    char *endptr = NULL;
 	    netmask = strtol(netmask_ptr, &endptr, 0);
-	    if ((endptr == NULL) || (*endptr != '\0'))
+	    if ((endptr == netmask_ptr) || (*endptr != '\0'))
 		{ /* invalid netmask value */
 		  return NO;
 		}


### PR DESCRIPTION
According to the manual page: "If there were no digits at all, strtol() stores the original value of nptr in *endptr (and returns 0)", so it will not be set to NULL.