### PR TITLE
pam_unix: Add support for (gost-)yescrypt hashing methods.

### DIFF
--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -333,12 +333,43 @@
       </varlistentry>
       <varlistentry>
         <term>
+          <option>gost_yescrypt</option>
+        </term>
+        <listitem>
+          <para>
+            When a user changes their password next,
+            encrypt it with the gost-yescrypt algorithm. If the
+            gost-yescrypt algorithm is not known to the <citerefentry>
+	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
+            </citerefentry> function,
+            fall back to MD5.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <option>yescrypt</option>
+        </term>
+        <listitem>
+          <para>
+            When a user changes their password next,
+            encrypt it with the yescrypt algorithm. If the
+            yescrypt algorithm is not known to the <citerefentry>
+	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
+            </citerefentry> function,
+            fall back to MD5.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
           <option>rounds=<replaceable>n</replaceable></option>
         </term>
         <listitem>
           <para>
-            Set the optional number of rounds of the SHA256, SHA512
-            and blowfish password hashing algorithms to
+            Set the optional number of rounds of the SHA256, SHA512,
+            blowfish, gost-yescrypt, and yescrypt password hashing
+            algorithms to
             <replaceable>n</replaceable>.
           </para>
         </listitem>

--- a/modules/pam_unix/pam_unix_acct.c
+++ b/modules/pam_unix/pam_unix_acct.c
@@ -62,7 +62,7 @@
 #include "support.h"
 #include "passverify.h"
 
