### PR TITLE
Fix documentation for pam_wheel

### DIFF
--- a/modules/pam_wheel/pam_wheel.8.xml
+++ b/modules/pam_wheel/pam_wheel.8.xml
@@ -43,8 +43,8 @@
     <title>DESCRIPTION</title>
     <para>
       The pam_wheel PAM module is used to enforce the so-called
-      <emphasis>wheel</emphasis> group. By default it permits root
-      access to the system if the applicant user is a member of the
+      <emphasis>wheel</emphasis> group. By default it permits
+      access to the target user if the applicant user is a member of the
       <emphasis>wheel</emphasis> group. If no group with this name exist,
       the module is using the group with the group-ID
       <emphasis remap='B'>0</emphasis>.


### PR DESCRIPTION
By default, pam_wheel checks for applicant membership in the wheel group
for *all* access requests, regardless of whether the target user is root
or non-root. Only if root_only is provided does it limit the membership
check to cases when the target user is root. Update the documentation to
reflect this.