### PR TITLE
Add missing va_end() call

### DIFF
--- a/modules/pam_rootok/pam_rootok.c
+++ b/modules/pam_rootok/pam_rootok.c
@@ -73,12 +73,15 @@ log_callback (int type, const char *fmt, ...)
     if (audit_fd >= 0) {
 	char *buf;
 
-	if (vasprintf (&buf, fmt, ap) < 0)
+	if (vasprintf (&buf, fmt, ap) < 0) {
+		va_end(ap);
 		return 0;
+	}
 	audit_log_user_avc_message(audit_fd, AUDIT_USER_AVC, buf, NULL, NULL,
 				   NULL, 0);
 	audit_close(audit_fd);
 	free(buf);
+	va_end(ap);
 	return 0;
     }
 


### PR DESCRIPTION
According to the man pages, "Each invocation of va_start() must be matched by a corresponding invocation of va_end() in the same function."
