### PR TITLE
Add support for a vendor directory and libeconf

### DIFF
--- a/Make.xml.rules
+++ b/Make.xml.rules
@@ -3,22 +3,22 @@
 #
 
 README: README.xml
-	$(XSLTPROC) --path $(srcdir) --xinclude --stringparam generate.toc "none" --nonet http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl $< | $(BROWSER) > $(srcdir)/$@
+	$(XSLTPROC) --path $(srcdir) --xinclude --stringparam generate.toc "none" $(XSLTPROC_CUSTOM) --nonet $(top_srcdir)/doc/custom-html.xsl $< | $(BROWSER) > $(srcdir)/$@
 
 %.1: %.1.xml
 	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude $(XSLTPROC_CUSTOM) --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.3: %.3.xml
 	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude $(XSLTPROC_CUSTOM) --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.5: %.5.xml
 	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude $(XSLTPROC_CUSTOM) --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.8: %.8.xml
 	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude $(XSLTPROC_CUSTOM) --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 #CLEANFILES += $(man_MANS) README

--- a/configure.ac
+++ b/configure.ac
@@ -504,6 +504,23 @@ if test ! -z "$LIBSELINUX" ; then
     LIBS=$BACKUP_LIBS
 fi
 
+AC_ARG_ENABLE([econf],
+  AS_HELP_STRING([--disable-econf], [do not use libeconf]),
+  [WITH_ECONF=$enableval], WITH_ECONF=yes)
+if test "$WITH_ECONF" = "yes" ; then
+  PKG_CHECK_MODULES([ECONF], [libeconf], [],
+  [AC_CHECK_LIB([econf],[econf_readDirs],[ECONF_LIBS="-leconf"],[ECONF_LIBS=""])])
+  if test -n "$ECONF_LIBS" ; then
+    ECONF_CFLAGS="-DUSE_ECONF=1 $ECONF_CFLAGS"
+  fi
+fi
+AC_SUBST([ECONF_CFLAGS])
+AC_SUBST([ECONF_LIBS])
+AC_ARG_ENABLE([vendordir],
+  AS_HELP_STRING([--enable-vendordir=DIR], [Directory for distribution provided configuration files]),,[])
+AC_SUBST([VENDORDIR], [$enable_vendordir])
+AM_CONDITIONAL([HAVE_VENDORDIR], [test "x$enable_vendordir" != x])
+
 dnl Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,6 +8,8 @@ CLEANFILES = *~
 
 dist_html_DATA = index.html
 
+EXTRA_DIST = custom-html.xsl custom-man.xsl
+
 #######################################################
 
 releasedocs: all

--- a/doc/custom-html.xsl
+++ b/doc/custom-html.xsl
@@ -1,0 +1,19 @@
+<?xml version='1.0'?> <!--*-nxml-*-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:ss="http://docbook.sf.net/xmlns/string.subst/1.0"
+  xmlns:exsl="http://exslt.org/common" version="1.0">
+
+  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
+  <xsl:param name="vendordir"/>
+
+  <xsl:template match="filename">
+    <xsl:variable name="replacements">
+      <ss:substitution oldstring="%vendordir%" newstring="{$vendordir}" />
+    </xsl:variable>
+    <xsl:call-template name="apply-string-subst-map">
+      <xsl:with-param name="content" select="."/>
+      <xsl:with-param name="map.contents" select="exsl:node-set($replacements)/*" />
+    </xsl:call-template>
+  </xsl:template>
+</xsl:stylesheet>
+

--- a/doc/custom-man.xsl
+++ b/doc/custom-man.xsl
@@ -1,0 +1,10 @@
+<?xml version='1.0'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ss="http://docbook.sf.net/xmlns/string.subst/1.0" version="1.0">
+  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl"/>
+  <xsl:param name="vendordir"/>
+
+  <xsl:param name="man.string.subst.map.local.pre">
+    <ss:substitution oldstring="%vendordir%" newstring="{$vendordir}" />
+  </xsl:param>
+</xsl:stylesheet>
+

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -59,5 +59,10 @@ pam.d.5: pam.conf.5
 pam_get_item.3: pam_item_types_std.inc.xml pam_item_types_ext.inc.xml
 pam_set_data.3: pam_item_types_std.inc.xml pam_item_types_ext.inc.xml
 pam.conf.5: pam.conf-desc.xml pam.conf-dir.xml pam.conf-syntax.xml
