### PR TITLE
Debian spellcheck

### DIFF
--- a/doc/man/misc_conv.3.xml
+++ b/doc/man/misc_conv.3.xml
@@ -70,7 +70,7 @@
         <term><type>const char *</type><varname>pam_misc_conv_warn_line</varname>;</term>
         <listitem>
           <para>
-            Used in conjuction with
+            Used in conjunction with
             <varname>pam_misc_conv_warn_time</varname>, this variable is
             a pointer to the string that will be displayed when it becomes
             time to warn the user that the timeout is approaching. Its
@@ -103,7 +103,7 @@
         <term><type>const char *</type><varname>pam_misc_conv_die_line</varname>;</term>
         <listitem>
           <para>
-            Used in conjuction with
+            Used in conjunction with
             <varname>pam_misc_conv_die_time</varname>, this variable is
             a pointer to the string that will be displayed when the
             conversation times out. Its default value is a translated

--- a/doc/man/pam_get_item.3.xml
+++ b/doc/man/pam_get_item.3.xml
@@ -19,7 +19,7 @@
   <refnamediv id='pam_get_item-name'>
     <refname>pam_get_item</refname>
     <refpurpose>
-       getting PAM informations
+       getting PAM information
     </refpurpose>
   </refnamediv>
 
@@ -45,7 +45,7 @@
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_get_item</function> function allows applications
-      and PAM service modules to access and retrieve PAM informations
+      and PAM service modules to access and retrieve PAM information
       of <emphasis>item_type</emphasis>. Upon successful return,
       <emphasis>item</emphasis> contains a pointer to the value of the
       corresponding item. Note, this is a pointer to the

--- a/doc/man/pam_prompt.3.xml
+++ b/doc/man/pam_prompt.3.xml
@@ -75,7 +75,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-              Conversation succeded, response is set.
+              Conversation succeeded, response is set.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_putenv.3.xml
+++ b/doc/man/pam_putenv.3.xml
@@ -79,7 +79,7 @@
       <emphasis>name_value</emphasis>, which means in contrast to
       <citerefentry>
         <refentrytitle>putenv</refentrytitle><manvolnum>3</manvolnum>
-      </citerefentry>, the application is responsible to free the data.
+      </citerefentry>, the application is responsible for freeing the data.
     </para>
   </refsect1>
 

--- a/doc/man/pam_set_item.3.xml
+++ b/doc/man/pam_set_item.3.xml
@@ -19,7 +19,7 @@
   <refnamediv id='pam_set_item-name'>
     <refname>pam_set_item</refname>
     <refpurpose>
-       set and update PAM informations
+       set and update PAM information
     </refpurpose>
   </refnamediv>
 
@@ -45,7 +45,7 @@
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_set_item</function> function allows applications
-      and PAM service modules to access and to update PAM informations
+      and PAM service modules to access and to update PAM information
       of <emphasis>item_type</emphasis>. For this a copy
       of the object pointed to by the <emphasis>item</emphasis> argument
       is created. The following <emphasis>item_type</emphasis>s are

--- a/doc/man/pam_set_item.3.xml
+++ b/doc/man/pam_set_item.3.xml
@@ -74,7 +74,7 @@
     </para>
 
     <para>
-      Both, PAM_AUTHTOK and PAM_OLDAUTHTOK, will be reseted before
+      Both, PAM_AUTHTOK and PAM_OLDAUTHTOK, will be reset before
       returning to the application. Which means an application is not
       able to access the authentication tokens.
     </para>

--- a/modules/pam_cracklib/pam_cracklib.8.xml
+++ b/modules/pam_cracklib/pam_cracklib.8.xml
@@ -402,7 +402,7 @@
           </term>
           <listitem>
             <para>
-              Check whether the words from the GECOS field (usualy full name
+              Check whether the words from the GECOS field (usually full name
               of the user) longer than 3 characters in straight or reversed
               form are contained in the new password. If any such word is
               found the new password is rejected.

--- a/modules/pam_env/pam_env.8.xml
+++ b/modules/pam_env/pam_env.8.xml
@@ -62,7 +62,7 @@
       Second a file (<filename>/etc/environment</filename> by default) with simple
       <emphasis>KEY=VAL</emphasis> pairs on separate lines will be read.
       With the <emphasis>envfile</emphasis> option an alternate file can be specified.
-      And with the <emphasis>readenv</emphasis> option this can be completly disabled.
+      And with the <emphasis>readenv</emphasis> option this can be completely disabled.
     </para>
     <para>
       Third it will read a user configuration file

--- a/modules/pam_env/pam_env.conf
+++ b/modules/pam_env/pam_env.conf
@@ -26,7 +26,7 @@
 #
 # Each line starts with the variable name, there are then two possible
 # options for each variable DEFAULT and OVERRIDE.
-# DEFAULT allows and administrator to set the value of the
+# DEFAULT allows an administrator to set the value of the
 # variable  to some default value, if none is supplied then the empty
 # string is assumed. The OVERRIDE option tells pam_env that it should
 # enter in its value (overriding the default value) if there is one

--- a/modules/pam_exec/pam_exec.8.xml
+++ b/modules/pam_exec/pam_exec.8.xml
@@ -75,7 +75,7 @@
 
     <para>
       Commands called by pam_exec need to be aware of that the user
-      can have controll over the environment.
+      can have control over the environment.
     </para>
 
   </refsect1>

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -376,7 +376,7 @@ set_filter (pam_handle_t *pamh, int flags UNUSED, int ctrl,
 
 	    /* grant slave terminal */
 	    if (grantpt (fd[0]) < 0) {
-		pam_syslog(pamh, LOG_ERR, "Cannot grant acccess to slave terminal");
+		pam_syslog(pamh, LOG_ERR, "Cannot grant access to slave terminal");
 		return PAM_ABORT;
 	    }
 

--- a/modules/pam_lastlog/pam_lastlog.8.xml
+++ b/modules/pam_lastlog/pam_lastlog.8.xml
@@ -203,7 +203,7 @@
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option> module type
-      allows to lock out users which did not login recently enough.
+      allows one to lock out users who did not login recently enough.
       The <option>session</option> module type is provided for displaying
       the information about the last login and/or updating the lastlog and
       wtmp files.

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -2149,7 +2149,7 @@ int pam_sm_close_session(pam_handle_t *pamh, int flags UNUSED,
 	pam_set_data(idata.pamh, NAMESPACE_PROTECT_DATA, NULL, NULL);
 
 	if (idata.flags & PAMNS_DEBUG)
-	    pam_syslog(idata.pamh, LOG_DEBUG, "close_session - sucessful");
+	    pam_syslog(idata.pamh, LOG_DEBUG, "close_session - successful");
         return PAM_SUCCESS;
     }
 

--- a/modules/pam_timestamp/pam_timestamp_check.8.xml
+++ b/modules/pam_timestamp/pam_timestamp_check.8.xml
@@ -78,7 +78,7 @@ see if the default timestamp is valid, or optionally remove it.
                the user authenticates as herself. When the user authenticates as a
                different user, the name of the timestamp file changes to
                accommodate this. <replaceable>target_user</replaceable> allows
-               to specify this user name.
+               one to specify this user name.
             </para>
          </listitem>
       </varlistentry>


### PR DESCRIPTION
A collection of spelling and grammar fixes identified by Debian's static analysis tools and Debian's users.