### PR TITLE
Fix build on OpenWrt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,7 +532,10 @@ AC_CHECK_FUNCS(fseeko getdomainname gethostname gettimeofday lckpwdf mkdir selec
 AC_CHECK_FUNCS(strcspn strdup strspn strstr strtol uname)
 AC_CHECK_FUNCS(getutent_r getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r)
 AC_CHECK_FUNCS(getgrouplist getline getdelim)
-AC_CHECK_FUNCS(inet_ntop inet_pton innetgr ruserok_af)
+AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
+AC_CHECK_FUNCS([ruserok_af ruserok], [break])
+
+AM_CONDITIONAL([COND_BUILD_PAM_RHOSTS], [test "$ac_cv_func_ruserok_af" = yes -o "$ac_cv_func_ruserok" = yes])
 
 AC_CHECK_FUNCS(unshare, [UNSHARE=yes], [UNSHARE=no])
 AM_CONDITIONAL([HAVE_UNSHARE], [test "$UNSHARE" = yes])

--- a/configure.ac
+++ b/configure.ac
@@ -534,8 +534,10 @@ AC_CHECK_FUNCS(getutent_r getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r
 AC_CHECK_FUNCS(getgrouplist getline getdelim)
 AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
+AC_CHECK_FUNCS([logwtmp])
 
 AM_CONDITIONAL([COND_BUILD_PAM_RHOSTS], [test "$ac_cv_func_ruserok_af" = yes -o "$ac_cv_func_ruserok" = yes])
+AM_CONDITIONAL([COND_BUILD_PAM_LASTLOG], [test "$ac_cv_func_logwtmp" = yes])
 
 AC_CHECK_FUNCS(unshare, [UNSHARE=yes], [UNSHARE=no])
 AM_CONDITIONAL([HAVE_UNSHARE], [test "$UNSHARE" = yes])

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -6,9 +6,13 @@ if COND_BUILD_PAM_RHOSTS
 	MAYBE_PAM_RHOSTS = pam_rhosts
 endif
 
+if COND_BUILD_PAM_LASTLOG
+	MAYBE_PAM_LASTLOG = pam_lastlog
+endif
+
 SUBDIRS := pam_access pam_cracklib pam_debug pam_deny pam_echo \
 	pam_env pam_exec pam_faildelay pam_filter pam_ftp \
-	pam_group pam_issue pam_keyinit pam_lastlog pam_limits \
+	pam_group pam_issue pam_keyinit pam_limits \
 	pam_listfile pam_localuser pam_loginuid pam_mail \
 	pam_mkhomedir pam_motd pam_namespace pam_nologin \
 	pam_permit pam_pwhistory pam_rootok pam_securetty \
@@ -16,7 +20,7 @@ SUBDIRS := pam_access pam_cracklib pam_debug pam_deny pam_echo \
 	pam_succeed_if pam_tally pam_tally2 pam_time pam_timestamp \
 	pam_tty_audit pam_umask \
 	pam_unix pam_userdb pam_warn pam_wheel pam_xauth \
-	$(MAYBE_PAM_RHOSTS)
+	$(MAYBE_PAM_RHOSTS) $(MAYBE_PAM_LASTLOG)
 
 CLEANFILES = *~
 

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -2,16 +2,21 @@
 # Copyright (c) 2005, 2006, 2008 Thorsten Kukuk <kukuk@thkukuk.de>
 #
 
-SUBDIRS = pam_access pam_cracklib pam_debug pam_deny pam_echo \
+if COND_BUILD_PAM_RHOSTS
+	MAYBE_PAM_RHOSTS = pam_rhosts
+endif
+
+SUBDIRS := pam_access pam_cracklib pam_debug pam_deny pam_echo \
 	pam_env pam_exec pam_faildelay pam_filter pam_ftp \
 	pam_group pam_issue pam_keyinit pam_lastlog pam_limits \
 	pam_listfile pam_localuser pam_loginuid pam_mail \
 	pam_mkhomedir pam_motd pam_namespace pam_nologin \
-	pam_permit pam_pwhistory pam_rhosts pam_rootok pam_securetty \
+	pam_permit pam_pwhistory pam_rootok pam_securetty \
 	pam_selinux pam_sepermit pam_shells pam_stress \
 	pam_succeed_if pam_tally pam_tally2 pam_time pam_timestamp \
 	pam_tty_audit pam_umask \
-	pam_unix pam_userdb pam_warn pam_wheel pam_xauth
+	pam_unix pam_userdb pam_warn pam_wheel pam_xauth \
+	$(MAYBE_PAM_RHOSTS)
 
 CLEANFILES = *~
 

--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -102,7 +102,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
   int use_stdout = 0;
   int optargc;
   const char *logfile = NULL;
-  const char *authtok = NULL;
+  char authtok[PAM_MAX_RESP_SIZE] = {};
   pid_t pid;
   int fds[2];
   int stdout_fds[2];
@@ -180,12 +180,12 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 	      if (resp)
 		{
 		  pam_set_item (pamh, PAM_AUTHTOK, resp);
-		  authtok = strndupa (resp, PAM_MAX_RESP_SIZE);
+		  strncpy (authtok, resp, sizeof(authtok) - 1);
 		  _pam_drop (resp);
 		}
 	    }
 	  else
-	    authtok = strndupa (void_pass, PAM_MAX_RESP_SIZE);
+	    strncpy (authtok, void_pass, sizeof(authtok) - 1);
 
 	  if (pipe(fds) != 0)
 	    {
@@ -225,23 +225,14 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
       if (expose_authtok) /* send the password to the child */
 	{
-	  if (authtok != NULL)
-	    {            /* send the password to the child */
-	      if (debug)
-		pam_syslog (pamh, LOG_DEBUG, "send password to child");
-	      if (write(fds[1], authtok, strlen(authtok)+1) == -1)
-		pam_syslog (pamh, LOG_ERR,
-			    "sending password to child failed: %m");
-	      authtok = NULL;
-	    }
-	  else
-	    {
-	      if (write(fds[1], "", 1) == -1)   /* blank password */
-		pam_syslog (pamh, LOG_ERR,
-			    "sending password to child failed: %m");
-	    }
-        close(fds[0]);       /* close here to avoid possible SIGPIPE above */
-        close(fds[1]);
+	  if (debug)
+	    pam_syslog (pamh, LOG_DEBUG, "send password to child");
+	  if (write(fds[1], authtok, strlen(authtok)) == -1)
+	    pam_syslog (pamh, LOG_ERR,
+			      "sending password to child failed: %m");
+
+          close(fds[0]);       /* close here to avoid possible SIGPIPE above */
+          close(fds[1]);
 	}
 
       if (use_stdout)

--- a/modules/pam_rhosts/pam_rhosts.c
+++ b/modules/pam_rhosts/pam_rhosts.c
@@ -35,6 +35,7 @@
 #include <pwd.h>
 #include <netdb.h>
 #include <string.h>
+#include <stdlib.h>
 #include <syslog.h>
 
 #define PAM_SM_AUTH  /* only defines this management group */


### PR DESCRIPTION
These are a few patches that are kept in OpenWrt in order to fix compilation with musl. These should be the non-OpenWrt specific ones.