### PR TITLE
pam_namespace: secure tmp-inst directories

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -687,6 +687,7 @@ AC_CONFIG_FILES([Makefile libpam/Makefile libpamc/Makefile libpamc/test/Makefile
 	modules/pam_loginuid/Makefile modules/pam_mail/Makefile \
 	modules/pam_mkhomedir/Makefile modules/pam_motd/Makefile \
 	modules/pam_namespace/Makefile \
+	modules/pam_namespace/pam_namespace_helper modules/pam_namespace/pam_namespace.service \
 	modules/pam_nologin/Makefile modules/pam_permit/Makefile \
 	modules/pam_pwhistory/Makefile modules/pam_rhosts/Makefile \
 	modules/pam_rootok/Makefile modules/pam_exec/Makefile \

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -8,7 +8,7 @@ MAINTAINERCLEANFILES = $(MAN5) $(MAN8) README
 
 if HAVE_DOC
 MAN5 = namespace.conf.5
-MAN8 = pam_namespace.8
+MAN8 = pam_namespace.8 pam_namespace_helper.8
 endif
 
 EXTRA_DIST = README namespace.conf namespace.init $(MAN5) $(MAN8) $(XMLS) tst-pam_namespace
@@ -18,11 +18,12 @@ if HAVE_UNSHARE
   man_MANS = $(MAN5) $(MAN8)
 endif
 
-XMLS = README.xml namespace.conf.5.xml pam_namespace.8.xml
+XMLS = README.xml namespace.conf.5.xml pam_namespace.8.xml pam_namespace_helper.8.xml
 
 securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 namespaceddir = $(SCONFIGDIR)/namespace.d
+servicedir = $(prefix)/lib/systemd
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
         -DSECURECONF_DIR=\"$(SCONFIGDIR)/\" $(WARN_CFLAGS)
@@ -43,11 +44,18 @@ if HAVE_UNSHARE
 
 install-data-local:
 	mkdir -p $(DESTDIR)$(namespaceddir)
+	mkdir -p $(DESTDIR)$(servicedir)
+	$(INSTALL_DATA) pam_namespace.service $(DESTDIR)$(servicedir)
+
+  sbin_SCRIPTS = pam_namespace_helper
+
+uninstall-local:
+	-rm $(DESTDIR)$(servicedir)/pam_namespace.service
 endif
 
 
 if ENABLE_REGENERATE_MAN
 noinst_DATA = README
-README: pam_namespace.8.xml namespace.conf.5.xml
+README: pam_namespace.8.xml namespace.conf.5.xml pam_namespace_helper.8.xml
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_namespace/namespace.conf
+++ b/modules/pam_namespace/namespace.conf
@@ -21,7 +21,10 @@
 # is explicitly called with an argument to ignore the mode of the
 # instance parent. System administrators should use this argument with
 # caution, as it will reduce security and isolation achieved by
-# polyinstantiation.
+# polyinstantiation. The parent directories (except $HOME) are created
+# at boot by pam_namespace_helper, but in a live system, system
+# administrators should create the parent directories before enabling
+# them here.
 #
 #/tmp     /tmp-inst/       	level      root,adm
 #/var/tmp /var/tmp/tmp-inst/   	level      root,adm

--- a/modules/pam_namespace/pam_namespace.service.in
+++ b/modules/pam_namespace/pam_namespace.service.in
@@ -1,0 +1,11 @@
+[Unit]
+After=local-fs.target
+Before=multi-user.target shutdown.target
+Conflicts=shutdown.target
+DefaultDependencies=no
+Description=Make sure parent directories configured in @SCONFIGDIR@/namespace.conf for polyinstantiation exist
+Documentation=man:pam_namespace(8)
+
+[Service]
+ExecStart=@sbindir@/pam_namespace_helper
+Type=oneshot

--- a/modules/pam_namespace/pam_namespace_helper.8.xml
+++ b/modules/pam_namespace/pam_namespace_helper.8.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+
+<refentry id="pam_namespace_helper">
+
+  <refmeta>
+    <refentrytitle>pam_namespace_helper</refentrytitle>
+    <manvolnum>8</manvolnum>
+    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+  </refmeta>
+
+  <refnamediv id="pam_namespace_helper-name">
+    <refname>pam_namespace_helper</refname>
+    <refpurpose>Helper binary that creates home directories</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis id="pam_namespace_helper-cmdsynopsis">
+      <command>pam_namespace_helper</command>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1 id="pam_namespace_helper-description">
+
+    <title>DESCRIPTION</title>
+
+    <para>
+      <emphasis>pam_namespace_helper</emphasis> is a helper program
+      for the <emphasis>pam_namespace</emphasis> module that sets up a
+      private namespace for a session with polyinstantiated
+      directories. The helper ensures that the namespace mount points
+      exist before they are started to be used for the
+      polyinstantiated directories. Mount points for home directories
+      (lines with $HOME) are not created.
+    </para>
+
+    <para>
+      <emphasis>pam_namespace_helper</emphasis> should be run by
+      systemd at system startup. It should also be run by the
+      administrator after defining the polyinstantiated directories
+      but before enabling them.
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_namespace_helper-see_also'>
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+	<refentrytitle>pam_namespace</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_namespace_helper-author'>
+    <title>AUTHOR</title>
+      <para>
+        Written by Topi Miettinen.
+      </para>
+  </refsect1>
+
+</refentry>

--- a/modules/pam_namespace/pam_namespace_helper.in
+++ b/modules/pam_namespace/pam_namespace_helper.in
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CONF=@SCONFIGDIR@/namespace.conf
+
+# Match logic of process_line(), except lines with $HOME are ignored
+# skip the leading white space, rip off the comments, ignore empty lines
+sed -e 's/^[ 	]*//g' -e 's/#.*//g' -e '/.*\$HOME.*/d'  -e '/^$/d' < $CONF | \
+    while read polydir instance_prefix method uids; do
+	if [ ! -e "$instance_prefix" ]; then
+	    echo "mkdir $instance_prefix"
+	    mkdir --parents --mode=0 -Z "$instance_prefix"
+	fi
+    done
+
+exit 0


### PR DESCRIPTION
When using polyinstantiation for /tmp and/or /var/tmp, pam_namespace
creates subdirectories with fixed name tmp-inst. These paths should be
secured as early as possible to avoid that somehow these directories
could created and controlled by for example a malicious user or
service.

Ship a tmpfiles.d drop-in file, which creates the directories early in
boot sequence with correct permissions and ownership.

Closes #111.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>