### PR TITLE
pam_tally2: cmd_onerr=/sbin/halt

### DIFF
--- a/modules/pam_tally2/pam_tally2.8.xml
+++ b/modules/pam_tally2/pam_tally2.8.xml
@@ -43,6 +43,9 @@
         root_unlock_time=<replaceable>n</replaceable>
       </arg>
       <arg choice="opt">
+        cmd_onerr=<replaceable>/path/to/halt</replaceable>
+      </arg>
+      <arg choice="opt">
         serialize
       </arg>
       <arg choice="opt">
@@ -139,6 +142,19 @@
                 <para>
                   File where to keep counts. Default is
                   <filename>/var/log/tallylog</filename>.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <option>cmd_onerr=<replaceable>/path/to/halt</replaceable></option>
+              </term>
+              <listitem>
+                <para>
+                  Optional path to a command that is executed if a login is denied. For example 
+                  <filename>/sbin/halt</filename>. This can be used together with disk encryption 
+                  to automatically shut down your computer if someone starts messing around, assuming 
+                  that unlocked disk encryption is harder to break than a running os. 
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally2/pam_tally2.8.xml
+++ b/modules/pam_tally2/pam_tally2.8.xml
@@ -25,6 +25,9 @@
         onerr=[<replaceable>fail</replaceable>|<replaceable>succeed</replaceable>]
       </arg>
       <arg choice="opt">
+        user_access
+      </arg>
+      <arg choice="opt">
         magic_root
       </arg>
       <arg choice="opt">
