### PR TITLE
pam_motd: Export MOTD_SHOWN=pam after showing MOTD

### DIFF
--- a/modules/pam_motd/pam_motd.8.xml
+++ b/modules/pam_motd/pam_motd.8.xml
@@ -77,6 +77,11 @@
     <para>
       <command>ln -s /dev/null /etc/motd.d/my_motd</command>
     </para>
+    <para>
+      The <emphasis remap='B'>MOTD_SHOWN=pam</emphasis> environment variable
+      is set after showing the motd files, even when all of them were silenced
+      using symbolic links.
+    </para>
   </refsect1>
 
   <refsect1 id="pam_motd-options">

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -396,6 +396,8 @@ int pam_sm_open_session(pam_handle_t *pamh, int flags,
     _pam_drop(motd_dir_path_copy);
     _pam_drop(motd_dir_path_split);
 
+    retval = pam_putenv(pamh, "MOTD_SHOWN=pam");
+
     return retval;
 }
 


### PR DESCRIPTION
This is a useful indication for update-motd profile.d snippet which can
also try to show MOTD when it is not already shown.

The use-case for that is showing MOTD in shells in containers without
PAM being involved.