### PR TITLE
pam_setquota: new module to set or modify disk quotas on session start

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -576,9 +576,10 @@ AC_FUNC_MEMCMP
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS(fseeko getdomainname gethostname gettimeofday lckpwdf mkdir select)
 AC_CHECK_FUNCS(strcspn strdup strspn strstr strtol uname)
-AC_CHECK_FUNCS(getutent_r getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r)
+AC_CHECK_FUNCS(getutent_r getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r getmntent_r)
 AC_CHECK_FUNCS(getgrouplist getline getdelim)
 AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
+AC_CHECK_FUNCS(quotactl)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
 BACKUP_LIBS=$LIBS
 LIBS="$LIBS -lutil"
@@ -587,6 +588,7 @@ LIBS=$BACKUP_LIBS
 
 AM_CONDITIONAL([COND_BUILD_PAM_RHOSTS], [test "$ac_cv_func_ruserok_af" = yes -o "$ac_cv_func_ruserok" = yes])
 AM_CONDITIONAL([COND_BUILD_PAM_LASTLOG], [test "$ac_cv_func_logwtmp" = yes])
+AM_CONDITIONAL([COND_BUILD_PAM_SETQUOTA], [test "$ac_cv_func_quotactl" = yes])
 
 AC_CHECK_FUNCS(unshare, [UNSHARE=yes], [UNSHARE=no])
 AM_CONDITIONAL([HAVE_UNSHARE], [test "$UNSHARE" = yes])
