### PR TITLE
pam_userdb: allow key_only with hashes, use DB API

### DIFF
--- a/modules/pam_userdb/create.pl
+++ b/modules/pam_userdb/create.pl
@@ -1,21 +1,45 @@
 #!/usr/bin/perl
-# this program creates a database in ARGV[1] from pairs given on
-# stdandard input
-#
+# this program creates a database from pairs given on standard input
 # $Id$
 
 use DB_File;
 
-my $database = $ARGV[0];
-die "Use: create.pl <database>\n" unless ($database);
-print "Using database: $database\n";
+my ($database, $keyonly, $hash) = (undef, 0, 'none');
+
+while ($#ARGV > -1) {
+	my $arg = shift(@ARGV);
+	if ($arg eq '--keyonly') {
+		$keyonly = 1;
+	} elsif ($arg =~ /^--hash=(crypt|none)$/) {
+		$hash = $1;
+	} else {
+		die "Use: create.pl [--keyonly] [--hash=<crypt|none>] <database>\n" if defined $database;
+		$database = $arg;
+	}
+}
+
+die "Use: create.pl [--keyonly] [--hash=<crypt|none>] <database>\n" unless defined $database;
+print "Using database: $database\nKey only: $keyonly\nHash: $hash\n";
 
 my %lusers = ();
 
-tie %lusers, 'DB_File', $database, O_RDWR|O_CREAT, 0644, $DB_HASH ;
+tie %lusers, 'DB_File', $database, O_RDWR|O_CREAT, 0644, $DB_HASH;
 while (<STDIN>) {
-  my ($user, $pass) = split;
+	my ($user, $pass) = split;
+	warn "Empty password (line $.)" unless length $pass > 0;
 
-  $lusers{$user} = $pass;
+	if ($hash eq 'crypt') {
+		my $salt = join('', ('.', '/', 0..9, 'A'..'Z', 'a'..'z')[rand 64, rand 64]);
+		$pass = crypt($pass, $salt);
+	}
+
+	if ($keyonly) {
+		warn "User \"$user\" contains the \"-\" character (line $.)" if $user =~ tr/-// > 0;
+		$user = "$user-$pass";
+		$pass = 5; # this random value was obtained by rolling a dice
+	}
+
+	$lusers{$user} = $pass;
 }
+
 untie %lusers;

--- a/modules/pam_userdb/pam_userdb.8.xml
+++ b/modules/pam_userdb/pam_userdb.8.xml
@@ -25,7 +25,7 @@
 	debug
       </arg>
       <arg choice="opt">
-        crypt=[crypt|none]
+        hash=[crypt|none]
       </arg>
       <arg choice="opt">
         icase
@@ -66,17 +66,19 @@
     <variablelist>
       <varlistentry>
         <term>
-          <option>crypt=[crypt|none]</option>
+          <option>hash=[crypt|none]</option>
         </term>
         <listitem>
           <para>
-            Indicates whether encrypted or plaintext passwords are stored
+            Indicates the hashing algorithm used to store passwords
             in the database.  If it is <option>crypt</option>, passwords
             should be stored in the database in
             <citerefentry>
 	      <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
             </citerefentry> form.  If <option>none</option> is selected,
             passwords should be stored in the database as plaintext.
+	    Note that in versions older than 1.3.1 this parameter was called
+	    <option>crypt</option>.
           </para>
         </listitem>
       </varlistentry>
@@ -86,11 +88,11 @@
         </term>
         <listitem>
           <para>
-            Use the <filename>/path/database</filename> database for
+            Use the <filename>/path/database.db</filename> database for
             performing lookup. There is no default; the module will
             return <emphasis remap='B'>PAM_IGNORE</emphasis> if no
-            database is provided. Note that the path to the database file
-            should be specified without the <filename>.db</filename> suffix.
+            database is provided. Note that in versions older than 1.3.1
+	    this parameter was specified without the <filename>.db</filename> suffix.
           </para>
         </listitem>
       </varlistentry>
@@ -286,7 +288,8 @@ auth  sufficient pam_userdb.so icase db=/etc/dbtest
   <refsect1 id='pam_userdb-author'>
     <title>AUTHOR</title>
       <para>
-        pam_userdb was written by Cristian Gafton &gt;gafton@redhat.com&lt;.
+        pam_userdb was written by Cristian Gafton &lt;gafton@redhat.com&gt;.
+	With additions by Alan Mizrahi &lt;lameventanas@gmail.com&gt;.
       </para>
   </refsect1>
 

