### PR TITLE
Adding check if user is member of any group from the list.(pam_succeed_if.c)

### DIFF
--- a/modules/pam_succeed_if/pam_succeed_if.8.xml
+++ b/modules/pam_succeed_if/pam_succeed_if.8.xml
@@ -198,27 +198,15 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user ingroup group</option></term>
+        <term><option>user ingroup group:group:...</option></term>
         <listitem>
-          <para>User is in given group.</para>
+          <para>User is in given group(s).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user ismemberof group:group:...</option></term>
+        <term><option>user notingroup group:group:...</option></term>
         <listitem>
-          <para>User is a member of any group in the list.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term><option>user notingroup group</option></term>
-        <listitem>
-          <para>User is not in given group.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term><option>user isnonmemberof group:group:...</option></term>
-        <listitem>
-          <para>User is not a member of any group in the list.</para>
+          <para>User is not in given group(s).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -287,6 +275,7 @@
     </para>
     <programlisting>
 auth required pam_succeed_if.so quiet user ingroup wheel
+auth required pam_succeed_if.so quiet user ingroup group1:group2
     </programlisting>
 
     <para>

--- a/modules/pam_succeed_if/pam_succeed_if.8.xml
+++ b/modules/pam_succeed_if/pam_succeed_if.8.xml
@@ -198,13 +198,13 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user ingroup group:group:...</option></term>
+        <term><option>user ingroup group[:group:....]</option></term>
         <listitem>
           <para>User is in given group(s).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user notingroup group:group:...</option></term>
+        <term><option>user notingroup group[:group:....]</option></term>
         <listitem>
           <para>User is not in given group(s).</para>
         </listitem>
@@ -271,11 +271,10 @@
     <title>EXAMPLES</title>
     <para>
       To emulate the behaviour of <emphasis>pam_wheel</emphasis>, except
-      there is no fallback to group 0:
+      there is no fallback to group 0 being only approximated by checking also the root group membership:
     </para>
     <programlisting>
-auth required pam_succeed_if.so quiet user ingroup wheel
-auth required pam_succeed_if.so quiet user ingroup group1:group2
+auth required pam_succeed_if.so quiet user ingroup wheel:root
     </programlisting>
 
     <para>

--- a/modules/pam_succeed_if/pam_succeed_if.8.xml
+++ b/modules/pam_succeed_if/pam_succeed_if.8.xml
@@ -204,9 +204,21 @@
         </listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>user ismemberof group:group:...</option></term>
+        <listitem>
+          <para>User is a member of any group in the list.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>user notingroup group</option></term>
         <listitem>
           <para>User is not in given group.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>user isnonmemberof group:group:...</option></term>
+        <listitem>
+          <para>User is not a member of any group in the list.</para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -207,6 +207,24 @@ evaluate_inlist(const char *left, const char *right)
 	}
 	return PAM_AUTH_ERR;
 }
+/* Check for groupname match */
+static int
+evaluate_groupname_list(pam_handle_t *pamh, const char *user, char *groups)
+{
+        char *ptr = NULL;
+        const char const *delim = ":";
+        char const *group = NULL;
+
+        group = strtok_r(groups, delim, &ptr);
+        while(group != NULL) {
+                if (pam_modutil_user_in_group_nam_nam(pamh, user, group) == 1) {
+                        return PAM_SUCCESS;
+                }
+                group = strtok_r(NULL, delim, &ptr);
+        }
+
+        return PAM_AUTH_ERR;
+}
 /* Check for list mismatch. */
 static int
 evaluate_notinlist(const char *left, const char *right)
@@ -220,6 +238,12 @@ evaluate_ingroup(pam_handle_t *pamh, const char *user, const char *group)
 	if (pam_modutil_user_in_group_nam_nam(pamh, user, group) == 1)
 		return PAM_SUCCESS;
 	return PAM_AUTH_ERR;
+}
+/* Return PAM_SUCCESS if the user is a member of any group in the list. */
+static int
+evaluate_membership(pam_handle_t *pamh, const char *user, char *groups)
+{
+        return evaluate_groupname_list(pamh, user, groups);
 }
 /* Return PAM_SUCCESS if the user is NOT in the group. */
 static int
@@ -407,10 +431,18 @@ evaluate(pam_handle_t *pamh, int debug,
 	if (strcasecmp(qual, "ingroup") == 0) {
 		return evaluate_ingroup(pamh, user, right);
 	}
+        /* User is a member of any group from the list. */
+        if (strcasecmp(qual, "ismemberof") == 0) {
+                return evaluate_membership(pamh, user, right);
+        }
 	/* User is not in this group. */
 	if (strcasecmp(qual, "notingroup") == 0) {
 		return evaluate_notingroup(pamh, user, right);
 	}
+        /* User is not a member of any group from the list. */
+        if (strcasecmp(qual, "isnonmemberof") == 0) {
+                return evaluate_nonmembership(pamh, user, right);
+        }
 	/* (Rhost, user) is in this netgroup. */
 	if (strcasecmp(qual, "innetgr") == 0) {
 		const void *rhost;

--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -223,7 +223,7 @@ evaluate_ingroup(pam_handle_t *pamh, const char *user, const char *group)
 
 	grp = strtok_r(group, delim, &ptr);
 	while(grp != NULL) {
-		if (pam_modutil_user_in_group_nam_nam(pamh, user, group) == 1)
+		if (pam_modutil_user_in_group_nam_nam(pamh, user, grp) == 1)
 			return PAM_SUCCESS;
 		grp = strtok_r(NULL, delim, &ptr);
 	}
@@ -239,11 +239,11 @@ evaluate_notingroup(pam_handle_t *pamh, const char *user, const char *group)
 
 	grp = strtok_r(group, delim, &ptr);
 	while(grp != NULL) {
-		if (pam_modutil_user_in_group_nam_nam(pamh, user, group) == 0)
-			return PAM_SUCCESS;
+		if (pam_modutil_user_in_group_nam_nam(pamh, user, grp) == 1)
+			return PAM_AUTH_ERR;
 		grp = strtok_r(NULL, delim, &ptr);
 	}
-	return PAM_AUTH_ERR;
+	return PAM_SUCCESS;
 }
 
 #ifdef HAVE_INNETGR


### PR DESCRIPTION
There is no way to check if user is a member of any group from the list like with an attribute from passwd struct for example.

Examples:
	account    requisite    pam_succeed_if.so user ingroup group1:group2
OR
	account    requisite    pam_succeed_if.so user notingroup group1:group2

Can be very convenient to grant access based on complex group memberships(LDAP, etc)