### PR TITLE
pam_unix: Use bcrypt b-variant for computing new hashes.

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -385,7 +385,7 @@ PAMH_ARG_DECL(char * create_password_hash,
 		/* algoid = "$1" */
 		return crypt_md5_wrapper(password);
 	} else if (on(UNIX_BLOWFISH_PASS, ctrl)) {
-		algoid = "$2a$";
+		algoid = "$2b$";
 	} else if (on(UNIX_SHA256_PASS, ctrl)) {
 		algoid = "$5$";
 	} else if (on(UNIX_SHA512_PASS, ctrl)) {


### PR DESCRIPTION
Bcrypt hashes used the "$2a$" prefix since 1997.
However, in 2011 an implementation bug was discovered in bcrypt affecting the handling of characters in passphrases with the 8th bit set.

Besides fixing the bug, OpenBSD 5.5 introduced the "$2b$" prefix for a behavior that exactly matches crypt_blowfish's "$2y$", and the crypt_blowfish implementation supports it as well since v1.1.

That said new computed bcrypt hashes should use the "$2b$" prefix.

* modules/pam_unix/passverify.c: Use bcrypt b-variant.