### PR TITLE
Add ability to specify alt shells and passwd files

### DIFF
--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -1,7 +1,5 @@
 /* pam_shells module */
 
-#define SHELL_FILE "/etc/shells"
-
 /*
  * by Erik Troan <ewt@redhat.com>, Red Hat Software.
  * August 5, 1996.
@@ -19,6 +17,7 @@
 #include <sys/stat.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <errno.h>
 
 /*
  * here, we make a definition for the externally accessible function
@@ -29,12 +28,137 @@
 
 #define PAM_SM_AUTH
 #define PAM_SM_ACCOUNT
+#define SHELL_FILE_DEFAULT "/etc/shells"
+#define PWFILE_DEFAULT     "/etc/passwd"
 
 #include <security/pam_modules.h>
 #include <security/pam_modutil.h>
 #include <security/pam_ext.h>
 
-static int perform_check(pam_handle_t *pamh)
+struct pam_shells_options
+{
+    int         debug;
+    const char *shellfile;
+    const char *pwfile;
+};
+
+static int
+pam_shells_parse_options(pam_handle_t               *pamh,
+                         int                         argc,
+                         const char                **argv,
+                         struct pam_shells_options  *opt)
+{
+    int         i;
+
+    if (pamh == NULL)
+    {
+        return(PAM_SERVICE_ERR);
+    }
+
+    if (opt == NULL)
+    {
+        pam_syslog(pamh, LOG_ERR, "Options are invalid");
+        return(PAM_SERVICE_ERR);
+    }
+
+    /*
+     *  Initialize the options.
+     */
+    opt->debug     = 0;
+    opt->shellfile = SHELL_FILE_DEFAULT;
+    opt->pwfile    = PWFILE_DEFAULT;
+
+    /* process arguments */
+    for (i = 0; i < argc; i++)
+    {
+        if (strcmp("debug", argv[i]) == 0)
+        {
+            opt->debug = 1;
+        }
+    }
+
+    for (i = 0; i < argc; i++)
+    {
+        if (strncmp("pwfile=", argv[i], 7) == 0)
+        {
+            opt->pwfile = argv[i] + 7;
+            if (opt->debug)
+            {
+                pam_syslog(pamh, LOG_DEBUG, "set pwfile to \"%s\"", opt->pwfile);
+            }
+        }
+        else if (strncmp("shellfile=", argv[i], 10) == 0)
+        {
+            opt->shellfile = argv[i] + 10;
+            if (opt->debug)
+            {
+                pam_syslog(pamh, LOG_DEBUG, "set shellfile to \"%s\"", opt->shellfile);
+            }
+        }
+    }
+
+    return(PAM_SUCCESS);
+}
+
+static struct passwd *
+pam_shells_getpwnam(pam_handle_t               *pamh,
+                    struct pam_shells_options  *opt,
+                    const char                 *username)
+{
+    FILE          *fp;
+    struct passwd *pw;
+
+
+    if (pamh == NULL)
+    {
+        return(NULL);
+    }
+
+    if (opt == NULL
+            ||
+        opt->pwfile == NULL
+            ||
+        username == NULL)
+    {
+        pam_syslog(pamh, LOG_ERR, "Arguments to pam_shells_getpwnam invalid");
+        return(NULL);
+    }
+
+
+    /*
+     *  Open the password file.
+     */
+    errno = 0;
+    fp = fopen(opt->pwfile, "r");
+    if (fp == NULL)
+    {
+        pam_syslog(pamh, LOG_ERR, "Failed to open passwd file %s", opt->pwfile);
+        return(NULL);
+    }
+
+
+    pw = fgetpwent(fp);
+    while (pw != NULL)
+    {
+        if (strcmp(username, pw->pw_name) == 0)
+        {
+            if (opt->debug)
+            {
+                pam_syslog(pamh, LOG_DEBUG, "User %s found in passwd file %s", username, opt->pwfile);
+            }
+
+            break;
+        }
+
+        pw = fgetpwent(fp);
+    }
+
+    fclose(fp);
+    return(pw);
+}
+
+static int perform_check(pam_handle_t               *pamh,
+                         struct pam_shells_options  *opt)
 {
     int retval = PAM_AUTH_ERR;
     const char *userName;
@@ -45,83 +169,141 @@ static int perform_check(pam_handle_t *pamh)
     FILE * shellFile;
 
     retval = pam_get_user(pamh, &userName, NULL);
-    if (retval != PAM_SUCCESS) {
-	return PAM_SERVICE_ERR;
+    if (retval != PAM_SUCCESS)
+    {
+        pam_syslog(pamh, LOG_ERR, "pam_get_user(1) failed. rc: %d", retval);
+        return PAM_SERVICE_ERR;
     }
 
-    if (!userName || (userName[0] == '\0')) {
+    if (!userName || (userName[0] == '\0'))
+    {
 
-	/* Don't let them use a NULL username... */
-	retval = pam_get_user(pamh,&userName,NULL);
+        /* Don't let them use a NULL username... */
+        retval = pam_get_user(pamh,&userName,NULL);
         if (retval != PAM_SUCCESS)
-	    return PAM_SERVICE_ERR;
+        {
+            pam_syslog(pamh, LOG_ERR, "pam_get_user(2) failed. rc: %d", retval);
+            return PAM_SERVICE_ERR;
+        }
 
-	/* It could still be NULL the second time. */
-	if (!userName || (userName[0] == '\0'))
-	    return PAM_SERVICE_ERR;
+        /* It could still be NULL the second time. */
+        if (!userName || (userName[0] == '\0'))
+        {
+            pam_syslog(pamh, LOG_ERR, "Username is not set");
+            return PAM_SERVICE_ERR;
+        }
     }
 
-    pw = pam_modutil_getpwnam(pamh, userName);
-    if (!pw) {
-	return PAM_AUTH_ERR;		/* user doesn't exist */
+    pw = pam_shells_getpwnam(pamh, opt, userName);
+    if (!pw)
+    {
+        pam_syslog(pamh, LOG_ERR, "User %s not in %s", userName, opt->pwfile);
+        return PAM_AUTH_ERR;		/* user doesn't exist */
     }
     userShell = pw->pw_shell;
 
-    if (stat(SHELL_FILE,&sb)) {
-	pam_syslog(pamh, LOG_ERR, "Cannot stat %s: %m", SHELL_FILE);
-	return PAM_AUTH_ERR;		/* must have /etc/shells */
+    if (stat(opt->shellfile,&sb))
+    {
+        pam_syslog(pamh, LOG_ERR, "Cannot stat %s: %m", opt->shellfile);
+        return PAM_AUTH_ERR;		/* must have /etc/shells */
     }
 
-    if ((sb.st_mode & S_IWOTH) || !S_ISREG(sb.st_mode)) {
-	pam_syslog(pamh, LOG_ERR,
-		   "%s is either world writable or not a normal file",
-		   SHELL_FILE);
-	return PAM_AUTH_ERR;
+    if ((sb.st_mode & S_IWOTH) || !S_ISREG(sb.st_mode))
+    {
+        pam_syslog(pamh, LOG_ERR,
+                   "%s is either world writable or not a normal file",
+                   opt->shellfile);
+        return PAM_AUTH_ERR;
     }
 
-    shellFile = fopen(SHELL_FILE,"r");
-    if (shellFile == NULL) {       /* Check that we opened it successfully */
-	pam_syslog(pamh, LOG_ERR, "Error opening %s: %m", SHELL_FILE);
-	return PAM_SERVICE_ERR;
+    /* Check that we opened it successfully */
+    shellFile = fopen(opt->shellfile,"r");
+    if (shellFile == NULL)
+    {
+        pam_syslog(pamh, LOG_ERR, "Error opening %s: %m", opt->shellfile);
+        return PAM_SERVICE_ERR;
     }
 
     retval = 1;
+    while(retval && (fgets(shellFileLine, 255, shellFile) != NULL))
+    {
+        /*
+         *
+         *  Ignore lines that begin with a '#'
+         *
+         */
+        if (shellFileLine[strlen(shellFileLine) - 1] == '\n')
+        {
+            shellFileLine[strlen(shellFileLine) - 1] = '\0';
+        }
 
-    while(retval && (fgets(shellFileLine, 255, shellFile) != NULL)) {
-	if (shellFileLine[strlen(shellFileLine) - 1] == '\n')
-	    shellFileLine[strlen(shellFileLine) - 1] = '\0';
-	retval = strcmp(shellFileLine, userShell);
+        retval = strcmp(shellFileLine, userShell);
     }
-
     fclose(shellFile);
 
-    if (retval) {
-	return PAM_AUTH_ERR;
-    } else {
-	return PAM_SUCCESS;
+    if (retval)
+    {
+        pam_syslog(pamh, LOG_ERR, "User shell is invalid %s", userShell);
+        return PAM_AUTH_ERR;
+    }
+    else
+    {
+        return PAM_SUCCESS;
     }
 }
 
 /* --- authentication management functions (only) --- */
 
-int pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
-		        int argc UNUSED, const char **argv UNUSED)
+int pam_sm_authenticate(pam_handle_t  *pamh,
+                        int            flags UNUSED,
+                        int            argc,
+                        const char   **argv)
 {
-    return perform_check(pamh);
+    struct pam_shells_options  opt;
+    int                        rc;
+
+    rc = pam_shells_parse_options(pamh,
+                                  argc,
+                                  argv,
+                                  &opt);
+    if (rc != PAM_SUCCESS)
+    {
+        return(rc);
+    }
+
+    return( perform_check(pamh,
+                          &opt) );
 }
 
-int pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
-		   int argc UNUSED, const char **argv UNUSED)
+int pam_sm_setcred(pam_handle_t  *pamh  UNUSED,
+                   int            flags UNUSED,
+                   int            argc  UNUSED,
+                   const char   **argv  UNUSED)
 {
      return PAM_SUCCESS;
 }
 
 /* --- account management functions (only) --- */
 
-int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
-		     int argc UNUSED, const char **argv UNUSED)
+int pam_sm_acct_mgmt(pam_handle_t  *pamh,
+                     int            flags UNUSED,
+                     int            argc,
+                     const char   **argv)
 {
-    return perform_check(pamh);
+    struct pam_shells_options  opt;
+    int                        rc;
+
+    rc = pam_shells_parse_options(pamh,
+                                  argc,
+                                  argv,
+                                  &opt);
+    if (rc != PAM_SUCCESS)
+    {
+        return(rc);
+    }
+
+    return( perform_check(pamh,
+                          &opt) );
 }
 
 /* end of module definition */


### PR DESCRIPTION
This patch adds the ability to specify an alternate password file (pwfile=/path/to/pwfile; default /etc/passwd) and an alternate shells file (shellfile=/path/to/shellfile; default /etc/shells).