### PR TITLE
pam_env: ignore / skip lines beginning with '='

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -231,6 +231,9 @@ _parse_env_file(pam_handle_t *pamh, int ctrl, const char *file)
 	* sanity check, the key must be alpha-numeric
 	*/
 
+	if (key[0] == '=')
+	    continue;
+
 	for ( i = 0 ; key[i] != '=' && key[i] != '\0' ; i++ )
 	    if (!isalnum(key[i]) && key[i] != '_') {
 		pam_syslog(pamh, LOG_ERR,


### PR DESCRIPTION
pam_putenv in libpam/pam_env.c makes a special exception for an '=' as
the first character, aborting with PAM_BAD_ITEM. When combined with the
truncation to 1023 characters, if the 1024th character is an '=', this
can cause unexpected system lockout. Note, this would also happen if the
line started with an '='.

Related to issue #31.