+if HAVE_VENDORDIR
+XSLTPROC_CUSTOM = --stringparam vendordir $(VENDORDIR)
+else
+XSLTPROC_CUSTOM = --stringparam vendordir "<vendordir>"
+endif
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/doc/man/pam.8.xml
+++ b/doc/man/pam.8.xml
@@ -53,11 +53,12 @@
 
     <para>
       Vendor-supplied PAM configuration files might be installed in
-      the system directory <filename>/usr/lib/pam.d/</filename> instead
+      the system directory <filename>/usr/lib/pam.d/</filename> or
+      a configurable vendor specific directory instead
       of the machine configuration directory <filename>/etc/pam.d/</filename>.
       If no machine configuration file is found, the vendor-supplied file
       is used. All files in <filename>/etc/pam.d/</filename> override
-      files with the same name in <filename>/usr/lib/pam.d/</filename>.
+      files with the same name in other directories.
     </para>
 
 <para>From the point of view of the system administrator, for whom this
@@ -154,6 +155,18 @@ closing hook for modules to affect the services available to a user.</para>
             the <emphasis remap='B'>Linux-PAM</emphasis> vendor configuration
             directory. Files in <filename>/etc/pam.d</filename> override
             files with the same name in this directory.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><filename>%vendordir%/pam.d</filename></term>
+        <listitem>
+          <para>
+            the <emphasis remap='B'>Linux-PAM</emphasis> vendor configuration
+	    directory. Files in <filename>/etc/pam.d</filename> and
+	    <filename>/usr/lib/pam.d</filename> override files with the same
+	    name in this directory. Only available if Linux-PAM was compiled
+	    with vendordir enabled.
           </para>
         </listitem>
       </varlistentry>

--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -3,9 +3,13 @@
 #
 
 AM_CFLAGS = -DDEFAULT_MODULE_PATH=\"$(SECUREDIR)/\" -DLIBPAM_COMPILE \
-	-I$(srcdir)/include $(LIBPRELUDE_CFLAGS) -DPAM_VERSION=\"$(VERSION)\"
+	-I$(srcdir)/include $(LIBPRELUDE_CFLAGS) $(ECONF_CFLAGS) \
+	-DPAM_VERSION=\"$(VERSION)\" -DSYSCONFDIR=\"$(sysconfdir)\"
 if HAVE_LIBSELINUX
   AM_CFLAGS += -D"WITH_SELINUX"
+endif
+if HAVE_VENDORDIR
+  AM_CFLAGS += -DVENDORDIR=\"$(VENDORDIR)\"
 endif
 
 CLEANFILES = *~
@@ -21,7 +25,7 @@ noinst_HEADERS = pam_prelude.h pam_private.h pam_tokens.h \
 		pam_modutil_private.h
 
 libpam_la_LDFLAGS = -no-undefined -version-info 84:2:84
-libpam_la_LIBADD = @LIBAUDIT@ $(LIBPRELUDE_LIBS) @LIBDL@
+libpam_la_LIBADD = @LIBAUDIT@ $(LIBPRELUDE_LIBS) $(ECONF_LIBS) @LIBDL@
 
 if HAVE_VERSIONING
   libpam_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libpam.map

--- a/libpam/pam_modutil_searchkey.c
+++ b/libpam/pam_modutil_searchkey.c
@@ -13,8 +13,40 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#ifdef USE_ECONF
+#include <libeconf.h>
+#endif
 
 #define BUF_SIZE 8192
+
+#ifdef USE_ECONF
+#define LOGIN_DEFS "/etc/login.defs"
+
+#ifndef VENDORDIR
+#define VENDORDIR NULL
+#endif
+
+static char *
+econf_search_key (const char *name, const char *suffix, const char *key)
+{
+	econf_file *key_file = NULL;
+	char *val;
+
+	if (econf_readDirs (&key_file, VENDORDIR, SYSCONFDIR, name, suffix,
+			    " \t", "#"))
+		return NULL;
+
+	if (econf_getStringValue (key_file, NULL, key, &val)) {
+		econf_free (key_file);
+		return NULL;
+	}
+
+	econf_free (key_file);
+
+	return val;
+}
+
+#endif
 
 /* lookup a value for key in login.defs file or similar key value format */
 char *
