### PR TITLE
pam_motd: Add support for specifying multiple motd directories

### DIFF
--- a/modules/pam_motd/pam_motd.8.xml
+++ b/modules/pam_motd/pam_motd.8.xml
@@ -21,6 +21,9 @@
       <arg choice="opt">
         motd=<replaceable>/path/filename</replaceable>
       </arg>
+      <arg choice="opt">
+        motd_dir=<replaceable>/path/dirname.d</replaceable>
+      </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -31,10 +34,49 @@
     <para>
       pam_motd is a PAM module that can be used to display
       arbitrary motd (message of the day) files after a successful
-      login. By default the <filename>/etc/motd</filename> file is
-      shown. The message size is limited to 64KB.
+      login. By default, pam_motd shows files in the
+      following locations:
     </para>
-
+    <para>
+      <simplelist type='vert'>
+        <member><filename>/etc/motd</filename></member>
+        <member><filename>/run/motd</filename></member>
+        <member><filename>/usr/lib/motd</filename></member>
+        <member><filename>/etc/motd.d/</filename></member>
+        <member><filename>/run/motd.d/</filename></member>
+        <member><filename>/usr/lib/motd.d/</filename></member>
+      </simplelist>
+    </para>
+    <para>
+      Each message size is limited to 64KB.
+    </para>
+    <para>
+      If <filename>/etc/motd</filename> does not exist,
+      then <filename>/run/motd</filename> is shown. If
+      <filename>/run/motd</filename> does not exist, then
+      <filename>/usr/lib/motd</filename> is shown.
+    </para>
+    <para>
+      Similar overriding behavior applies to the directories.
+      Files in <filename>/etc/motd.d/</filename> override files
+      with the same name in <filename>/run/motd.d/</filename> and
+      <filename>/usr/lib/motd.d/</filename>. Files in <filename>/run/motd.d/</filename>
+      override files with the same name in <filename>/usr/lib/motd.d/</filename>.
+    </para>
+    <para>
+      Files the in the directories listed above are displayed in
+      lexicographic order by name.
+    </para>
+    <para>
+      To silence a message,
+      a symbolic link with target <filename>/dev/null</filename>
+      may be placed in <filename>/etc/motd.d</filename> with
+      the same filename as the message to be silenced. Example:
+      Creating a symbolic link as follows silences <filename>/usr/lib/motd.d/my_motd</filename>.
+    </para>
+    <para>
+      <command>ln -s /dev/null /etc/motd.d/my_motd</command>
+    </para>
   </refsect1>
 
   <refsect1 id="pam_motd-options">
@@ -47,8 +89,10 @@
         </term>
         <listitem>
           <para>
-	    The <filename>/path/filename</filename> file is displayed
-            as message of the day.
+            The <filename>/path/filename</filename> file is displayed
+            as message of the day. Multiple paths to try can be
+            specified as a colon-separated list. By default this option
+            is set to <filename>/etc/motd:/run/motd:/usr/lib/motd</filename>.
           </para>
         </listitem>
       </varlistentry>
@@ -59,16 +103,17 @@
         <listitem>
           <para>
             The <filename>/path/dirname.d</filename> directory is scanned
-            and each file contained inside of it is displayed.
+            and each file contained inside of it is displayed. Multiple
+            directories to scan can be specified as a colon-separated list.
+            By default this option is set to <filename>/etc/motd.d:/run/motd.d:/usr/lib/motd.d</filename>.
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
     <para>
-      When no options are given, the default is to display both
-      <filename>/etc/motd</filename> and the contents of
-      <filename>/etc/motd.d</filename>.  Specifying either option (or both)
-      will disable this default behavior.
+      When no options are given, the default behavior applies for both
+      options. Specifying either option (or both) will disable the
+      default behavior for both options.
     </para>
   </refsect1>
 

--- a/xtests/.gitignore
+++ b/xtests/.gitignore
@@ -20,3 +20,4 @@ tst-pam_authfail
 tst-pam_authsucceed
 tst-pam_pwhistory1
 tst-pam_time1
+tst-pam_motd

--- a/xtests/Makefile.am
+++ b/xtests/Makefile.am
@@ -32,7 +32,10 @@ EXTRA_DIST = run-xtests.sh tst-pam_dispatch1.pamd tst-pam_dispatch2.pamd \
 	tst-pam_substack5.pamd tst-pam_substack5a.pamd tst-pam_substack5.sh \
 	tst-pam_assemble_line1.pamd tst-pam_assemble_line1.sh \
 	tst-pam_pwhistory1.pamd tst-pam_pwhistory1.sh \
-	tst-pam_time1.pamd time.conf
+	tst-pam_time1.pamd time.conf \
+	tst-pam_motd.sh tst-pam_motd1.sh tst-pam_motd2.sh \
+	tst-pam_motd3.sh tst-pam_motd1.pamd \
+	tst-pam_motd2.pamd tst-pam_motd3.pamd
 
 XTESTS = tst-pam_dispatch1 tst-pam_dispatch2 tst-pam_dispatch3 \
 	tst-pam_dispatch4 tst-pam_dispatch5 \
