### PR TITLE
Fix (IPv6) address prefix size matching

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -737,7 +737,9 @@ network_netmask_match (pam_handle_t *pamh,
 		{ /* invalid netmask value */
 		  return NO;
 		}
-	    if ((netmask < 0) || (netmask >= 128))
+	    if ( (netmask < 0) ||
+		 (addr_type==AF_INET && netmask > 32) ||
+		 (addr_type==AF_INET6 && netmask > 128) )
 		{ /* netmask value out of range */
 		  return NO;
 		}

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -737,9 +737,9 @@ network_netmask_match (pam_handle_t *pamh,
 		{ /* invalid netmask value */
 		  return NO;
 		}
-	    if ( (netmask < 0) ||
-		 (addr_type==AF_INET && netmask > 32) ||
-		 (addr_type==AF_INET6 && netmask > 128) )
+	    if ((netmask < 0)
+		|| (addr_type == AF_INET && netmask > 32)
+		|| (addr_type == AF_INET6 && netmask > 128))
 		{ /* netmask value out of range */
 		  return NO;
 		}


### PR DESCRIPTION
IPv6 address prefix sizes larger than 128 (i.e. not larger or equal to) should
be discarded. Additionally, for IPv4 addresses, the largest valid prefix size
should be 32.
This fixes #161 