### PR TITLE
pam_unix: Return NULL instead of calling crypt_md5_wrapper().

### DIFF
--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -293,11 +293,10 @@
         <listitem>
           <para>
             When a user changes their password next,
-            encrypt it with the SHA256 algorithm. If the
-            SHA256 algorithm is not known to the <citerefentry>
+            encrypt it with the SHA256 algorithm. The
+            SHA256 algorithm must be supported by the <citerefentry>
 	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
-            </citerefentry> function,
-            fall back to MD5.
+            </citerefentry> function.
           </para>
         </listitem>
       </varlistentry>
@@ -308,11 +307,10 @@
         <listitem>
           <para>
             When a user changes their password next,
-            encrypt it with the SHA512 algorithm. If the
-            SHA512 algorithm is not known to the <citerefentry>
+            encrypt it with the SHA512 algorithm. The
+            SHA512 algorithm must be supported by the <citerefentry>
 	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
-            </citerefentry> function,
-            fall back to MD5.
+            </citerefentry> function.
           </para>
         </listitem>
       </varlistentry>
@@ -323,11 +321,10 @@
         <listitem>
           <para>
             When a user changes their password next,
-            encrypt it with the blowfish algorithm. If the
-            blowfish algorithm is not known to the <citerefentry>
+            encrypt it with the blowfish algorithm. The
+            blowfish algorithm must be supported by the <citerefentry>
 	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
-            </citerefentry> function,
-            fall back to MD5.
+            </citerefentry> function.
           </para>
         </listitem>
       </varlistentry>
@@ -338,11 +335,10 @@
         <listitem>
           <para>
             When a user changes their password next,
-            encrypt it with the gost-yescrypt algorithm. If the
-            gost-yescrypt algorithm is not known to the <citerefentry>
+            encrypt it with the gost-yescrypt algorithm. The
+            gost-yescrypt algorithm must be supported by the <citerefentry>
 	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
-            </citerefentry> function,
-            fall back to MD5.
+            </citerefentry> function.
           </para>
         </listitem>
       </varlistentry>
@@ -353,11 +349,10 @@
         <listitem>
           <para>
             When a user changes their password next,
-            encrypt it with the yescrypt algorithm. If the
-            yescrypt algorithm is not known to the <citerefentry>
+            encrypt it with the yescrypt algorithm. The
+            yescrypt algorithm must be supported by the <citerefentry>
 	    <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
-            </citerefentry> function,
-            fall back to MD5.
+            </citerefentry> function.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -457,10 +457,9 @@ PAMH_ARG_DECL(char * create_password_hash,
 	sp = crypt(password, salt);
 #endif
 	if (!sp || strncmp(algoid, sp, strlen(algoid)) != 0) {
-		/* libxcrypt/libc doesn't know the algorithm, use MD5 */
+		/* libxcrypt/libc doesn't know the algorithm, error out */
 		pam_syslog(pamh, LOG_ERR,
-			   "Algo %s not supported by the crypto backend, "
-			   "falling back to MD5\n",
+			   "Algo %s not supported by the crypto backend.\n",
 			   on(UNIX_YESCRYPT_PASS, ctrl) ? "yescrypt" :
 			   on(UNIX_GOST_YESCRYPT_PASS, ctrl) ? "gost_yescrypt" :
 			   on(UNIX_BLOWFISH_PASS, ctrl) ? "blowfish" :
@@ -472,7 +471,7 @@ PAMH_ARG_DECL(char * create_password_hash,
 #ifdef HAVE_CRYPT_R
 		free(cdata);
 #endif
-		return crypt_md5_wrapper(password);
+		return NULL;
 	}
 	sp = x_strdup(sp);
 #ifdef HAVE_CRYPT_R


### PR DESCRIPTION
If the call to the crypt(3) function failed for some reason during hashing a new login passphrase, the wrapper function for computing a hash with the md5crypt method was called internally by the pam_unix module in previous versions of linux-pam.

With CVE-2012-3287 in mind, the md5crypt method is not considered to be a safe nor recommended hashing method for a new login passphrase since at least 2012.  Thus pam_unix should error out in case of a failure in crypt(3) instead of silently computing a hashed passphrase using a potentially unsafe method.

* modules/pam_unix/pam_unix.8.xml: Update documentation.
* modules/pam_unix/passverify.c (create_password_hash): Return NULL
on error instead of silently invoke crypt_md5_wrapper().

***

As this is a long standing downstream patch from Fedora / Red Hat, this should be reviewed (or at least commented) by the Debian folks.