### PR TITLE
Fix a typo in pam_start(3) man page

### DIFF
--- a/doc/man/pam_start.3.xml
+++ b/doc/man/pam_start.3.xml
@@ -83,7 +83,7 @@
       <citerefentry>
         <refentrytitle>pam_get_item</refentrytitle><manvolnum>3</manvolnum>
       </citerefentry>.
-      The PAM handle cannot be used for mulitiple authentications at the
+      The PAM handle cannot be used for multiple authentications at the
       same time as long as <function>pam_end</function> was not called on
       it before.
     </para>


### PR DESCRIPTION
This is a trivial typo fixup.