### PR TITLE
doc: fix module type written in MODULE TYPES PROVIDED

### DIFF
--- a/modules/pam_nologin/pam_nologin.8.xml
+++ b/modules/pam_nologin/pam_nologin.8.xml
@@ -72,7 +72,7 @@
   <refsect1 id="pam_nologin-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
-      The <option>auth</option> and <option>acct</option> module
+      The <option>auth</option> and <option>account</option> module
       types are provided.
     </para>
   </refsect1>

--- a/modules/pam_rootok/pam_rootok.8.xml
+++ b/modules/pam_rootok/pam_rootok.8.xml
@@ -57,7 +57,7 @@
   <refsect1 id="pam_rootok-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
-      The <option>auth</option>, <option>acct</option> and
+      The <option>auth</option>, <option>account</option> and
       <option>password</option> module types are provided.
     </para>
   </refsect1>


### PR DESCRIPTION
Fixed the provided module type in pam_nologin and pam_rootok (acct -> account).