@@ -26,6 +58,11 @@ pam_modutil_search_key(pam_handle_t *pamh UNUSED,
 	char *buf = NULL;
 	size_t buflen = 0;
 	char *retval = NULL;
+
+#ifdef USE_ECONF
+	if (strcmp (file_name, LOGIN_DEFS) == 0)
+		return econf_search_key ("login", ".defs", key);
+#endif
 
 	fp = fopen(file_name, "r");
 	if (NULL == fp)

--- a/libpam/pam_private.h
+++ b/libpam/pam_private.h
@@ -29,6 +29,11 @@
 #define PAM_CONFIG_DF      "/etc/pam.d/%s"
 #define PAM_CONFIG_DIST_D  "/usr/lib/pam.d"
 #define PAM_CONFIG_DIST_DF "/usr/lib/pam.d/%s"
+#ifdef VENDORDIR
+#define PAM_CONFIG_DIST2_D  VENDORDIR"/pam.d"
+#define PAM_CONFIG_DIST2_DF VENDORDIR"/pam.d/%s"
+#endif
+
 
 #define PAM_DEFAULT_SERVICE        "other"     /* lower case */
 

--- a/modules/pam_securetty/Makefile.am
+++ b/modules/pam_securetty/Makefile.am
@@ -20,6 +20,9 @@ AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
+if HAVE_VENDORDIR
+  AM_CFLAGS += -DVENDORDIR=\"$(VENDORDIR)\"
+endif
 
 securelib_LTLIBRARIES = pam_securetty.la
 pam_securetty_la_LIBADD = $(top_builddir)/libpam/libpam.la
@@ -27,5 +30,10 @@ pam_securetty_la_LIBADD = $(top_builddir)/libpam/libpam.la
 if ENABLE_REGENERATE_MAN
 noinst_DATA = README
 README: pam_securetty.8.xml
+if HAVE_VENDORDIR
+XSLTPROC_CUSTOM = --stringparam vendordir $(VENDORDIR)
+else
+XSLTPROC_CUSTOM = --stringparam vendordir "<vendordir>"
+endif
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_securetty/pam_securetty.8.xml
+++ b/modules/pam_securetty/pam_securetty.8.xml
@@ -31,9 +31,12 @@
     <para>
       pam_securetty is a PAM module that allows root logins only if the
       user is logging in on a "secure" tty, as defined by the listing
-      in <filename>/etc/securetty</filename>. pam_securetty also checks
-      to make sure that <filename>/etc/securetty</filename> is a plain
-      file and not world writable. It will also allow root logins on
+      in the <filename>securetty</filename> file. pam_securetty checks at
+      first, if <filename>/etc/securetty</filename> exists. If not and
+      it was built with vendordir support, it will use
+      <filename>%vendordir%/securetty</filename>. pam_securetty also
+      checks that the <filename>securetty</filename> files are plain
+      files and not world writable. It will also allow root logins on
       the tty specified with <option>console=</option> switch on the
       kernel command line and on ttys from the
       <filename>/sys/class/tty/console/active</filename>.
@@ -73,7 +76,7 @@
             Do not automatically allow root logins on the kernel console
             device, as specified on the kernel command line or by the sys file,
             if it is not also specified in the
-            <filename>/etc/securetty</filename> file.
+            <filename>securetty</filename> file.
           </para>
         </listitem>
       </varlistentry>
@@ -106,7 +109,7 @@
           <para>
             Authentication is rejected. Either root is attempting to
             log in via an unacceptable device, or the
-            <filename>/etc/securetty</filename> file is world writable or
+            <filename>securetty</filename> file is world writable or
             not a normal file.
           </para>
         </listitem>
@@ -127,7 +130,7 @@
           <para>
             An error occurred while the module was determining the
             user's name or tty, or the module could not open
-            <filename>/etc/securetty</filename>.
+            the <filename>securetty</filename> file.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
With this, it is possible for Linux distributors to store their
supplied default configuration files somewhere below /usr, while
/etc only contains the changes made by the user. The new option
--enable-vendordir defines where Linux-PAM should additional look
for pam.d/*, login.defs and securetty if this files are not in /etc.
libeconf is a key/value configuration file reading library, which
handles the split of configuration files in different locations
and merges them transparently for the application.