### PR TITLE
pam_mkhomedir: Add debug option to pam_mkhomedir(8) man page

### DIFF
--- a/modules/pam_mkhomedir/pam_mkhomedir.8.xml
+++ b/modules/pam_mkhomedir/pam_mkhomedir.8.xml
@@ -26,6 +26,9 @@
         silent
       </arg>
       <arg choice="opt">
+        debug
+      </arg>
+      <arg choice="opt">
         umask=<replaceable>mode</replaceable>
       </arg>
       <arg choice="opt">
@@ -63,6 +66,20 @@
         <listitem>
           <para>
             Don't print informative messages.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>debug</option>
+        </term>
+        <listitem>
+          <para>
+           Turns on debugging via
+            <citerefentry>
+              <refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum>
+            </citerefentry>.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
pam_mkhomedir has 'debug' option, but it is not listed in the man page.
Add 'debug' option to the man page so that the user can specify 'debug' option.