### PR TITLE
Keep returning only PAM_IGNORE from pam_motd

### DIFF
--- a/modules/pam_motd/pam_motd.8.xml
+++ b/modules/pam_motd/pam_motd.8.xml
@@ -133,10 +133,26 @@
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
+        <term>PAM_ABORT</term>
+        <listitem>
+           <para>
+             Not all relevant data or options could be obtained.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_BUF_ERR</term>
+        <listitem>
+           <para>
+              Memory buffer error.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term>PAM_IGNORE</term>
         <listitem>
           <para>
-            This is the only return value of this module.
+            This is the default return value of this module.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -398,7 +398,7 @@ int pam_sm_open_session(pam_handle_t *pamh, int flags,
 
     retval = pam_putenv(pamh, "MOTD_SHOWN=pam");
 
-    return retval;
+    return retval == PAM_SUCCESS ? PAM_IGNORE : retval;
 }
 
 /* end of module definition */


### PR DESCRIPTION
Follow-up for c81280b16e1831ab0bdd0383486c7e2d1eaf1b5e.