### PR TITLE
pam_unix: Do not fail passphraseless sudo on locked accounts.

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -266,8 +266,10 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 	    && (curdays - spent->sp_lstchg > spent->sp_inact)
 	    && (curdays - spent->sp_lstchg > spent->sp_max + spent->sp_inact)
 	    && (spent->sp_max != -1) && (spent->sp_inact != -1))
-	    || (crypt_checksalt(spent->sp_pwdp) == CRYPT_SALT_METHOD_DISABLED)
-	    || (crypt_checksalt(spent->sp_pwdp) == CRYPT_SALT_INVALID)) {
+	    || (((crypt_checksalt(spent->sp_pwdp) == CRYPT_SALT_METHOD_DISABLED)
+		 || (crypt_checksalt(spent->sp_pwdp) == CRYPT_SALT_INVALID))
+	        && ((spent->sp_pwdp != NULL)
+		    && !((spent->sp_pwdp[0] == '!') || (spent->sp_pwdp[0] == '*'))))) {
 #else
 	if ((curdays - spent->sp_lstchg > spent->sp_max)
 	    && (curdays - spent->sp_lstchg > spent->sp_inact)


### PR DESCRIPTION
Commit 4da9febc39b9 introduced a regression that made passphraseless sudo fail when it was invoked from a user with a locked passphrase.  Thus we should check for such a scenario when evaluating the return value of crypt_checksalt(3).

* modules/pam_unix/passverify.c (check_shadow_expiry): Do not return
PAM_AUTHTOK_EXPIRED on locked user accounts.

***

@t8m This is the fix for [rhbz#1653023](https://bugzilla.redhat.com/show_bug.cgi?id=1653023) as shipped in pam-1.3.1-10.fc30.