### PR TITLE
Make maxclassrepeat=1 behavior consistent with docs

### DIFF
--- a/modules/pam_cracklib/pam_cracklib.c
+++ b/modules/pam_cracklib/pam_cracklib.c
@@ -408,7 +408,7 @@ static int simple(struct cracklib_options *opt, const char *new)
             } else
                 sameclass++;
         }
-        if (opt->max_class_repeat > 1 && sameclass > opt->max_class_repeat) {
+        if (opt->max_class_repeat > 0 && sameclass > opt->max_class_repeat) {
                 return 1;
         }
     }


### PR DESCRIPTION
I'm Saul, a researcher at Teesside University, UK. We use `pam_cracklib` in our teaching and found what seems to be a bug when the `maxclassrepeat` option is set to `1`. Myself, along with researchers from the university's [Software Reliability Lab](https://github.com/sr-lab) discovered the following:

If `maxclassrepeat` is set to a number greater than `1` it behaves as expected. For instance setting it to `3` would cause the following password to be flagged as 'too simple':

```
myfavouritesong
```

Due to it containing more than 3 lowercase letters in a row. This is consistent with the documentation.

However, setting `maxclassrepeat` to `1` would result in the example above being allowed. This is due to a check done in `pam_cracklib.c` [line 411](https://github.com/linux-pam/linux-pam/blob/a9253114c719eace32006058656671f8987eeb12/modules/pam_cracklib/pam_cracklib.c#L411) which should presumably test `opt->max_class_repeat > 0` rather than `opt->max_class_repeat > 1`. 

With the change in the proposed PR, the behaviour of the option is changed to be consistent with [the documentation](https://github.com/linux-pam/linux-pam/blob/a9253114c719eace32006058656671f8987eeb12/modules/pam_cracklib/pam_cracklib.8.xml#L379), which states that it will cause passwords with more than `N` consecutive characters of the same class to be rejected with `0` disabling the check. 