@@ -41,7 +44,7 @@ XTESTS = tst-pam_dispatch1 tst-pam_dispatch2 tst-pam_dispatch3 \
 	tst-pam_access1 tst-pam_access2 tst-pam_access3 \
 	tst-pam_access4 tst-pam_limits1 tst-pam_succeed_if1 \
 	tst-pam_group1 tst-pam_authfail tst-pam_authsucceed \
-	tst-pam_pwhistory1 tst-pam_time1
+	tst-pam_pwhistory1 tst-pam_time1 tst-pam_motd
 
 NOSRCTESTS = tst-pam_substack1 tst-pam_substack2 tst-pam_substack3 \
 	tst-pam_substack4 tst-pam_substack5 tst-pam_assemble_line1

--- a/xtests/tst-pam_motd.c
+++ b/xtests/tst-pam_motd.c
@@ -1,0 +1,69 @@
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU Public License, in which case the provisions of the GPL are
+ * required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <security/pam_appl.h>
+#include <security/pam_misc.h>
+
+static struct pam_conv conv = {
+    misc_conv,
+    NULL
+};
+
+int main(int argc, char *argv[])
+{
+    pam_handle_t *pamh=NULL;
+    char *tst_arg = NULL;
+    int retval;
+
+    if (argc > 1)
+	tst_arg = argv[1];
+
+    retval = pam_start(tst_arg, NULL, &conv, &pamh);
+
+    retval = pam_open_session(pamh, 0);
+
+    retval = pam_close_session(pamh, 0);
+
+    if (pam_end(pamh,retval) != PAM_SUCCESS) {     /* close Linux-PAM */
+	pamh = NULL;
+	exit(1);
+    }
+
+    return ( retval == PAM_SUCCESS ? 0:1 );       /* indicate success */
+}

--- a/xtests/tst-pam_motd.sh
+++ b/xtests/tst-pam_motd.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+./tst-pam_motd1.sh
+./tst-pam_motd2.sh
+./tst-pam_motd3.sh

--- a/xtests/tst-pam_motd1.pamd
+++ b/xtests/tst-pam_motd1.pamd
@@ -1,0 +1,3 @@
+#%PAM-1.0
+session    required    pam_permit.so
+session    optional    pam_motd.so motd=tst-pam_motd1.d/etc/motd motd_dir=tst-pam_motd1.d/etc/motd.d

