### PR TITLE
Lower "bad username" log priority

### DIFF
--- a/modules/pam_umask/pam_umask.c
+++ b/modules/pam_umask/pam_umask.c
@@ -199,7 +199,7 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
     {
       if (name)
         {
-          pam_syslog (pamh, LOG_ERR, "bad username [%s]", name);
+          pam_syslog (pamh, LOG_NOTICE, "bad username [%s]", name);
           return PAM_USER_UNKNOWN;
         }
       return PAM_SERVICE_ERR;

--- a/modules/pam_unix/pam_unix_auth.c
+++ b/modules/pam_unix/pam_unix_auth.c
@@ -125,7 +125,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
 		 * allow this characters here.
 		 */
 		if (name == NULL || name[0] == '-' || name[0] == '+') {
-			pam_syslog(pamh, LOG_ERR, "bad username [%s]", name);
+			pam_syslog(pamh, LOG_NOTICE, "bad username [%s]", name);
 			retval = PAM_USER_UNKNOWN;
 			AUTH_RETURN;
 		}

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -632,7 +632,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
 		 * allow them.
 		 */
 		if (user == NULL || user[0] == '-' || user[0] == '+') {
-			pam_syslog(pamh, LOG_ERR, "bad username [%s]", user);
+			pam_syslog(pamh, LOG_NOTICE, "bad username [%s]", user);
 			return PAM_USER_UNKNOWN;
 		}
 		if (retval == PAM_SUCCESS && on(UNIX_DEBUG, ctrl))


### PR DESCRIPTION
This is more in conformance with how other message priorities are chosen.