### PR TITLE
pam_securetty: silently ignore missing securetty file

### DIFF
--- a/modules/pam_securetty/pam_securetty.c
+++ b/modules/pam_securetty/pam_securetty.c
@@ -119,19 +119,14 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
 #ifdef VENDORDIR
       if (errno == ENOENT) {
 	if (stat(SECURETTY2_FILE, &ttyfileinfo)) {
-	  pam_syslog(pamh, LOG_NOTICE,
-		     "Couldn't open %s: %m", SECURETTY2_FILE);
 	  return PAM_SUCCESS; /* for compatibility with old securetty handling,
-				 this needs to succeed.  But we still log the
-				 error. */
+				 this needs to succeed. */
 	}
 	securettyfile = SECURETTY2_FILE;
       } else {
 #endif
-	pam_syslog(pamh, LOG_NOTICE, "Couldn't open %s: %m", SECURETTY_FILE);
 	return PAM_SUCCESS; /* for compatibility with old securetty handling,
-			       this needs to succeed.  But we still log the
-			       error. */
+			       this needs to succeed.  */
 #ifdef VENDORDIR
       }
 #endif


### PR DESCRIPTION
Fedora stopped shipping /etc/securetty years ago and it is also not shipped in
Debian and Debian derivatives either because nowadays it is not found to be
useful.
Since the default state is not having /etc/securetty on the system PAM noticing
its absence also should not show up in syslog either.