@@ -703,7 +705,7 @@ AC_CONFIG_FILES([Makefile libpam/Makefile libpamc/Makefile libpamc/test/Makefile
 	modules/pam_pwhistory/Makefile modules/pam_rhosts/Makefile \
 	modules/pam_rootok/Makefile modules/pam_exec/Makefile \
 	modules/pam_securetty/Makefile modules/pam_selinux/Makefile \
-	modules/pam_sepermit/Makefile \
+	modules/pam_sepermit/Makefile modules/pam_setquota/Makefile \
 	modules/pam_shells/Makefile modules/pam_stress/Makefile \
 	modules/pam_succeed_if/Makefile modules/pam_tally/Makefile \
 	modules/pam_tally2/Makefile modules/pam_time/Makefile \

--- a/doc/sag/pam_setquota.xml
+++ b/doc/sag/pam_setquota.xml
@@ -1,0 +1,34 @@
+﻿<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
+<section id='sag-pam_setquota'>
+  <title>pam_setquota - set or modify disk quotas on session start</title>
+  <cmdsynopsis>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_setquota-cmdsynopsis"]/*)'/>
+  </cmdsynopsis>
+  <section id='sag-pam_setquota-description'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-description"]/*)'/>
+  </section>
+  <section id='sag-pam_setquota-options'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-options"]/*)'/>
+  </section>
+  <section id='sag-pam_setquota-types'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-types"]/*)'/>
+  </section>
+  <section id='sag-pam_setquota-return_values'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-return_values"]/*)'/>
+  </section>
+  <section id='sag-pam_setquota-examples'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-examples"]/*)'/>
+  </section>
+  <section id='sag-pam_setquota-author'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-author"]/*)'/>
+  </section>
+</section>

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -10,6 +10,10 @@ if COND_BUILD_PAM_LASTLOG
  MAYBE_PAM_LASTLOG = pam_lastlog
 endif
 
+if COND_BUILD_PAM_SETQUOTA
+ MAYBE_PAM_SETQUOTA = pam_setquota
+endif
+
 SUBDIRS := pam_access pam_cracklib pam_debug pam_deny pam_echo \
 	pam_env pam_exec pam_faildelay pam_filter pam_ftp \
 	pam_group pam_issue pam_keyinit pam_limits \
@@ -20,7 +24,7 @@ SUBDIRS := pam_access pam_cracklib pam_debug pam_deny pam_echo \
 	pam_succeed_if pam_tally pam_tally2 pam_time pam_timestamp \
 	pam_tty_audit pam_umask \
 	pam_unix pam_userdb pam_usertype pam_warn pam_wheel pam_xauth \
-	$(MAYBE_PAM_RHOSTS) $(MAYBE_PAM_LASTLOG)
+	$(MAYBE_PAM_RHOSTS) $(MAYBE_PAM_LASTLOG) $(MAYBE_PAM_SETQUOTA)
 
 CLEANFILES = *~
 

--- a/modules/pam_setquota/Makefile.am
+++ b/modules/pam_setquota/Makefile.am
@@ -1,0 +1,29 @@
+CLEANFILES = *~
+MAINTAINERCLEANFILES = $(MANS) README
+
+EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_setquota
+
+if HAVE_DOC
+man_MANS = pam_setquota.8
+endif
+XMLS = README.xml pam_setquota.8.xml
+
+TESTS = tst-pam_setquota
+
+securelibdir = $(SECUREDIR)
+secureconfdir = $(SCONFIGDIR)
+
+AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include
+AM_LDFLAGS = -no-undefined -avoid-version -module
+if HAVE_VERSIONING
+  AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
+endif
+
+securelib_LTLIBRARIES = pam_setquota.la
+pam_setquota_la_LIBADD = $(top_builddir)/libpam/libpam.la
+
+if ENABLE_REGENERATE_MAN
+noinst_DATA = README
+README: pam_setquota.8.xml
+-include $(top_srcdir)/Make.xml.rules
+endif

--- a/modules/pam_setquota/README.xml
+++ b/modules/pam_setquota/README.xml
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+"http://www.docbook.org/xml/4.3/docbookx.dtd"
+[
+<!--
+<!ENTITY pamaccess SYSTEM "pam_setquota.8.xml">
+-->
+]>
+
+<article>
+
+  <articleinfo>
+
+    <title>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+      href="pam_setquota.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_setquota-name"]/*)'/>
+    </title>
+
+  </articleinfo>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-description"]/*)'/>
+  </section>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-options"]/*)'/>
+  </section>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-examples"]/*)'/>
+  </section>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-author"]/*)'/>
+  </section>
+
+</article>

--- a/modules/pam_setquota/pam_setquota.8.xml
+++ b/modules/pam_setquota/pam_setquota.8.xml
@@ -1,0 +1,301 @@
+﻿<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+
+<refentry id="pam_setquota">
+
+  <refmeta>
+    <refentrytitle>pam_setquota</refentrytitle>
+    <manvolnum>8</manvolnum>
+    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+  </refmeta>
+
+  <refnamediv id="pam_setquota-name">
+    <refname>pam_setquota</refname>
+    <refpurpose>PAM module to set or modify disk quotas on session start</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis id="pam_setquota-cmdsynopsis">
+      <command>pam_setquota.so</command>
+       <arg choice="opt">
+        fs=<replaceable>/home</replaceable>
+      </arg>
+      <arg choice="opt">
+        overwrite=<replaceable>0</replaceable>
+      </arg>
+      <arg choice="opt">
+        debug=<replaceable>0</replaceable>
+      </arg>
+      <arg choice="opt">
+        startuid=<replaceable>1000</replaceable>
+      </arg>
+       <arg choice="opt">
+        enduid=<replaceable>0</replaceable>
+      </arg>
+       <arg choice="opt">
+        bsoftlimit=<replaceable>19000</replaceable>
+      </arg>
+       <arg choice="opt">
+        bhardlimit=<replaceable>20000</replaceable>
+      </arg>
+       <arg choice="opt">
+        isoftlimit=<replaceable>3000</replaceable>
+      </arg>
+       <arg choice="opt">
+        ihardlimit=<replaceable>4000</replaceable>
+      </arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1 id="pam_setquota-description">
+
+    <title>DESCRIPTION</title>
+
+    <para>
+      pam_setquota is a PAM module to set or modify a disk quota at session start
+    </para>
+    <para>
+      This makes quotas usable with central user databases, such as MySQL or LDAP.
+    </para>
+
+  </refsect1>
+
+  <refsect1 id="pam_setquota-options">
+
+    <title>OPTIONS</title>
+    <para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <option>fs=<replaceable>/home</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+             The device file or mountpoint the policy applies to. Defaults to the
+             filesystem containing the users home directory.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>overwrite=<replaceable>0</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+             Overwrite an existing quota. Note: Enabling this will remove the ability
+             for the admin to manually configure different quotas for users for a
+             filesystem with <citerefentry><refentrytitle>edquota</refentrytitle>
+             <manvolnum>8</manvolnum></citerefentry>. (Defaults to 0)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>debug=<replaceable>0</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+             Enable debugging. A value of 1 outputs the old and new quota on a device.
+             A value of 2 also prints out the matched and found filesystems should
+             <option>fs</option> be unset. (Defaults to 0)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>startuid=<replaceable>1000</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+             Describe the start of the UID range the policy is applied to.
+             (Defaults to UID_MIN from login.defs or the uidmin value defined
+             at compile-time if UID_MIN is undefined)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>enduid=<replaceable>0</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+             Describe the end of the UID range the policy is applied to. Setting
+             <emphasis>enduid=0</emphasis> results in an open-ended UID
+             range (i.e. all uids greater than <option>startuid</option> are
+             included). (Defaults to 0)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>bsoftlimit=<replaceable>19000</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+              Soft limit for disk quota blocks, as defined by <citerefentry>
+              <refentrytitle>quotactl</refentrytitle><manvolnum>2</manvolnum>
+              </citerefentry>.
+              Note: <option>bsoftlimit</option> and <option>bhardlimit</option>
+              <emphasis>must</emphasis> be set at the same time!
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>bhardlimit=<replaceable>20000</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+              Hard limit for disk quota blocks, as defined by <citerefentry>
+              <refentrytitle>quotactl</refentrytitle><manvolnum>2</manvolnum>
+              </citerefentry>.
+              Note: <option>bsoftlimit</option> and <option>bhardlimit</option>
+              <emphasis>must</emphasis> be set at the same time!
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>isoftlimit=<replaceable>3000</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+              Soft limit for inodes, as defined by <citerefentry><refentrytitle>
+              quotactl</refentrytitle><manvolnum>2</manvolnum></citerefentry>.
+              Note: <option>isoftlimit</option> and <option>ihardlimit</option>
+              <emphasis>must</emphasis> be set at the same time!
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <option>ihardlimit=<replaceable>4000</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+              Hard limit for inodes, as defined by <citerefentry><refentrytitle>
+              quotactl</refentrytitle><manvolnum>2</manvolnum></citerefentry>.
+              Note: <option>isoftlimit</option> and <option>ihardlimit</option>
+              <emphasis>must</emphasis> be set at the same time!
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </para>
+  </refsect1>
+
+  <refsect1 id="pam_setquota-types">
+    <title>MODULE TYPES PROVIDED</title>
+    <para>
+       Only the <option>session</option> module type is provided.
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_setquota-return_values'>
+    <title>RETURN VALUES</title>
+    <para>
+      <variablelist>
+
+        <varlistentry>
+          <term>PAM_SUCCESS</term>
+          <listitem>
+            <para>
+              The quota was set successfully.
+            </para>
+          </listitem>
+        </varlistentry>
+
+	<varlistentry>
+          <term>PAM_IGNORE</term>
+          <listitem>
+            <para>
+              No action was taken because either the UID of the user was outside
+              of the specifed range, a quota already existed and
+              <option>overwrite=1</option> was not configured or no limits were
+              configured at all.
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>PAM_CRED_INSUFFICIENT</term>
+          <listitem>
+            <para>
+              The user was not found.
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>PAM_PERM_DENIED</term>
+          <listitem>
+            <para>
+               <filename>/proc/mounts</filename> could not be opened.
+            </para>
+            <para>
+               The filesystem or device specified was not found.
+            </para>
+            <para>
+               The limits for the user could not be retrieved. See syslog for
+               more information.
+            </para>
+            <para>
+               The limits for the user could not be set. See syslog for
+               more information.
+            </para>
+            <para>
+               Either <option>isoftlimit</option>/<option>ihardlimit</option>
+               or <option>bsoftlimit</option>/<option>bhardlimit</option> were
+               not set at the same time.
+            </para>
+          </listitem>
+        </varlistentry>
+
+      </variablelist>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_setquota-examples'>
+    <title>EXAMPLES</title>
+    <para>
+    A single invocation of `pam_setquota` applies a specific policy to a UID
+    range. Applying different policies to specific UID ranges is done by
+    invoking pam_setquota more than once. The last matching entry
+    defines the resulting quota.
+    <programlisting>
+      session  required   pam_setquota.so bsoftlimit=1000 bhardlimit=2000 isoftlimit=1000 ihardlimit=2000 startuid=1000 enduid=0 fs=/home
+      session  required   pam_setquota.so bsoftlimit=19000 bhardlimit=20000 isoftlimit=3000 ihardlimit=4000 startuid=2001 enduid=3000 fs=/dev/sda1
+      session  required   pam_setquota.so bsoftlimit=19000 bhardlimit=20000 isoftlimit=3000 ihardlimit=4000 startuid=3001 enduid=4000 fs=/dev/sda1 overwrite=1
+    </programlisting>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_setquota-see_also'>
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+        <refentrytitle>pam.conf</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam.d</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_setquota-author'>
+    <title>AUTHOR</title>
+      <para>
+       pam_setquota was originally written by
+       Ruslan Savchenko &lt;savrus@mexmat.net&gt;.
+      </para>
+      <para>
+       Further modifications were made by Shane Tzen&lt;shane@ict.usc.edu&gt;,
+       Sven Hartge &lt;sven@svenharte.de&gt;
+       and Keller Fuchs &lt;kellerfuchs@hashbang.sh&gt;
+      </para>
+  </refsect1>
+
+</refentry>

--- a/modules/pam_setquota/pam_setquota.c
+++ b/modules/pam_setquota/pam_setquota.c
@@ -1,0 +1,396 @@
+/* PAM setquota module
+
+   This PAM module sets disk quota when a session begins.
+
+   Copyright © 2006 Ruslan Savchenko <savrus@mexmat.net>
+   Copyright © 2010 Shane Tzen <shane@ict.usc.edu>
+   Copyright © 2012-2020 Sven Hartge <sven@svenhartge.de>
+   Copyright © 2016 Keller Fuchs <kellerfuchs@hashbang.sh>
+
+*/
+
+#include <sys/types.h>
+#include <sys/quota.h>
+#include <linux/quota.h>
+#include <pwd.h>
+#include <syslog.h>
+#include <errno.h>
+#include <mntent.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#define PAM_SM_SESSION
+
+#include <security/pam_modules.h>
+#include <security/_pam_macros.h>
+#include <security/pam_ext.h>
+#include <security/pam_modutil.h>
+#include "pam_inline.h"
+
+#ifndef PATH_LOGIN_DEFS
+# define PATH_LOGIN_DEFS "/etc/login.defs"
+#endif
+
+#define MAX_UID_VALUE 0xFFFFFFFFUL
+
+struct pam_params {
+  uid_t start_uid;
+  uid_t end_uid;
+  const char *fs;
+  size_t fs_len;
+  int overwrite;
+  int debug;
+};
+
+static inline void
+debug(pam_handle_t *pamh, const struct if_dqblk *p,
+      const char *device, const char *dbgprefix) {
+  pam_syslog(pamh, LOG_DEBUG, "%s device=%s bsoftlimit=%llu bhardlimit=%llu "
+                              "isoftlimit=%llu ihardlimit=%llu btime=%llu itime=%llu",
+             dbgprefix, device,
+             p->dqb_bsoftlimit, p->dqb_bhardlimit,
+             p->dqb_isoftlimit, p->dqb_ihardlimit,
+             p->dqb_btime, p->dqb_itime);
+}
+
+static unsigned long long
+str_to_dqb_num(pam_handle_t *pamh, const char *str, const char *param) {
+  char *ep = NULL;
+
+  errno = 0;
+  long long temp = strtoll(str, &ep, 10);
+  if (temp < 0 || str == ep || *ep != '\0' || errno !=0) {
+    pam_syslog(pamh, LOG_ERR, "Parameter \"%s=%s\" invalid, setting to 0", param, str);
+    return 0;
+  }
+  else {
+    return temp;
+  }
+}
+
+static bool
+parse_dqblk(pam_handle_t *pamh, int argc, const char **argv, struct if_dqblk *p) {
+  bool bhard = false, bsoft = false, ihard = false, isoft = false;
+
+  /* step through arguments */
+  for (; argc-- > 0; ++argv) {
+    const char *str;
+    if ((str = pam_str_skip_prefix(*argv, "bhardlimit=")) != NULL) {
+      p->dqb_bhardlimit = str_to_dqb_num(pamh, str, "bhardlimit");
+      p->dqb_valid |= QIF_BLIMITS;
+      bhard = true;
+    } else if ((str = pam_str_skip_prefix(*argv, "bsoftlimit=")) != NULL) {
+      p->dqb_bsoftlimit = str_to_dqb_num(pamh, str, "bsoftlimit");
+      p->dqb_valid |= QIF_BLIMITS;
+      bsoft = true;
+    } else if ((str = pam_str_skip_prefix(*argv, "ihardlimit=")) != NULL) {
+      p->dqb_ihardlimit = str_to_dqb_num(pamh, str, "ihardlimit");
+      p->dqb_valid |= QIF_ILIMITS;
+      ihard = true;
+    } else if ((str = pam_str_skip_prefix(*argv, "isoftlimit=")) != NULL) {
+      p->dqb_isoftlimit = str_to_dqb_num(pamh, str, "isoftlimit");
+      p->dqb_valid |= QIF_ILIMITS;
+      isoft = true;
+    } else if ((str = pam_str_skip_prefix(*argv, "btime=")) != NULL) {
+      p->dqb_btime = str_to_dqb_num(pamh, str, "btime");
+      p->dqb_valid |= QIF_BTIME;
+    } else if ((str = pam_str_skip_prefix(*argv, "itime=")) != NULL) {
+      p->dqb_itime = str_to_dqb_num(pamh, str, "itime");
+      p->dqb_valid |= QIF_ITIME;
+    }
+  }
+
+  /* return FALSE if a softlimit or hardlimit has been set
+   * independently of its counterpart.
+   */
+  return !(bhard ^ bsoft) && !(ihard ^ isoft);
+}
+
+/* inspired by pam_usertype_get_id */
+static uid_t
+str_to_uid(pam_handle_t *pamh, const char *value, uid_t default_value, const char *param) {
+    unsigned long ul;
+    char *ep;
+    uid_t uid;
+
+    errno = 0;
+    ul = strtoul(value, &ep, 10);
+    if (!(ul >= MAX_UID_VALUE
+        || (uid_t)ul >= MAX_UID_VALUE
+        || (errno != 0 && ul == 0)
+        || value == ep
+        || *ep != '\0')) {
+        uid = (uid_t)ul;
+    } else {
+        pam_syslog(pamh, LOG_ERR, "Parameter \"%s=%s\" invalid, "
+                   "setting to %u", param, value, default_value);
+        uid = default_value;
+    }
+
+    return uid;
+}
+
+static void
+parse_params(pam_handle_t *pamh, int argc, const char **argv, struct pam_params *p) {
+  /* step through arguments */
+  for (; argc-- > 0; ++argv) {
+    const char *str;
+    char *ep = NULL;
+    if ((str = pam_str_skip_prefix(*argv, "startuid=")) != NULL) {
+      p->start_uid = str_to_uid(pamh, str, p->start_uid, "startuid");
+    } else if ((str = pam_str_skip_prefix(*argv, "enduid=")) != NULL) {
+      p->end_uid = str_to_uid(pamh, str, p->end_uid, "enduid");
+    } else if ((str = pam_str_skip_prefix(*argv, "fs=")) != NULL) {
+      p->fs = str;
+      p->fs_len = strlen(str);
+      /* Mask the unnecessary '/' from the end of fs parameter */
+      if (p->fs_len > 1 && p->fs[p->fs_len - 1] == '/')
+        --p->fs_len;
+    } else if ((str = pam_str_skip_prefix(*argv, "overwrite=")) != NULL) {
+      errno = 0;
+      p->overwrite = strtol(str, &ep, 10);
+      if (*ep != '\0' || str == ep || errno !=0 || (p->overwrite < 0)) {
+        pam_syslog(pamh, LOG_ERR, "Parameter \"overwrite=%s\" invalid, "
+                        "setting to 0", str);
+        p->overwrite = 0;
+      }
+    } else if ((str = pam_str_skip_prefix(*argv, "debug=")) != NULL) {
+      errno = 0;
+      p->debug = strtol(str, &ep, 10);
+      if (*ep != '\0' || str == ep || errno != 0 || (p->debug < 0)) {
+        pam_syslog(pamh, LOG_ERR, "Parameter \"debug=%s\" invalid, "
+                        "setting to 0", str);
+        p->debug = 0;
+      }
+    }
+  }
+}
+
+PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc,
+                                   const char **argv) {
+  int retval;
+  unsigned long ul;
+  char *ep, *val, *mntdevice = NULL;
+  const void *user;
+  const struct passwd *pwd;
+  struct pam_params param = {
+          .start_uid = PAM_USERTYPE_UIDMIN,
+          .end_uid = 0,
+          .fs = NULL };
+  struct if_dqblk ndqblk;
+  FILE *fp;
+  size_t mnt_len = 0, match_size = 0;
+#ifdef HAVE_GETMNTENT_R
+  char buf[BUFSIZ];
+  struct mntent ent;
+#endif
+  const struct mntent *mnt;
+  const char *service;
+
+  if (pam_get_item(pamh, PAM_SERVICE, (const void **)&service) != PAM_SUCCESS)
+    service = "";
+
+  /* Get UID_MIN for default start_uid from login.defs */
+  val = pam_modutil_search_key(pamh, PATH_LOGIN_DEFS, "UID_MIN");
+
+  /* Should UID_MIN be undefined, use current value of param.start_uid
+   * pre-defined as PAM_USERTYPE_UIDMIN set by configure as safe
+   * starting UID to avoid setting a quota for root and system
+   * users if startuid= parameter is absent.
+   */
+  if (val) {
+    param.start_uid = str_to_uid(pamh, val, param.start_uid, PATH_LOGIN_DEFS":UID_MIN");
+  }
+
+  /* Parse parameter values
+   * Must come after pam_modutil_search_key so that the current system
+   * default for UID_MIN is already in p.start_uid to serve as default
+   * for str_to_uid in case of a parse error.
+   * */
+  parse_params(pamh, argc, argv, &param);
+
+  if (param.debug >= 1)
+    pam_syslog(pamh, LOG_DEBUG, "Config: startuid=%u enduid=%u fs=%s "
+                    "debug=%d overwrite=%d",
+                    param.start_uid, param.end_uid,
+                    param.fs ? param.fs : "(none)",
+                    param.debug, param.overwrite);
+
+  /* Determine the user name so we can get the home directory */
+  retval = pam_get_item(pamh, PAM_USER, &user);
+  if (retval != PAM_SUCCESS || user == NULL || *(const char *)user == '\0') {
+    pam_syslog(pamh, LOG_NOTICE, "user unknown");
+    return PAM_USER_UNKNOWN;
+  }
+
+  /* Get the password entry */
+  pwd = pam_modutil_getpwnam(pamh, user);
+  if (pwd == NULL) {
+    return PAM_CRED_INSUFFICIENT;
+  }
+
+  /* Check if we should not set quotas for user */
+  if ((pwd->pw_uid < param.start_uid) ||
+      ((param.end_uid >= param.start_uid) && (param.start_uid != 0) &&
+       (pwd->pw_uid > param.end_uid)))
+    return PAM_SUCCESS;
+
+  /* Find out what device the filesystem is hosted on */
+  if ((fp = setmntent("/proc/mounts", "r")) == NULL) {
+    pam_syslog(pamh, LOG_ERR, "Unable to open /proc/mounts");
+    return PAM_PERM_DENIED;
+  }
+
+  while (
+#ifdef HAVE_GETMNTENT_R
+           (mnt = getmntent_r(fp, &ent, buf, sizeof(buf))) != NULL
+#else
+           (mnt = getmntent(fp)) != NULL
+#endif
+        ) {
+    /* If param.fs is not specified use filesystem with users homedir
+     * as default.
+     */
+    if (param.fs == NULL) {
+      /* Mask trailing / from mnt->mnt_dir, to get a leading / on the
+       * remaining suffix returned by pam_str_skip_prefix_len()
+       */
+      for (mnt_len = strlen(mnt->mnt_dir); mnt_len > 0; --mnt_len)
+        if (mnt->mnt_dir[mnt_len - 1] != '/')
+          break;
+      const char *s;
+      if (param.debug >= 2)
+        pam_syslog(pamh, LOG_DEBUG, "Trying to match pw_dir=\"%s\" "
+                        "with mnt_dir=\"%s\"", pwd->pw_dir, mnt->mnt_dir);
+      /*
+       * (mnt_len > match_size) Only try matching the mnt_dir if its length
+       * is longer than the last matched length, trying to find the longest
+       * mnt_dir for a given pwd_dir.
+       *
+       * (mnt_len == 0 && mnt->mnt_dir[0] == '/') special-cases the
+       * root-dir /, which is the only mnt_dir with a trailing '/', which
+       * got masked earlier.
+       */
+      if ((mnt_len > match_size || (mnt_len == 0 && mnt->mnt_dir[0] == '/')) &&
+         (s = pam_str_skip_prefix_len(pwd->pw_dir, mnt->mnt_dir, mnt_len)) != NULL &&
+         (s[0] == '\0' || s[0] == '/')) {
+        free(mntdevice);
+        if ((mntdevice = strdup(mnt->mnt_fsname)) == NULL) {
+          pam_syslog(pamh, LOG_CRIT, "Memory allocation error");
+          endmntent(fp);
+          return PAM_PERM_DENIED;
+        }
+        match_size = mnt_len;
+        if (param.debug >= 2)
+          pam_syslog(pamh, LOG_DEBUG, "Found pw_dir=\"%s\" in mnt_dir=\"%s\" "
+                     "with suffix=\"%s\" on device=\"%s\"", pwd->pw_dir,
+                     mnt->mnt_dir, s, mntdevice);
+      }
+    /* param.fs has been specified, find exactly matching fileystem */
+    } else if ((strncmp(param.fs, mnt->mnt_dir, param.fs_len) == 0
+                && mnt->mnt_dir[param.fs_len] == '\0') ||
+               (strncmp(param.fs, mnt->mnt_fsname, param.fs_len) == 0
+                && mnt->mnt_fsname[param.fs_len] == '\0' )) {
+        free(mntdevice);
+        if ((mntdevice = strdup(mnt->mnt_fsname)) == NULL) {
+          pam_syslog(pamh, LOG_CRIT, "Memory allocation error");
+          endmntent(fp);
+          return PAM_PERM_DENIED;
+        }
+        if (param.debug >= 2)
+          pam_syslog(pamh, LOG_DEBUG, "Found fs=\"%s\" in mnt_dir=\"%s\" "
+                     "on device=\"%s\"", param.fs, mnt->mnt_dir, mntdevice);
+    }
+  }
+
+  endmntent(fp);
+
+  if (mntdevice == NULL) {
+    pam_syslog(pamh, LOG_ERR, "Filesystem or device not found: %s", param.fs ? param.fs : pwd->pw_dir);
+    return PAM_PERM_DENIED;
+  }
+
+  /* Get limits */
+  if (quotactl(QCMD(Q_GETQUOTA, USRQUOTA), mntdevice, pwd->pw_uid,
+               (void *)&ndqblk) == -1) {
+    pam_syslog(pamh, LOG_ERR, "fail to get limits for user %s : %m",
+               pwd->pw_name);
+    free(mntdevice);
+    return PAM_PERM_DENIED;
+  }
+
+  if (param.debug >= 1)
+    debug(pamh, &ndqblk, mntdevice, "Quota read:");
+
+  /* Only overwrite if quotas aren't already set or if overwrite is set */
+  if ((ndqblk.dqb_bsoftlimit == 0 && ndqblk.dqb_bhardlimit == 0 &&
+       ndqblk.dqb_isoftlimit == 0 && ndqblk.dqb_ihardlimit == 0) ||
+      param.overwrite == 1) {
+
+    /* Parse new limits
+     * Exit with an error should only the hard- or softlimit be
+     * configured but not both.
+     * This avoids errors, inconsistencies and possible race conditons
+     * during setquota.
+     */
+    ndqblk.dqb_valid = 0;
+    if (!parse_dqblk(pamh, argc, argv, &ndqblk)) {
+      pam_syslog(pamh, LOG_ERR,
+                 "Both soft- and hardlimits for %s need to be configured "
+                 "at the same time!", mntdevice);
+      free(mntdevice);
+      return PAM_PERM_DENIED;
+    }
+
+    /* Nothing changed? Are no limits defined at all in configuration? */
+    if (ndqblk.dqb_valid == 0) {
+      pam_syslog(pamh, LOG_AUTH | LOG_WARNING, "no limits defined in "
+                 "configuration for user %s on %s", pwd->pw_name, mntdevice);
+      free(mntdevice);
+      return PAM_IGNORE;
+    }
+
+    /* Set limits */
+    if (quotactl(QCMD(Q_SETQUOTA, USRQUOTA), mntdevice, pwd->pw_uid,
+                 (void *)&ndqblk) == -1) {
+      pam_syslog(pamh, LOG_ERR, "failed to set limits for user %s on %s: %m",
+                 pwd->pw_name, mntdevice);
+      free(mntdevice);
+      return PAM_PERM_DENIED;
+    }
+    if (param.debug >= 1)
+      debug(pamh, &ndqblk, mntdevice, "Quota set:");
+
+    /* End module */
+    free(mntdevice);
+    return PAM_SUCCESS;
+
+  } else {
+    /* Quota exists and overwrite!=1 */
+    if (param.debug >= 1) {
+      pam_syslog(pamh, LOG_DEBUG, "Quota already exists for user %s "
+                 "on %s, not overwriting it without \"overwrite=1\"",
+                 pwd->pw_name, mntdevice);
+    }
+    /* End module */
+    free(mntdevice);
+    return PAM_IGNORE;
+  }
+
+}
+
+PAM_EXTERN
+int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc,
+                         const char **argv) {
+  return PAM_SUCCESS;
+}
+
+#ifdef PAM_STATIC
+
+/* static module data */
+struct pam_module _pam_setquota_modstruct = {
+  "pam_setquota",      NULL,                 NULL, NULL,
+  pam_sm_open_session, pam_sm_close_session, NULL
+};
+
+#endif

--- a/modules/pam_setquota/tst-pam_setquota
+++ b/modules/pam_setquota/tst-pam_setquota
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../tests/tst-dlopen .libs/pam_setquota.so


### PR DESCRIPTION
This module makes disk quotas usable with central user databases, such as MySQL or
LDAP.

Resolves: #92