### PR TITLE
Deprecate pam_unix' explicit "usergroups" option in favor of /etc/login.defs

### DIFF
--- a/modules/pam_umask/pam_umask.8.xml
+++ b/modules/pam_umask/pam_umask.8.xml
@@ -58,7 +58,8 @@
         </listitem>
         <listitem>
           <para>
-            UMASK entry from /etc/login.defs
+            UMASK entry from /etc/login.defs (influenced by USERGROUPS_ENAB in
+	    /etc/login.defs)
           </para>
         </listitem>
         <listitem>
@@ -115,6 +116,11 @@
               If the user is not root and the username is the same as
               primary group name, the umask group bits are set to be the
               same as owner bits (examples: 022 -> 002, 077 -> 007).
+	      Note that using this option explicitly is discouraged. pam_umask
+	      enables this functionality by default if /etc/login.defs enables
+	      USERGROUPS_ENAB, and the umask is not set explicitly in other
+	      places than /etc/login.defs (this is compatible with login's
+	      behaviour without PAM).
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
/etc/login.defs has a USERGROUP_ENAB option with the same semantics as the
usergroup module option.  If our definition of the umask comes from
/etc/login.defs, we should read this setting as well.

This restores compatibility with the pre-PAM behaviour of login.

See https://blueprints.launchpad.net/ubuntu/+spec/umask-to-0002.

Signed-off-by: Martin Pitt <martin.pitt@ubuntu.com>
Signed-off-by: Steve Langasek <vorlon@debian.org>

Bug-Debian: http://bugs.debian.org/583958

This patch has been carried in Ubuntu for a number of years and belongs upstream.  I'm happy to discuss whether deprecation of the module option in favor of /etc/login.defs is the right thing to do (IMHO it is).