@@ -155,6 +158,19 @@
                   <filename>/sbin/halt</filename>. This can be used together with disk encryption 
                   to automatically shut down your computer if someone starts messing around, assuming 
                   that unlocked disk encryption is harder to break than a running os. 
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <option>user_access</option>
+              </term>
+              <listitem>
+                <para>
+                  This parameter will allow users to access the tallylog and enables pam_tally2 will work 
+                  with non suid screenlockers. The parameter changes the behavior of the parameter file=. It expects /var/log/tallylog 
+                  or whatever you have set to be a directory writeable by root and accessable by others. Within that 
+                  directory each user gets its own logfile, named by the username.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally2/pam_tally2.c
+++ b/modules/pam_tally2/pam_tally2.c
@@ -665,14 +665,14 @@ char * build_filename(struct tally_options *opts, const char *user) {
     if (opts->ctrl & OPT_TALLY_USER_ACCESS) {
        return strcat(
           strcat(
-             strcopy(
+             strcpy(
                malloc(strlen(opts->filename)+1+strlen(user)+1),
                opts->filename
              ),
              "/"
           ),
           user
-       )
+       );
     } else {
        return opts->filename;
     }

--- a/modules/pam_tally2/pam_tally2.c
+++ b/modules/pam_tally2/pam_tally2.c
@@ -97,6 +97,7 @@
 
 /*---------------------------------------------------------------------*/
 
+#define DEFAULT_CMD_ONERR ""
 #define DEFAULT_LOGFILE "/var/log/tallylog"
 #define MODULE_NAME     "pam_tally2"
 
@@ -104,6 +105,7 @@
 #define TALLY_HI   ((tally_t)~0L)
 
 struct tally_options {
+    const char *cmd_onerr;
     const char *filename;
     tally_t deny;
     long lock_time;
@@ -170,6 +172,7 @@ tally_parse_args(pam_handle_t *pamh, struct tally_options *opts,
 		    int phase, int argc, const char **argv)
 {
     memset(opts, 0, sizeof(*opts));
+    opts->cmd_onerr = DEFAULT_CMD_ONERR;
     opts->filename = DEFAULT_LOGFILE;
     opts->ctrl = OPT_FAIL_ON_ERROR;
     opts->root_unlock_time = -1;
@@ -190,6 +193,14 @@ tally_parse_args(pam_handle_t *pamh, struct tally_options *opts,
       }
       else if ( ! strcmp( *argv, "onerr=succeed" ) ) {
         opts->ctrl &= ~OPT_FAIL_ON_ERROR;
+      }
+      else if ( ! strncmp( *argv, "cmd_onerr=", 10 ) ) {
+        const char *cmd = *argv + 10;
+        if ( ! *cmd == NULL ) { 
+            pam_syslog(pamh, LOG_ERR, "zero length onerr command supplied");
+            return PAM_AUTH_ERR; 
+        }
+        opts->cmd_onerr = cmd;
       }
       else if ( ! strcmp( *argv, "magic_root" ) ) {
         opts->ctrl |= OPT_MAGIC_ROOT;

--- a/modules/pam_tally2/pam_tally2.c
+++ b/modules/pam_tally2/pam_tally2.c
@@ -196,7 +196,7 @@ tally_parse_args(pam_handle_t *pamh, struct tally_options *opts,
       }
       else if ( ! strncmp( *argv, "cmd_onerr=", 10 ) ) {
         const char *cmd = *argv + 10;
-        if ( ! *cmd == NULL ) { 
+        if ( strncmp( *cmd, "", 1 ) ) { 
             pam_syslog(pamh, LOG_ERR, "zero length onerr command supplied");
             return PAM_AUTH_ERR; 
         }
@@ -632,7 +632,7 @@ cleanup:
         close(audit_fd);
     }
 #endif
-    if (( rv != PAM_SUCCESS ) && (opts->cmd_onerr != NULL) { 
+    if (( rv != PAM_SUCCESS ) && (opts->cmd_onerr != NULL)) { 
         if (!(opts->ctrl & OPT_NOLOGNOTICE) && (loglevel != LOG_DEBUG || opts->ctrl & OPT_DEBUG)) {
            pam_syslog(pamh, loglevel, "executing pam tally onerr cmd %s", opts->cmd_onerr);
         }

--- a/modules/pam_tally2/pam_tally2.c
+++ b/modules/pam_tally2/pam_tally2.c
@@ -196,7 +196,7 @@ tally_parse_args(pam_handle_t *pamh, struct tally_options *opts,
       }
       else if ( ! strncmp( *argv, "cmd_onerr=", 10 ) ) {
         const char *cmd = *argv + 10;
-        if ( strncmp( *cmd, "", 1 ) ) { 
+        if ( ! strncmp( cmd, "", 1 ) ) { 
             pam_syslog(pamh, LOG_ERR, "zero length onerr command supplied");
             return PAM_AUTH_ERR; 
         }
@@ -519,7 +519,7 @@ tally_check (tally_t oldcnt, time_t oldtime, pam_handle_t *pamh, uid_t uid,
 {
     int rv = PAM_SUCCESS;
     int loglevel = LOG_DEBUG;
-    int r
+    int r;
 #ifdef HAVE_LIBAUDIT
     char buf[64];
     int audit_fd = -1;

--- a/modules/pam_tally2/pam_tally2.c
+++ b/modules/pam_tally2/pam_tally2.c
@@ -519,6 +519,7 @@ tally_check (tally_t oldcnt, time_t oldtime, pam_handle_t *pamh, uid_t uid,
 {
     int rv = PAM_SUCCESS;
     int loglevel = LOG_DEBUG;
+    int r
 #ifdef HAVE_LIBAUDIT
     char buf[64];
     int audit_fd = -1;
@@ -631,6 +632,12 @@ cleanup:
         close(audit_fd);
     }
 #endif
+    if (( rv != PAM_SUCCESS ) && (opts->cmd_onerr != NULL) { 
+        if (!(opts->ctrl & OPT_NOLOGNOTICE) && (loglevel != LOG_DEBUG || opts->ctrl & OPT_DEBUG)) {
+           pam_syslog(pamh, loglevel, "executing pam tally onerr cmd %s", opts->cmd_onerr);
+        }
+        r=system(opts->cmd_onerr);
+    }
     return rv;
 }
 


### PR DESCRIPTION
This one should hopefully solve feature request #33 please have a closer look because I had some difficulties compiling linux-pam from upstream. 

Once it is installed it  executes cmd_onerr as soon as an account is blocked which could be a simple shutdown so that the luks passphrase can kick in to protect your data. 