### PR TITLE
pam_limits PWD_ABSURD_PWD_LENGTH is still too low

### DIFF
--- a/libpam/pam_modutil_private.h
+++ b/libpam/pam_modutil_private.h
@@ -14,7 +14,7 @@
 #include <security/pam_modutil.h>
 
 #define PWD_INITIAL_LENGTH     0x400
-#define PWD_ABSURD_PWD_LENGTH  0x40001
+#define PWD_ABSURD_PWD_LENGTH  0x400001
 #define PWD_LENGTH_SHIFT 4 /* 2^4 == 16 */
 
 extern void


### PR DESCRIPTION
With a group of more than 14739 users defined in /etc/group file, PAM access authentication ingroup test in PAM access authentication fails due to insufficient memory buffer size to store the group structure.

pam_modutil_getgrnam() gets the group structure from getgrnam_r() provided by glibc. Once the group size goes beyond a threshold, the size of the buffer required to store the group structure in jumps from 256KB to 4MB. Refer to the debugging message below for details too.

[pam_modutil_getpwnam.c:pam_modutil_getpwnam(92)] success
[pam_modutil_getgrnam.c:pam_modutil_getgrnam(112)] grp structure took 4194336 bytes or so of memory
[pam_dispatch.c:_pam_dispatch_aux(114)] module returned: Authentication failure

The PWD_ABSURD_PWD_LENGTH limit is increased to 4MB in the fix. In the long term, the structure storing group members in glibc:getgrnam_r() needs to be redesigned for better efficiency.

There have been a few other reports of the same problem and same ask to bump the limit to 4MB in the past.

https://bugzilla.redhat.com/show_bug.cgi?id=447842
https://forge.univention.org/bugzilla/show_bug.cgi?id=29393
https://lists.fedorahosted.org/archives/list/pam-developers@lists.fedorahosted.org/thread/NHM43M4TDOHXM7YN5JXG3IIGTOZKSNPN/