### PR TITLE
pam_lastlog: Respect silent option

### DIFF
--- a/modules/pam_lastlog/pam_lastlog.c
+++ b/modules/pam_lastlog/pam_lastlog.c
@@ -135,11 +135,6 @@ _pam_session_parse(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
     int ctrl=(LASTLOG_DATE|LASTLOG_HOST|LASTLOG_LINE|LASTLOG_WTMP|LASTLOG_UPDATE);
 
-    /* does the appliction require quiet? */
-    if (flags & PAM_SILENT) {
-	ctrl |= LASTLOG_QUIET;
-    }
-
     /* step through arguments */
     for (; argc-- > 0; ++argv) {
 
@@ -166,6 +161,12 @@ _pam_session_parse(pam_handle_t *pamh, int flags, int argc, const char **argv)
 	} else {
 	    pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
 	}
+    }
+
+    /* does the appliction require quiet? */
+    if (flags & PAM_SILENT) {
+	ctrl |= LASTLOG_QUIET;
+	ctrl &= ~LASTLOG_BTMP;
     }
 
     D(("ctrl = %o", ctrl));


### PR DESCRIPTION
pam_lastlog module will not log info about failed login if the module
was configured with the "silent" option, or the session was opened with
PAM_SILENT flag.

Example use case enabled by this change:

    sudo --non-interactive program

If this command is run by another program expecting specific output from
the command run by sudo, the unexpected info about failed logins will
break this program.

* modules/pam_lastlog/pam_lastlog.c: Respect silent option.
  (last_login_failed): Skip info if LASTLOG_QUITE bit is set.