### PR TITLE
pam_lastlog: Improve silent option documentation

### DIFF
--- a/modules/pam_lastlog/pam_lastlog.8.xml
+++ b/modules/pam_lastlog/pam_lastlog.8.xml
@@ -102,6 +102,7 @@
           <para>
             Don't inform the user about any previous login,
             just update the <filename>/var/log/lastlog</filename> file.
+            This option does not affect display of bad login attempts.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
The silent option explicitly silents only the last login message and not
bad logins. Add a note to the manual to make this clear.

* modules/pam_lastlog/pam_lastlog.8.xml: Clearify "silent showfailed"