### PR TITLE
pam_unix: Fix closing curly brace.

### DIFF
--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -261,7 +261,7 @@ int _set_ctrl(pam_handle_t *pamh, int flags, int *remember, int *rounds,
 				unset(UNIX_ALGO_ROUNDS, ctrl);
 			} else if (*rounds >= 10000000) {
 				*rounds = 9999999;
-			{
+			}
 		}
 	}
 


### PR DESCRIPTION
This has been overlooked during review of commit dce80b3f11b3.

* modules/pam_unix/support.c: Fix closing curly brace.

***

@t8m:  We both didn't see it…