-int _unix_run_verify_binary(pam_handle_t *pamh, unsigned int ctrl,
+int _unix_run_verify_binary(pam_handle_t *pamh, unsigned long long ctrl,
 	const char *user, int *daysleft)
 {
   int retval=0, child, fds[2];
@@ -185,7 +185,7 @@ int _unix_run_verify_binary(pam_handle_t *pamh, unsigned int ctrl,
 int
 pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
-	unsigned int ctrl;
+	unsigned long long ctrl;
 	const void *void_uname;
 	const char *uname;
 	int retval, daysleft;

--- a/modules/pam_unix/pam_unix_auth.c
+++ b/modules/pam_unix/pam_unix_auth.c
@@ -96,7 +96,7 @@ setcred_free (pam_handle_t *pamh UNUSED, void *ptr, int err UNUSED)
 int
 pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
-	unsigned int ctrl;
+	unsigned long long ctrl;
 	int retval, *ret_data = NULL;
 	const char *name;
 	const char *p;
@@ -194,7 +194,7 @@ pam_sm_setcred (pam_handle_t *pamh, int flags,
 {
 	int retval;
 	const void *pretval = NULL;
-	unsigned int ctrl;
+	unsigned long long ctrl;
 
 	D(("called."));
 

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -138,7 +138,7 @@ __taddr2port (const struct netconfig *nconf, const struct netbuf *nbuf)
 }
 #endif
 
-static char *getNISserver(pam_handle_t *pamh, unsigned int ctrl)
+static char *getNISserver(pam_handle_t *pamh, unsigned long long ctrl)
 {
 	char *master;
 	char *domainname;
@@ -233,7 +233,7 @@ static char *getNISserver(pam_handle_t *pamh, unsigned int ctrl)
 
 #ifdef WITH_SELINUX
 
-static int _unix_run_update_binary(pam_handle_t *pamh, unsigned int ctrl, const char *user,
+static int _unix_run_update_binary(pam_handle_t *pamh, unsigned long long ctrl, const char *user,
     const char *fromwhat, const char *towhat, int remember)
 {
     int retval, child, fds[2];
@@ -388,7 +388,7 @@ static int check_old_password(const char *forwho, const char *newpass)
 
 static int _do_setpass(pam_handle_t* pamh, const char *forwho,
 		       const char *fromwhat,
-		       char *towhat, unsigned int ctrl, int remember)
+		       char *towhat, unsigned long long ctrl, int remember)
 {
 	struct passwd *pwd = NULL;
 	int retval = 0;
@@ -512,7 +512,7 @@ done:
 	return retval;
 }
 
-static int _unix_verify_shadow(pam_handle_t *pamh, const char *user, unsigned int ctrl)
+static int _unix_verify_shadow(pam_handle_t *pamh, const char *user, unsigned long long ctrl)
 {
 	struct passwd *pwent = NULL;	/* Password and shadow password */
 	struct spwd *spent = NULL;	/* file entries for the user */
@@ -542,7 +542,7 @@ static int _unix_verify_shadow(pam_handle_t *pamh, const char *user, unsigned in
 }
 
 static int _pam_unix_approve_pass(pam_handle_t * pamh
-				  ,unsigned int ctrl
+				  ,unsigned long long ctrl
 				  ,const char *pass_old
 				  ,const char *pass_new,
                                   int pass_min_len)
@@ -600,7 +600,7 @@ static int _pam_unix_approve_pass(pam_handle_t * pamh
 int
 pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
-	unsigned int ctrl, lctrl;
+	unsigned long long ctrl, lctrl;
 	int retval;
 	int remember = -1;
 	int rounds = 0;

--- a/modules/pam_unix/pam_unix_sess.c
+++ b/modules/pam_unix/pam_unix_sess.c
@@ -67,7 +67,7 @@ int
 pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
 	char *user_name, *service;
-	unsigned int ctrl;
+	unsigned long long ctrl;
 	int retval;
     const char *login_name;
 
@@ -103,7 +103,7 @@ int
 pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
 	char *user_name, *service;
-	unsigned int ctrl;
+	unsigned long long ctrl;
 	int retval;
 
 	D(("called."));

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -387,7 +387,7 @@ crypt_md5_wrapper(const char *pass_new)
 }
 
 PAMH_ARG_DECL(char * create_password_hash,
-	const char *password, unsigned int ctrl, int rounds)
+	const char *password, unsigned long long ctrl, int rounds)
 {
 	const char *algoid;
 #if defined(CRYPT_GENSALT_OUTPUT_SIZE) && CRYPT_GENSALT_OUTPUT_SIZE > 64
@@ -404,6 +404,10 @@ PAMH_ARG_DECL(char * create_password_hash,
 	if (on(UNIX_MD5_PASS, ctrl)) {
 		/* algoid = "$1" */
 		return crypt_md5_wrapper(password);
+	} else if (on(UNIX_YESCRYPT_PASS, ctrl)) {
+		algoid = "$y$";
+	} else if (on(UNIX_GOST_YESCRYPT_PASS, ctrl)) {
+		algoid = "$gy$";
 	} else if (on(UNIX_BLOWFISH_PASS, ctrl)) {
 		algoid = "$2b$";
 	} else if (on(UNIX_SHA256_PASS, ctrl)) {
@@ -466,6 +470,8 @@ PAMH_ARG_DECL(char * create_password_hash,
 		pam_syslog(pamh, LOG_ERR,
 			   "Algo %s not supported by the crypto backend, "
 			   "falling back to MD5\n",
+			   on(UNIX_YESCRYPT_PASS, ctrl) ? "yescrypt" :
+			   on(UNIX_GOST_YESCRYPT_PASS, ctrl) ? "gost_yescrypt" :
 			   on(UNIX_BLOWFISH_PASS, ctrl) ? "blowfish" :
 			   on(UNIX_SHA256_PASS, ctrl) ? "sha256" :
 			   on(UNIX_SHA512_PASS, ctrl) ? "sha512" : algoid);

--- a/modules/pam_unix/passverify.h
+++ b/modules/pam_unix/passverify.h
@@ -66,7 +66,7 @@ read_passwords(int fd, int npass, char **passwords);
 #endif
 
 PAMH_ARG_DECL(char * create_password_hash,
-	const char *password, unsigned int ctrl, int rounds);
+	const char *password, unsigned long long ctrl, int rounds);
 
 PAMH_ARG_DECL(int get_account_info,
 	const char *name, struct passwd **pwd, struct spwd **spwdent);

--- a/modules/pam_unix/support.h
+++ b/modules/pam_unix/support.h
@@ -22,8 +22,8 @@
 
 typedef struct {
 	const char *token;
-	unsigned int mask;	/* shall assume 32 bits of flags */
-	unsigned int flag;
+	unsigned long long mask;	/* shall assume 64 bits of flags */
+	unsigned long long flag;
         unsigned int is_hash_algo;
 } UNIX_Ctrls;
 
@@ -48,7 +48,7 @@ typedef struct {
 
 /* the generic mask */
 
-#define _ALL_ON_  (~0U)
+#define _ALL_ON_  (~0ULL)
 
 /* end of macro definitions definitions for the control flags */
 
@@ -98,47 +98,51 @@ typedef struct {
 #define UNIX_QUIET		 28	/* Don't print informational messages */
 #define UNIX_NO_PASS_EXPIRY      29     /* Don't check for password expiration if not used for authentication */
 #define UNIX_DES                 30     /* DES, default */
+#define UNIX_GOST_YESCRYPT_PASS  31     /* new password hashes will use gost-yescrypt */
+#define UNIX_YESCRYPT_PASS       32     /* new password hashes will use yescrypt */
 /* -------------- */
-#define UNIX_CTRLS_              31	/* number of ctrl arguments defined */
+#define UNIX_CTRLS_              33	/* number of ctrl arguments defined */
 
-#define UNIX_DES_CRYPT(ctrl)	(off(UNIX_MD5_PASS,ctrl)&&off(UNIX_BIGCRYPT,ctrl)&&off(UNIX_SHA256_PASS,ctrl)&&off(UNIX_SHA512_PASS,ctrl)&&off(UNIX_BLOWFISH_PASS,ctrl))
+#define UNIX_DES_CRYPT(ctrl)	(off(UNIX_MD5_PASS,ctrl)&&off(UNIX_BIGCRYPT,ctrl)&&off(UNIX_SHA256_PASS,ctrl)&&off(UNIX_SHA512_PASS,ctrl)&&off(UNIX_BLOWFISH_PASS,ctrl)&&off(UNIX_GOST_YESCRYPT_PASS,ctrl)&&off(UNIX_YESCRYPT_PASS,ctrl))
 
 static const UNIX_Ctrls unix_args[UNIX_CTRLS_] =
 {
-/* symbol                  token name          ctrl mask             ctrl     *
- * ----------------------- ------------------- --------------------- -------- */
+/* symbol                      token name          ctrl mask                  ctrl             *
+ * --------------------------- -------------------- ------------------------- ---------------- */
 
-/* UNIX__OLD_PASSWD */     {NULL,              _ALL_ON_,                  01, 0},
-/* UNIX__VERIFY_PASSWD */  {NULL,              _ALL_ON_,                  02, 0},
-/* UNIX__IAMROOT */        {NULL,              _ALL_ON_,                  04, 0},
-/* UNIX_AUDIT */           {"audit",           _ALL_ON_,                 010, 0},
-/* UNIX_USE_FIRST_PASS */  {"use_first_pass",  _ALL_ON_^(060),           020, 0},
-/* UNIX_TRY_FIRST_PASS */  {"try_first_pass",  _ALL_ON_^(060),           040, 0},
-/* UNIX_AUTHTOK_TYPE */    {"authtok_type=",   _ALL_ON_,                0100, 0},
-/* UNIX__PRELIM */         {NULL,              _ALL_ON_^(0600),         0200, 0},
-/* UNIX__UPDATE */         {NULL,              _ALL_ON_^(0600),         0400, 0},
-/* UNIX__NONULL */         {NULL,              _ALL_ON_,               01000, 0},
-/* UNIX__QUIET */          {NULL,              _ALL_ON_,               02000, 0},
-/* UNIX_USE_AUTHTOK */     {"use_authtok",     _ALL_ON_,               04000, 0},
-/* UNIX_SHADOW */          {"shadow",          _ALL_ON_,              010000, 0},
-/* UNIX_MD5_PASS */        {"md5",            _ALL_ON_^(0260420000),  020000, 1},
-/* UNIX__NULLOK */         {"nullok",          _ALL_ON_^(01000),           0, 0},
-/* UNIX_DEBUG */           {"debug",           _ALL_ON_,              040000, 0},
-/* UNIX_NODELAY */         {"nodelay",         _ALL_ON_,             0100000, 0},
-/* UNIX_NIS */             {"nis",             _ALL_ON_,             0200000, 0},
-/* UNIX_BIGCRYPT */        {"bigcrypt",       _ALL_ON_^(0260420000), 0400000, 1},
-/* UNIX_LIKE_AUTH */       {"likeauth",        _ALL_ON_,            01000000, 0},
-/* UNIX_REMEMBER_PASSWD */ {"remember=",       _ALL_ON_,            02000000, 0},
-/* UNIX_NOREAP */          {"noreap",          _ALL_ON_,            04000000, 0},
-/* UNIX_BROKEN_SHADOW */   {"broken_shadow",   _ALL_ON_,           010000000, 0},
-/* UNIX_SHA256_PASS */     {"sha256",       _ALL_ON_^(0260420000), 020000000, 1},
-/* UNIX_SHA512_PASS */     {"sha512",       _ALL_ON_^(0260420000), 040000000, 1},
-/* UNIX_ALGO_ROUNDS */     {"rounds=",         _ALL_ON_,          0100000000, 0},
-/* UNIX_BLOWFISH_PASS */   {"blowfish",    _ALL_ON_^(0260420000), 0200000000, 1},
-/* UNIX_MIN_PASS_LEN */    {"minlen=",		_ALL_ON_,         0400000000, 0},
-/* UNIX_QUIET */           {"quiet",           _ALL_ON_,         01000000000, 0},
-/* UNIX_NO_PASS_EXPIRY */  {"no_pass_expiry",  _ALL_ON_,         02000000000, 0},
-/* UNIX_DES */             {"des",             _ALL_ON_^(0260420000),      0, 1},
+/* UNIX__OLD_PASSWD */         {NULL,               _ALL_ON_,                              01, 0},
+/* UNIX__VERIFY_PASSWD */      {NULL,               _ALL_ON_,                              02, 0},
+/* UNIX__IAMROOT */            {NULL,               _ALL_ON_,                              04, 0},
+/* UNIX_AUDIT */               {"audit",            _ALL_ON_,                             010, 0},
+/* UNIX_USE_FIRST_PASS */      {"use_first_pass",   _ALL_ON_^(060ULL),                    020, 0},
+/* UNIX_TRY_FIRST_PASS */      {"try_first_pass",   _ALL_ON_^(060ULL),                    040, 0},
+/* UNIX_AUTHTOK_TYPE */        {"authtok_type=",    _ALL_ON_,                            0100, 0},
+/* UNIX__PRELIM */             {NULL,               _ALL_ON_^(0600ULL),                  0200, 0},
+/* UNIX__UPDATE */             {NULL,               _ALL_ON_^(0600ULL),                  0400, 0},
+/* UNIX__NONULL */             {NULL,               _ALL_ON_,                           01000, 0},
+/* UNIX__QUIET */              {NULL,               _ALL_ON_,                           02000, 0},
+/* UNIX_USE_AUTHTOK */         {"use_authtok",      _ALL_ON_,                           04000, 0},
+/* UNIX_SHADOW */              {"shadow",           _ALL_ON_,                          010000, 0},
+/* UNIX_MD5_PASS */            {"md5",              _ALL_ON_^(015660420000ULL),        020000, 1},
+/* UNIX__NULLOK */             {"nullok",           _ALL_ON_^(01000ULL),                    0, 0},
+/* UNIX_DEBUG */               {"debug",            _ALL_ON_,                          040000, 0},
+/* UNIX_NODELAY */             {"nodelay",          _ALL_ON_,                         0100000, 0},
+/* UNIX_NIS */                 {"nis",              _ALL_ON_,                         0200000, 0},
+/* UNIX_BIGCRYPT */            {"bigcrypt",         _ALL_ON_^(015660420000ULL),       0400000, 1},
+/* UNIX_LIKE_AUTH */           {"likeauth",         _ALL_ON_,                        01000000, 0},
+/* UNIX_REMEMBER_PASSWD */     {"remember=",        _ALL_ON_,                        02000000, 0},
+/* UNIX_NOREAP */              {"noreap",           _ALL_ON_,                        04000000, 0},
+/* UNIX_BROKEN_SHADOW */       {"broken_shadow",    _ALL_ON_,                       010000000, 0},
+/* UNIX_SHA256_PASS */         {"sha256",           _ALL_ON_^(015660420000ULL),     020000000, 1},
+/* UNIX_SHA512_PASS */         {"sha512",           _ALL_ON_^(015660420000ULL),     040000000, 1},
+/* UNIX_ALGO_ROUNDS */         {"rounds=",          _ALL_ON_,                      0100000000, 0},
+/* UNIX_BLOWFISH_PASS */       {"blowfish",         _ALL_ON_^(015660420000ULL),    0200000000, 1},
+/* UNIX_MIN_PASS_LEN */        {"minlen=",          _ALL_ON_,                      0400000000, 0},
+/* UNIX_QUIET */               {"quiet",            _ALL_ON_,                     01000000000, 0},
+/* UNIX_NO_PASS_EXPIRY */      {"no_pass_expiry",   _ALL_ON_,                     02000000000, 0},
+/* UNIX_DES */                 {"des",              _ALL_ON_^(015660420000ULL),             0, 1},
+/* UNIX_GOST_YESCRYPT_PASS */  {"gost_yescrypt",    _ALL_ON_^(015660420000ULL),   04000000000, 1},
+/* UNIX_YESCRYPT_PASS */       {"yescrypt",         _ALL_ON_^(015660420000ULL),  010000000000, 1},
 };
 
 #define UNIX_DEFAULTS  (unix_args[UNIX__NONULL].flag)
@@ -151,20 +155,23 @@ static const UNIX_Ctrls unix_args[UNIX_CTRLS_] =
 	_pam_drop(xx);		\
 }
 
-extern int _make_remark(pam_handle_t * pamh, unsigned int ctrl
-		       ,int type, const char *text);
-extern int _set_ctrl(pam_handle_t * pamh, int flags, int *remember, int *rounds,
-		     int *pass_min_len, int argc, const char **argv);
+extern int _make_remark(pam_handle_t * pamh, unsigned long long ctrl,
+		        int type, const char *text);
+extern unsigned long long _set_ctrl(pam_handle_t * pamh, int flags,
+				    int *remember, int *rounds,
+				    int *pass_min_len,
+				    int argc, const char **argv);
 extern int _unix_getpwnam (pam_handle_t *pamh,
 			   const char *name, int files, int nis,
 			   struct passwd **ret);
 extern int _unix_comesfromsource (pam_handle_t *pamh,
 				  const char *name, int files, int nis);
-extern int _unix_blankpasswd(pam_handle_t *pamh,unsigned int ctrl,
+extern int _unix_blankpasswd(pam_handle_t *pamh, unsigned long long ctrl,
 			     const char *name);
-extern int _unix_verify_password(pam_handle_t * pamh, const char *name
-			  ,const char *p, unsigned int ctrl);
+extern int _unix_verify_password(pam_handle_t * pamh, const char *name,
+				 const char *p, unsigned long long ctrl);
 
 extern int _unix_run_verify_binary(pam_handle_t *pamh,
-			unsigned int ctrl, const char *user, int *daysleft);
+				   unsigned long long ctrl,
+				   const char *user, int *daysleft);
 #endif /* _PAM_UNIX_SUPPORT_H */


### PR DESCRIPTION
libxcrypt (v4.2 and later) has added support for the yescrypt hashing method; gost-yescrypt has been added in v4.3.

* modules/pam_unix/passverify.c: Add support for (gost-)yescrypt.
* modules/pam_unix/support.c: Set sane rounds for (gost-)yescrypt.
* modules/pam_unix/support.h: Add support for (gost-)yescrypt.

***

Needs #73 to be merged as prerequisite.