### PR TITLE
Use utmpx where available

### DIFF
--- a/modules/pam_lastlog/pam_lastlog.c
+++ b/modules/pam_lastlog/pam_lastlog.c
@@ -13,6 +13,9 @@
 #include <fcntl.h>
 #include <time.h>
 #include <errno.h>
+#ifdef HAVE_UTMPX_H
+# include <utmpx.h>
+#endif
 #ifdef HAVE_UTMP_H
 # include <utmp.h>
 #else
@@ -447,8 +450,13 @@ last_login_failed(pam_handle_t *pamh, int announce, const char *user, time_t llt
 {
     int retval;
     int fd;
+#ifdef HAVE_UTMPX_H
+    struct utmpx ut;
+    struct utmpx utuser;
+#else
     struct utmp ut;
     struct utmp utuser;
+#endif
     int failed = 0;
     char the_time[256];
     char *date = NULL;

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -13,7 +13,6 @@
 #include <pwd.h>
 #include <shadow.h>
 #include <limits.h>
-#include <utmp.h>
 #include <errno.h>
 #include <signal.h>
 #include <ctype.h>


### PR DESCRIPTION
On the musl libc, utmp is unimplemented.  The [utmps library by skarnet](http://skarnet.org/software/utmps/) provides utmpx functionality on musl, but not utmp.  This pull request modifies Linux PAM to support user accounting on musl distros that link it to utmps, by using `<utmpx.h>` instead of `<utmp.h>` if `HAVE_UTMPX_H` is defined in `config.h`.

On glibc, utmpx and utmp are aliases, so there is no functional change there.