### PR TITLE
Adds an auth module to pam_keyinit

### DIFF
--- a/modules/pam_keyinit/pam_keyinit.8.xml
+++ b/modules/pam_keyinit/pam_keyinit.8.xml
@@ -37,18 +37,32 @@
       session keyring other than the user default session keyring.
     </para>
     <para>
-      The session component of the module checks to see if the process's
-      session keyring is the user default, and, if it is, creates a new
-      anonymous session keyring with which to replace it.
+      The module checks to see if the process's session keyring is the
+      <citerefentry>
+	<refentrytitle>user-session-keyring</refentrytitle><manvolnum>7</manvolnum>
+      </citerefentry>,
+      and, if it is, creates a new
+      <citerefentry>
+	<refentrytitle>session-keyring</refentrytitle><manvolnum>7</manvolnum>
+      </citerefentry>
+      with which to replace it. If a new session keyring is created, it will
+      install a link to the
+      <citerefentry>
+	<refentrytitle>user-keyring</refentrytitle><manvolnum>7</manvolnum>
+      </citerefentry>
+      in the session keyring so that keys common to the user will be
+      automatically accessible through it. The session keyring of the invoking
+      process will thenceforth be inherited by all its children unless they override it.
     </para>
     <para>
-      If a new session keyring is created, it will install a link to the user
-      common keyring in the session keyring so that keys common to the user
-      will be automatically accessible through it.
-    </para>
-    <para>
-      The session keyring of the invoking process will thenceforth be inherited
-      by all its children unless they override it.
+      In order to allow other PAM modules to attach tokens to the keyring, this module
+      provides both an <emphasis>auth</emphasis> (limited to
+      <citerefentry>
+	<refentrytitle>pam_setcred</refentrytitle><manvolnum>3</manvolnum>
+      </citerefentry>
+      and a <emphasis>session</emphasis> component. The session keyring is created
+      in the module called. Moreover this module should be included as early as
+      possible in a PAM configuration.
     </para>
     <para>
       This module is intended primarily for use by login processes.  Be aware
@@ -60,11 +74,6 @@
       <emphasis remap='B'>su</emphasis>, since it is usually desirable for the
       key set to percolate through to the alternate context.  The keys have
       their own permissions system to manage this.
-    </para>
-    <para>
-      This module should be included as early as possible in a PAM
-      configuration, so that other PAM modules can attach tokens to the
-      keyring.
     </para>
     <para>
       The keyutils package is used to manipulate keys more directly.  This


### PR DESCRIPTION
Adds an auth module to pam_keyinit, whose implementation of

pam_sm_setcred

is identical to the implementation of pam_sm_open_session.

It is useful with PAM applications, which call pam_setcred,
before calling pam_open_session. It closes #149.