### PR TITLE
Fixed missing quotes in configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ dnl Largefile support
 AC_SYS_LARGEFILE
 
 dnl icc claims to be GCC compatible, but use other flags for warnings
-if eval "test x$GCC = xyes -a $CC != icc"; then
+if eval 'test "x$GCC" = "xyes" -a "$CC" != "icc"'; then
   for flag in \
       -W \
       -Wall \
@@ -100,7 +100,7 @@ if eval "test x$GCC = xyes -a $CC != icc"; then
   done
 fi
 dnl icc has special warning flags
-if eval "test x$CC = xicc"; then
+if eval 'test "x$CC" = "xicc"'; then
   for flag in \
       -Wall \
       -Wmissing-prototypes \


### PR DESCRIPTION
If a compiler definition contains the spaces (e.g. CC="ccache gcc"), configure script produces a message:

./configure: line 13713: test: too many arguments
./configure: line 13740: test: too many arguments