### PR TITLE
pam_umask: build-time usergroups option default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -487,6 +487,17 @@ AS_IF([test "x$enable_nis" != "xno"], [
 AC_SUBST([NIS_CFLAGS])
 AC_SUBST([NIS_LIBS])
 
+AC_ARG_ENABLE([usergroups],
+  AS_HELP_STRING([--enable-usergroups], [sets the usergroups option default to enabled]),
+  [WITH_USERGROUPS=$enableval], WITH_USERGROUPS=no)
+if test "$WITH_USERGROUPS" = "yes" ; then
+   AC_DEFINE([DEFAULT_USERGROUPS_SETTING], 1,
+	     [Defines the value usergroups option should have by default])
+else
+   AC_DEFINE([DEFAULT_USERGROUPS_SETTING], 0,
+	     [Defines the value usergroups option should have by default])
+fi
+
 AC_ARG_ENABLE([selinux],
         AS_HELP_STRING([--disable-selinux],[do not use SELinux]),
         WITH_SELINUX=$enableval, WITH_SELINUX=yes)

--- a/modules/pam_umask/pam_umask.8.xml
+++ b/modules/pam_umask/pam_umask.8.xml
@@ -28,6 +28,9 @@
         usergroups
       </arg>
       <arg choice="opt">
+        nousergroups
+      </arg>
+      <arg choice="opt">
         umask=<replaceable>mask</replaceable>
       </arg>
     </cmdsynopsis>
@@ -115,6 +118,19 @@
               If the user is not root and the username is the same as
               primary group name, the umask group bits are set to be the
               same as owner bits (examples: 022 -> 002, 077 -> 007).
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>
+            <option>nousergroups</option>
+          </term>
+          <listitem>
+            <para>
+              This is the direct opposite of the usergroups option described above,
+              which can be useful in case pam_umask has been compiled with
+              usergroups enabled by default and you want to disable it at runtime.
             </para>
           </listitem>
         </varlistentry>

--- a/modules/pam_umask/pam_umask.c
+++ b/modules/pam_umask/pam_umask.c
@@ -90,6 +90,9 @@ get_options (pam_handle_t *pamh, options_t *options,
 	     int argc, const char **argv)
 {
   memset (options, 0, sizeof (options_t));
+
+  options->usergroups = DEFAULT_USERGROUPS_SETTING;
+
   /* Parse parameters for module */
   for ( ; argc-- > 0; argv++)
     parse_option (pamh, *argv, options);

--- a/modules/pam_umask/pam_umask.c
+++ b/modules/pam_umask/pam_umask.c
@@ -79,6 +79,8 @@ parse_option (const pam_handle_t *pamh, const char *argv, options_t *options)
     options->umask = strdup (&argv[6]);
   else if (strcasecmp (argv, "usergroups") == 0)
     options->usergroups = 1;
+  else if (strcasecmp (argv, "nousergroups") == 0)
+    options->usergroups = 0;
   else if (strcasecmp (argv, "silent") == 0)
     options->silent = 1;
   else


### PR DESCRIPTION
This change adds a configure option to set the default value of the
usergroups option (of the pam_umask module) at build-time.

Distributions usually makes the decision if usergroups should be used or
not. This allows them to control the built-in default value, without
having to ship the value in a config file (cluttering up the view
of actually relevant user/system configuration overrides).