--- a/xtests/tst-pam_motd1.sh
+++ b/xtests/tst-pam_motd1.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+TST_DIR="tst-pam_motd1.d"
+
+function tst_cleanup() {
+    rm -rf "${TST_DIR}"
+    rm -f tst-pam_motd1.out
+}
+
+mkdir -p ${TST_DIR}
+mkdir -p ${TST_DIR}/etc/motd.d
+
+# Verify the case of single motd and motd.d directory works
+echo "motd: /etc/motd" > ${TST_DIR}/etc/motd
+echo "motd: /etc/motd.d/test" > ${TST_DIR}/etc/motd.d/test
+
+./tst-pam_motd tst-pam_motd1 > tst-pam_motd1.out
+
+RET=$?
+
+motd_to_show_output=$(cat tst-pam_motd1.out | grep "motd: /etc/motd")
+if [ -z "${motd_to_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+motd_dir_to_show_output=$(cat tst-pam_motd1.out | grep "motd: /etc/motd.d/test")
+if [ -z "${motd_dir_to_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+tst_cleanup
+exit $RET

--- a/xtests/tst-pam_motd2.pamd
+++ b/xtests/tst-pam_motd2.pamd
@@ -1,0 +1,3 @@
+#%PAM-1.0
+session    required    pam_permit.so
+session optional    pam_motd.so    motd=tst-pam_motd2.d/etc/motd:tst-pam_motd2.d/run/motd:tst-pam_motd2.d/usr/lib/motd motd_dir=tst-pam_motd2.d/etc/motd.d:tst-pam_motd2.d/run/motd.d:tst-pam_motd2.d/usr/lib/motd.d

--- a/xtests/tst-pam_motd2.sh
+++ b/xtests/tst-pam_motd2.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+TST_DIR="tst-pam_motd2.d"
+
+function tst_cleanup() {
+    rm -rf "${TST_DIR}"
+    rm -f tst-pam_motd2.out
+}
+
+mkdir -p ${TST_DIR}
+mkdir -p ${TST_DIR}/etc/motd.d
+mkdir -p ${TST_DIR}/run/motd.d
+mkdir -p ${TST_DIR}/usr/lib/motd.d
+
+echo "motd: /etc/motd" > ${TST_DIR}/etc/motd
+echo "motd: /run/motd" > ${TST_DIR}/run/motd
+echo "motd: /usr/lib/motd" > ${TST_DIR}/usr/lib/motd
+
+# Drop a motd file in test directories such that every overriding
+# condition (for 3 directories in this case) will be seen.
+echo "motd: e0r0u1 in usr/lib - will show" > ${TST_DIR}/usr/lib/motd.d/e0r0u1.motd
+echo "motd: e0r1u0 in run - will show" > ${TST_DIR}/run/motd.d/e0r1u0.motd
+echo "motd: e0r1u1 in usr/lib - not show" > ${TST_DIR}/usr/lib/motd.d/e0r1u1.motd
+echo "motd: e0r1u1 in run - will show" > ${TST_DIR}/run/motd.d/e0r1u1.motd
+echo "motd: e1r0u0 in etc - will show" > ${TST_DIR}/etc/motd.d/e1r0u0.motd
+echo "motd: e1r0u1 in usr/lib - not show" > ${TST_DIR}/usr/lib/motd.d/e1r0u1.motd
+echo "motd: e1r0u1 in etc - will show" > ${TST_DIR}/etc/motd.d/e1r0u1.motd
+echo "motd: e1r1u0 in run - not show" > ${TST_DIR}/run/motd.d/e1r1u0.motd
+echo "motd: e1r1u0 in etc - will show" > ${TST_DIR}/etc/motd.d/e1r1u0.motd
+echo "motd: e1r1u1 in usr/lib - not show" > ${TST_DIR}/usr/lib/motd.d/e1r1u1.motd
+echo "motd: e1r1u1 in run - not show" > ${TST_DIR}/run/motd.d/e1r1u1.motd
+echo "motd: e1r1u1 in etc - will show" > ${TST_DIR}/etc/motd.d/e1r1u1.motd
+
+./tst-pam_motd tst-pam_motd2 > tst-pam_motd2.out
+
+RET=$?
+
+motd_to_show_output=$(cat tst-pam_motd2.out | grep "motd: /etc/motd")
+if [ -z "${motd_to_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+motd_dir_not_show_output=$(cat tst-pam_motd2.out | grep "not show")
+if [ -n "${motd_dir_not_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+tst_cleanup
+exit $RET

--- a/xtests/tst-pam_motd3.pamd
+++ b/xtests/tst-pam_motd3.pamd
@@ -1,0 +1,3 @@
+#%PAM-1.0
+session    required    pam_permit.so
+session optional    pam_motd.so    motd=tst-pam_motd3.d/etc/motd:tst-pam_motd3.d/run/motd:tst-pam_motd3.d/usr/lib/motd motd_dir=tst-pam_motd3.d/etc/motd.d:tst-pam_motd3.d/run/motd.d:tst-pam_motd3.d/usr/lib/motd.d

--- a/xtests/tst-pam_motd3.sh
+++ b/xtests/tst-pam_motd3.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+TST_DIR="tst-pam_motd3.d"
+
+function tst_cleanup() {
+    rm -rf "${TST_DIR}"
+    rm -f tst-pam_motd3.out
+}
+
+mkdir -p ${TST_DIR}
+mkdir -p ${TST_DIR}/etc/motd.d
+mkdir -p ${TST_DIR}/run/motd.d
+mkdir -p ${TST_DIR}/usr/lib/motd.d
+
+# Verify motd is still displayed when not overridden
+echo "motd: test-show in run - show" > ${TST_DIR}/run/motd.d/test-show.motd
+
+# Test overridden by a symlink to a file that isn't /dev/null; symlink target should show
+echo "motd: hidden-by-symlink in usr/lib - not show" > ${TST_DIR}/usr/lib/motd.d/hidden-by-symlink.motd
+echo "motd: test-from-symlink - show" > ${TST_DIR}/test-from-symlink.motd
+ln -sr ${TST_DIR}/test-from-symlink.motd ${TST_DIR}/run/motd.d/hidden-by-symlink.motd
+
+# Test hidden by a null symlink
+echo "motd: hidden-by-null-symlink in run - not show" > ${TST_DIR}/run/motd.d/hidden-by-null-symlink.motd
+ln -s /dev/null ${TST_DIR}/etc/motd.d/hidden-by-null-symlink.motd
+
+./tst-pam_motd tst-pam_motd3 > tst-pam_motd3.out
+
+RET=$?
+
+motd_dir_not_show_output=$(cat tst-pam_motd3.out | grep "not show")
+if [ -n "${motd_dir_not_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+motd_test_show_output=$(cat tst-pam_motd3.out | grep "test-show.*- show")
+if [ -z "${motd_test_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+motd_general_symlink_show_output=$(cat tst-pam_motd3.out | grep "test-from-symlink.*- show")
+if [ -z "${motd_general_symlink_show_output}" ];
+then
+    tst_cleanup
+    exit 1
+fi
+
+tst_cleanup
+exit $RET


### PR DESCRIPTION
This adds to `pam_motd.c` functions to parse a string of colon-separated directories as arguments for `motd` and `motd_dir`, and check for overriding filenames before displaying the motds. This also displays the motds in lexicographic order of the filenames, after merging the files contained in each directory.

Tests are added to verify the previous single-directory functionality works, as well as with multiple directories, and with symlinks.

If this is suitable to have in PAM, I will also update the documentation in this PR.

Appreciate your review and feedback!

Closes #68 