--- a/modules/pam_userdb/pam_userdb.c
+++ b/modules/pam_userdb/pam_userdb.c
@@ -2,6 +2,7 @@
 
 /*
  * Written by Cristian Gafton <gafton@redhat.com> 1996/09/10
+ * With additions by Alan Mizrahi <lameventanas@gmail.com> 2017/05/16
  * See the end of the file for Copyright Information
  */
 
@@ -87,12 +88,12 @@ obtain_authtok(pam_handle_t *pamh)
 
 static int
 _pam_parse (pam_handle_t *pamh, int argc, const char **argv,
-	    const char **database, const char **cryptmode)
+	    const char **database, e_hashmode *hashmode)
 {
   int ctrl;
 
   *database = NULL;
-  *cryptmode = NULL;
+  *hashmode = NONE;
 
   /* step through arguments */
   for (ctrl = 0; argc-- > 0; ++argv)
@@ -122,22 +123,67 @@ _pam_parse (pam_handle_t *pamh, int argc, const char **argv,
 		       "db= specification missing argument - ignored");
 	  }
 	}
-      else if (!strncasecmp(*argv,"crypt=", 6))
+      else if (!strncasecmp(*argv, "hash=", 5))
 	{
-	  *cryptmode = (*argv) + 6;
-	  if (**cryptmode == '\0')
-	    pam_syslog(pamh, LOG_ERR,
-		       "crypt= specification missing argument - ignored");
+		const char *algo = (*argv) + 5;
+		if (! strcmp(algo, "crypt")) {
+			ctrl |= PAM_HASH_ARG;
+			*hashmode = CRYPT;
+		} else if (! strcmp(algo, "none")) {
+			*hashmode = NONE;
+		} else {
+			pam_syslog(pamh, LOG_ERR, "Invalid hash argument: `%s' - ignored", algo);
+		}
 	}
       else
 	{
 	  pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
 	}
     }
-
+    if ( (ctrl | PAM_HASH_ARG) && (ctrl | PAM_ICASE_ARG) )
+	pam_syslog(pamh, LOG_ERR, "Warning: icase doesn't work with hashed passwords");
   return ctrl;
 }
 
+/* crypt-compare string with stored password
+ * returns 0 if equal
+ */
+static int cmp_hash_crypt(const char *stored, const char *str) {
+	char *cryptpw = NULL;
+	int compare = -2;
+
+#ifdef HAVE_CRYPT_R
+	struct crypt_data cdata;
+	memset(&cdata, 0, sizeof(cdata));
+	cryptpw = crypt_r(str, stored, &cdata);
+#else
+	cryptpw = crypt (str, stored);
+#endif
+	if (cryptpw != NULL && strlen(cryptpw) == strlen(stored))
+		compare = strncmp(stored, cryptpw, strlen(cryptpw));
+
+	return compare;
+}
+
+static int cmp_password(const char *stored, const char *str, const int ctrl, const e_hashmode hashmode) {
+	int compare = -1;
+
+	if (ctrl & PAM_HASH_ARG) {
+		switch(hashmode) {
+			case CRYPT:
+				compare = cmp_hash_crypt(stored, str);
+				break;
+			default:
+				break;
+		}
+	} else {
+		if (ctrl & PAM_ICASE_ARG)
+			compare = strcasecmp(stored, str);
+		else
+			compare = strcmp(stored, str);
+	}
+	return compare;
+}
 
 /*
  * Looks up an user name in a database and checks the password
@@ -149,187 +195,131 @@ _pam_parse (pam_handle_t *pamh, int argc, const char **argv,
  *	-2  = System error
  */
 static int
