### PR TITLE
pam_timestamp: Correctly handle Unix98 ptys.

### DIFF
--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -151,9 +151,10 @@ check_tty(const char *tty)
 	}
 	/* Pull out the meaningful part of the tty's name. */
 	if (strchr(tty, '/') != NULL) {
-		if (strncmp(tty, "/dev/", 5) != 0) {
+		if ((strncmp(tty, "/dev/", 5) != 0) && (strncmp(tty, "pts/", 4) != 0)) {
 			/* Make sure the device node is actually in /dev/,
-			 * noted by Michal Zalewski. */
+			 * noted by Michal Zalewski.
+			 * Still allow Unix98 ptys (pts/x) */
 			return NULL;
 		}
 		tty = strrchr(tty, '/') + 1;


### PR DESCRIPTION
pam_timestamp doesn't work correctly on Unix98 pseudoterminals.

For example, if you configure it for su, it works fine on ttyS0 and tty1, but fails to work from remote ssh session or xterm (which use ttys like pts/1).

The proposed pullrequest should fix it.