-user_lookup (pam_handle_t *pamh, const char *database, const char *cryptmode,
-	     const char *user, const char *pass, int ctrl)
-{
-    DBM *dbm;
-    datum key, data;
+user_lookup (pam_handle_t *pamh, const char *database, e_hashmode hashmode, const char *user, const char *pass, int ctrl) {
+	DB *dbp;
+	DBT key, data;
+	DBC *cur;
+	int err;
 
-    /* Open the DB file. */
-    dbm = dbm_open(database, O_RDONLY, 0644);
-    if (dbm == NULL) {
-	pam_syslog(pamh, LOG_ERR,
-		   "user_lookup: could not open database `%s': %m", database);
-	return -2;
-    }
-
-    /* dump out the database contents for debugging */
-    if (ctrl & PAM_DUMP_ARG) {
-	pam_syslog(pamh, LOG_INFO, "Database dump:");
-	for (key = dbm_firstkey(dbm);  key.dptr != NULL;
-	     key = dbm_nextkey(dbm)) {
-	    data = dbm_fetch(dbm, key);
-	    pam_syslog(pamh, LOG_INFO,
-		       "key[len=%d] = `%s', data[len=%d] = `%s'",
-		       key.dsize, key.dptr, data.dsize, data.dptr);
-	}
-    }
-
-    /* do some more init work */
-    memset(&key, 0, sizeof(key));
-    memset(&data, 0, sizeof(data));
-    if (ctrl & PAM_KEY_ONLY_ARG) {
-	if (asprintf(&key.dptr, "%s-%s", user, pass) < 0)
-	    key.dptr = NULL;
-	else
-	    key.dsize = strlen(key.dptr);
-    } else {
-        key.dptr = strdup(user);
-        key.dsize = strlen(user);
-    }
-
-    if (key.dptr) {
-	data = dbm_fetch(dbm, key);
-	memset(key.dptr, 0, key.dsize);
-	free(key.dptr);
-    }
-
-    if (ctrl & PAM_DEBUG_ARG) {
-	pam_syslog(pamh, LOG_INFO,
-		   "password in database is [%p]`%.*s', len is %d",
-		   data.dptr, data.dsize, (char *) data.dptr, data.dsize);
-    }
-
-    if (data.dptr != NULL) {
-	int compare = 0;
-
-	if (ctrl & PAM_KEY_ONLY_ARG)
-	  {
-	    dbm_close (dbm);
-	    return 0; /* found it, data contents don't matter */
+	if (ctrl & PAM_DUMP_ARG) {
+#define ARG_ACTIVE(a) ((ctrl & a) == a)
+		pam_syslog(pamh, LOG_INFO, "user_lookup key_only:%d icase:%d hash:%d unknown_ok:%d use_fpass:%d try_fpass:%d hashmode:%d database:`%s'", ARG_ACTIVE(PAM_KEY_ONLY_ARG), ARG_ACTIVE(PAM_ICASE_ARG), ARG_ACTIVE(PAM_HASH_ARG), ARG_ACTIVE(PAM_UNKNOWN_OK_ARG), ARG_ACTIVE(PAM_USE_FPASS_ARG), ARG_ACTIVE(PAM_TRY_FPASS_ARG), hashmode, database);
 	}
 
-	if (cryptmode && strncasecmp(cryptmode, "crypt", 5) == 0) {
-
-	  /* crypt(3) password storage */
-
-	  char *cryptpw = NULL;
-
-	  if (data.dsize < 13) {
-	    compare = -2;
-	  } else if (ctrl & PAM_ICASE_ARG) {
-	    compare = -2;
-	  } else {
-#ifdef HAVE_CRYPT_R
-	    struct crypt_data *cdata = NULL;
-	    cdata = malloc(sizeof(*cdata));
-	    if (cdata != NULL) {
-		cdata->initialized = 0;
-		cryptpw = crypt_r(pass, data.dptr, cdata);
-	    }
-#else
-	    cryptpw = crypt (pass, data.dptr);
-#endif
-	    if (cryptpw && strlen(cryptpw) == (size_t)data.dsize) {
-	      compare = memcmp(data.dptr, cryptpw, data.dsize);
-	    } else {
-	      compare = -2;
-	      if (ctrl & PAM_DEBUG_ARG) {
-		if (cryptpw)
-		  pam_syslog(pamh, LOG_INFO, "lengths of computed and stored hashes differ");
-		else
-		  pam_syslog(pamh, LOG_INFO, "crypt() returned NULL");
-	      }
-	    }
-#ifdef HAVE_CRYPT_R
-	    free(cdata);
-#endif
-	  }
-
-	} else {
-
-	  /* Unknown password encryption method -
-	   * default to plaintext password storage
-	   */
-
-	  if (strlen(pass) != (size_t)data.dsize) {
-	    compare = 1; /* wrong password len -> wrong password */
-	  } else if (ctrl & PAM_ICASE_ARG) {
-	    compare = strncasecmp(data.dptr, pass, data.dsize);
-	  } else {
-	    compare = strncmp(data.dptr, pass, data.dsize);
-	  }
-
-	  if (cryptmode && strncasecmp(cryptmode, "none", 4)
-		&& (ctrl & PAM_DEBUG_ARG)) {
-	    pam_syslog(pamh, LOG_INFO, "invalid value for crypt parameter: %s",
-		       cryptmode);
-	    pam_syslog(pamh, LOG_INFO, "defaulting to plaintext password mode");
-	  }
-
+	err = db_create(&dbp, NULL, 0);
+	if (err != 0) {
+		pam_syslog(pamh, LOG_ERR, "user_lookup: could not create database handle: %s", db_strerror(err));
+		return -2;
 	}
 
-	dbm_close(dbm);
-	if (compare == 0)
-	    return 0; /* match */
-	else
-	    return -1; /* wrong */
-    } else {
-        int saw_user = 0;
-
-	if (ctrl & PAM_DEBUG_ARG) {
-	    pam_syslog(pamh, LOG_INFO, "error returned by dbm_fetch: %m");
+	/* Open the DB file. */
+	err = dbp->open(dbp, NULL, database, NULL, DB_UNKNOWN, 0, 0644);
+	if (err != 0 ) {
+		pam_syslog(pamh, LOG_ERR,
+			"user_lookup: could not open database `%s': %s", database, db_strerror(err));
+		return -2;
 	}
 
-	/* probably we should check dbm_error() here */
+	/* dump database contents for debugging */
+	if (ctrl & PAM_DUMP_ARG) {
+		err = dbp->cursor(dbp, NULL, &cur, 0);
+		if (err != 0) {
+			pam_syslog(pamh, LOG_ERR, "user_lookup: could not create cursor for database `%s': %s", database, strerror(err));
+		} else {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.flags  = DB_DBT_REALLOC;
+			data.flags = DB_DBT_REALLOC;
+			pam_syslog(pamh, LOG_INFO, "user_lookup: database dump:");
+			while (0 == (err = cur->get(cur, &key, &data, DB_NEXT))) {
+				*(char *)(key.data + key.size) = 0;
+				*(char *)(data.data + data.size) = 0;
+				pam_syslog(pamh, LOG_INFO, "key[len=%d] = `%s', data[len=%d] = `%s'\n", key.size, (char *)key.data, data.size, (char *)data.data);
+			}
+			if (err != DB_NOTFOUND)
+				pam_syslog(pamh, LOG_ERR, "error getting next value: %s\n", db_strerror(err));
+			free(key.data);
+			free(data.data);
+			cur->close(cur);
+		}
+	}
 
-        if ((ctrl & PAM_KEY_ONLY_ARG) == 0) {
-	    dbm_close(dbm);
-            return 1; /* not key_only, so no entry => no entry for the user */
-        }
+	if (ctrl & PAM_DEBUG_ARG)
+		pam_syslog(pamh, LOG_INFO, "looking for `%s' len: %d", user, strlen(user));
 
-        /* now handle the key_only case */
-        for (key = dbm_firstkey(dbm);
-             key.dptr != NULL;
-             key = dbm_nextkey(dbm)) {
-            int compare;
-            /* first compare the user portion (case sensitive) */
-            compare = strncmp(key.dptr, user, strlen(user));
-            if (compare == 0) {
-                /* assume failure */
-                compare = -1;
-                /* if we have the divider where we expect it to be... */
-                if (key.dptr[strlen(user)] == '-') {
-		    saw_user = 1;
-		    if ((size_t)key.dsize == strlen(user) + 1 + strlen(pass)) {
-		        if (ctrl & PAM_ICASE_ARG) {
-			    /* compare the password portion (case insensitive)*/
-                            compare = strncasecmp(key.dptr + strlen(user) + 1,
-                                                  pass,
-                                                  strlen(pass));
-		        } else {
-                            /* compare the password portion (case sensitive) */
-                            compare = strncmp(key.dptr + strlen(user) + 1,
-                                              pass,
-                                              strlen(pass));
-		        }
-		    }
-                }
-                if (compare == 0) {
-                    dbm_close(dbm);
-                    return 0; /* match */
-                }
-            }
-        }
-        dbm_close(dbm);
-	if (saw_user)
-	    return -1; /* saw the user, but password mismatch */
-	else
-	    return 1; /* not found */
-    }
+	if (ctrl & PAM_KEY_ONLY_ARG) { // key_only
+		err = dbp->cursor(dbp, NULL, &cur, 0);
+		if (err != 0) {
+			pam_syslog(pamh, LOG_ERR, "user_lookup: could not create cursor for database `%s': %s", database, strerror(err));
+			cur->close(cur);
+			dbp->close(dbp, 0);
+			return -2;
+		}
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.flags  = DB_DBT_REALLOC;
 
-    /* NOT REACHED */
-    return -2;
+		int saw_user = 0;
+		int compare = -1;
+
+		while (0 == (err = cur->get(cur, &key, &data, DB_NEXT))) {
+			if (ctrl & PAM_DEBUG_ARG)
+				pam_syslog(pamh, LOG_INFO, "checking db entry `%.*s' len %d", key.size, key.data, key.size);
+
+			*(char *)(key.data + key.size) = 0;
+			if ((key.size > strlen(user)) && (*((char *)key.data + strlen(user)) == '-') && (0 == strncmp(key.data, user, strlen(user)))) {
+				/* username matched and divider was in right position */
+				saw_user = 1;
+				const char *dbpass = key.data + strlen(user) + 1;
+
+				compare = cmp_password(dbpass, pass, ctrl, hashmode);
+			}
+			if (compare == 0)
+				break; /* match */
+		}
+		if (err != 0 && err != DB_NOTFOUND)
+			pam_syslog(pamh, LOG_ERR, "error getting next value: %s\n", db_strerror(err));
+		free(key.data);
+		cur->close(cur);
+		dbp->close(dbp, 0);
+		if (compare == 0) {
+			return 0; /* password match */
+		} else {
+			if (saw_user)
+				return -1; /* saw the user, but password mismatch */
+			else
+				return 1; /* not found */
+		}
+
+	} else { // not key_only: can do a db->get
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		data.flags = DB_DBT_REALLOC;
+
+		key.data = (char *)user;
+		key.size = strlen(user);
+
+		err = dbp->get(dbp, NULL, &key, &data, 0);
+		if (err != 0) {
+			if ((ctrl & PAM_DEBUG_ARG) || (err != DB_NOTFOUND))
+				pam_syslog(pamh, LOG_INFO, "couldn't find `%.*s': %s", key.size, key.data, db_strerror(err));
+			dbp->close(dbp, 0);
+			return 1;
+		}
+
+		/* found user */
+
+		*(char *)(data.data + data.size) = 0;
+
+		/* now check password considering all cases: normal, icase or hash  */
+		int compare = cmp_password(data.data, pass, ctrl, hashmode);
+
+		dbp->close(dbp, 0);
+
+		return (compare == 0) ? 0 : -1;
+	}
+
+	return -2; /* not reached */
 }
 
 /* --- authentication management functions (only) --- */
@@ -341,11 +331,11 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
      const char *username;
      const void *password;
      const char *database = NULL;
-     const char *cryptmode = NULL;
+     e_hashmode hashmode;
      int retval = PAM_AUTH_ERR, ctrl;
 
      /* parse arguments */
-     ctrl = _pam_parse(pamh, argc, argv, &database, &cryptmode);
+     ctrl = _pam_parse(pamh, argc, argv, &database, &hashmode);
      if (database == NULL) {
         pam_syslog(pamh, LOG_ERR, "can not get the database name");
         return PAM_SERVICE_ERR;
@@ -390,7 +380,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
 		    username);
 
      /* Now use the username to look up password in the database file */
-     retval = user_lookup(pamh, database, cryptmode, username, password, ctrl);
+     retval = user_lookup(pamh, database, hashmode, username, password, ctrl);
      switch (retval) {
 	 case -2:
 	     /* some sort of system error. The log was already printed */
@@ -436,11 +426,11 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
 {
     const char *username;
     const char *database = NULL;
-    const char *cryptmode = NULL;
+    e_hashmode hashmode;
     int retval = PAM_AUTH_ERR, ctrl;
 
     /* parse arguments */
-    ctrl = _pam_parse(pamh, argc, argv, &database, &cryptmode);
+    ctrl = _pam_parse(pamh, argc, argv, &database, &hashmode);
 
     /* Get the username */
     retval = pam_get_user(pamh, &username, NULL);
@@ -450,7 +440,7 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
     }
 
     /* Now use the username to look up password in the database file */
-    retval = user_lookup(pamh, database, cryptmode, username, "", ctrl);
+    retval = user_lookup(pamh, database, hashmode, username, "", ctrl);
     switch (retval) {
         case -2:
 	    /* some sort of system error. The log was already printed */

--- a/modules/pam_userdb/pam_userdb.h
+++ b/modules/pam_userdb/pam_userdb.h
@@ -10,10 +10,17 @@
 #define PAM_DEBUG_ARG		0x0001
 #define PAM_ICASE_ARG		0x0002
 #define PAM_DUMP_ARG		0x0004
+#define PAM_HASH_ARG		0x0008
 #define PAM_UNKNOWN_OK_ARG	0x0010
 #define PAM_KEY_ONLY_ARG	0x0020
 #define PAM_USE_FPASS_ARG	0x0040
 #define PAM_TRY_FPASS_ARG	0x0080
+
+/* hash algorithms */
+typedef enum {
+	NONE,
+	CRYPT
+} e_hashmode;
 
 /* The name of the module we are compiling */
 #ifndef MODULE_NAME


### PR DESCRIPTION
This change allows using key_only with hashed passwords, which didn't
work before but was not documented.

I also migrated away from the historic dbm API, which means that the
db=/path/to/file parameter now has to be specified as a full filename,
including any suffix.

The crypt= parameter was also renamed to hash=