### PR TITLE
configure.ac: add --enable-doc option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,11 @@
 
 AUTOMAKE_OPTIONS = 1.9 gnu dist-bzip2 dist-xz check-news
 
-SUBDIRS = libpam tests libpamc libpam_misc modules po conf doc examples xtests
+SUBDIRS = libpam tests libpamc libpam_misc modules po conf examples xtests
+
+if HAVE_DOC
+SUBDIRS += doc
+endif
 
 CLEANFILES = *~
 

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,11 @@ dnl
 dnl options and defaults
 dnl
 
+AC_ARG_ENABLE([doc],
+        AS_HELP_STRING([--disable-doc],[Do not generate or install documentation]),
+        WITH_DOC=$enableval, WITH_DOC=yes)
+AM_CONDITIONAL([HAVE_DOC], [test "x$WITH_DOC" = "xyes"])
+
 AC_ARG_ENABLE([prelude],
 	AS_HELP_STRING([--disable-prelude],[do not use prelude]),
 	WITH_PRELUDE=$enableval, WITH_PRELUDE=yes)
@@ -606,7 +611,7 @@ fi
 
 AC_PATH_PROG([FO2PDF], [fop])
 
-AM_CONDITIONAL(ENABLE_REGENERATE_MAN, test x$enable_docu != xno)
+AM_CONDITIONAL(ENABLE_REGENERATE_MAN, test x$enable_docu != xno -a x$enable_doc != xno)
 AM_CONDITIONAL(ENABLE_GENERATE_PDF, test ! -z "$FO2PDF")
 
 

--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README access.conf $(MANS) $(XMLS) tst-pam_access
 
+if HAVE_DOC
 man_MANS = access.conf.5 pam_access.8
+endif
 
 XMLS = README.xml access.conf.5.xml pam_access.8.xml
 

--- a/modules/pam_cracklib/Makefile.am
+++ b/modules/pam_cracklib/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(XMLS) pam_cracklib.8 tst-pam_cracklib
 
 if HAVE_LIBCRACK
   TESTS = tst-pam_cracklib
+if HAVE_DOC
   man_MANS = pam_cracklib.8
+endif
 endif
 
 XMLS = README.xml pam_cracklib.8.xml

--- a/modules/pam_debug/Makefile.am
+++ b/modules/pam_debug/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_debug
 
+if HAVE_DOC
 man_MANS = pam_debug.8
+endif
 XMLS = README.xml pam_debug.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_deny/Makefile.am
+++ b/modules/pam_deny/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_deny
 
+if HAVE_DOC
 man_MANS = pam_deny.8
+endif
 
 XMLS = README.xml pam_deny.8.xml
 

--- a/modules/pam_echo/Makefile.am
+++ b/modules/pam_echo/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_echo
 
+if HAVE_DOC
 man_MANS = pam_echo.8
+endif
 
 XMLS = README.xml pam_echo.8.xml
 

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README pam_env.conf $(MANS) $(XMLS) tst-pam_env environment
 
+if HAVE_DOC
 man_MANS = pam_env.conf.5 pam_env.8 environment.5
+endif
 
 XMLS = README.xml pam_env.conf.5.xml pam_env.8.xml
 

--- a/modules/pam_exec/Makefile.am
+++ b/modules/pam_exec/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_exec
 
+if HAVE_DOC
 man_MANS = pam_exec.8
+endif
 
 XMLS = README.xml pam_exec.8.xml
 

--- a/modules/pam_faildelay/Makefile.am
+++ b/modules/pam_faildelay/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_faildelay
 
+if HAVE_DOC
 man_MANS = pam_faildelay.8
+endif
 XMLS = README.xml pam_faildelay.8.xml
 
 TESTS = tst-pam_faildelay

--- a/modules/pam_filter/Makefile.am
+++ b/modules/pam_filter/Makefile.am
@@ -9,7 +9,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_filter
 
+if HAVE_DOC
 man_MANS = pam_filter.8
+endif
 XMLS = README.xml pam_filter.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_ftp/Makefile.am
+++ b/modules/pam_ftp/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_ftp
 
+if HAVE_DOC
 man_MANS = pam_ftp.8
+endif
 XMLS = README.xml pam_ftp.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README group.conf $(MANS) $(XMLS) tst-pam_group
 
+if HAVE_DOC
 man_MANS = group.conf.5 pam_group.8
+endif
 XMLS = README.xml group.conf.5.xml pam_group.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_issue/Makefile.am
+++ b/modules/pam_issue/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_issue
 
+if HAVE_DOC
 man_MANS = pam_issue.8
+endif
 XMLS = README.xml pam_issue.8.xml
 
 TESTS = tst-pam_issue

--- a/modules/pam_keyinit/Makefile.am
+++ b/modules/pam_keyinit/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(XMLS) pam_keyinit.8 tst-pam_keyinit
 XMLS = README.xml pam_keyinit.8.xml
 
 if HAVE_KEY_MANAGEMENT
+if HAVE_DOC
   man_MANS =  pam_keyinit.8
+endif
   TESTS = tst-pam_keyinit
 endif
 

--- a/modules/pam_lastlog/Makefile.am
+++ b/modules/pam_lastlog/Makefile.am
@@ -10,7 +10,9 @@ secureconfdir = $(SCONFIGDIR)
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_lastlog
 
+if HAVE_DOC
 man_MANS = pam_lastlog.8
+endif
 XMLS = README.xml pam_lastlog.8.xml
 
 TESTS = tst-pam_lastlog

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) limits.conf tst-pam_limits
 
+if HAVE_DOC
 man_MANS = limits.conf.5 pam_limits.8
+endif
 XMLS = README.xml limits.conf.5.xml pam_limits.8.xml
 
 TESTS = tst-pam_limits

--- a/modules/pam_listfile/Makefile.am
+++ b/modules/pam_listfile/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_listfile
 
+if HAVE_DOC
 man_MANS = pam_listfile.8
+endif
 XMLS = README.xml pam_listfile.8.xml
 
 TESTS = tst-pam_listfile

--- a/modules/pam_localuser/Makefile.am
+++ b/modules/pam_localuser/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_localuser
 
 TESTS = tst-pam_localuser
 
+if HAVE_DOC
 man_MANS = pam_localuser.8
+endif
 XMLS = README.xml pam_localuser.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_loginuid/Makefile.am
+++ b/modules/pam_loginuid/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_loginuid
 
+if HAVE_DOC
 man_MANS = pam_loginuid.8
+endif
 
 XMLS = README.xml pam_loginuid.8.xml
 

--- a/modules/pam_mail/Makefile.am
+++ b/modules/pam_mail/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_mail
 
+if HAVE_DOC
 man_MANS = pam_mail.8
+endif
 XMLS = README.xml pam_mail.8.xml
 
 TESTS = tst-pam_mail

--- a/modules/pam_mkhomedir/Makefile.am
+++ b/modules/pam_mkhomedir/Makefile.am
@@ -8,7 +8,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_mkhomedir
 
+if HAVE_DOC
 man_MANS = pam_mkhomedir.8 mkhomedir_helper.8
+endif
 
 XMLS = README.xml pam_mkhomedir.8.xml mkhomedir_helper.8.xml
 

--- a/modules/pam_motd/Makefile.am
+++ b/modules/pam_motd/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_motd
 
+if HAVE_DOC
 man_MANS = pam_motd.8
+endif
 XMLS = README.xml pam_motd.8.xml
 
 TESTS = tst-pam_motd

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -6,8 +6,10 @@
 CLEANFILES = *~
 MAINTAINERCLEANFILES = $(MAN5) $(MAN8) README
 
+if HAVE_DOC
 MAN5 = namespace.conf.5
 MAN8 = pam_namespace.8
+endif
 
 EXTRA_DIST = README namespace.conf namespace.init $(MAN5) $(MAN8) $(XMLS) tst-pam_namespace
 

--- a/modules/pam_nologin/Makefile.am
+++ b/modules/pam_nologin/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_nologin
 
 TESTS = tst-pam_nologin
 
+if HAVE_DOC
 man_MANS = pam_nologin.8
+endif
 XMLS = README.xml pam_nologin.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_permit/Makefile.am
+++ b/modules/pam_permit/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_permit
 
+if HAVE_DOC
 man_MANS = pam_permit.8
+endif
 XMLS = README.xml pam_permit.8.xml
 
 TESTS = tst-pam_permit

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_pwhistory
 
 TESTS = tst-pam_pwhistory
 
+if HAVE_DOC
 man_MANS = pam_pwhistory.8
+endif
 
 XMLS = README.xml pam_pwhistory.8.xml
 

--- a/modules/pam_rhosts/Makefile.am
+++ b/modules/pam_rhosts/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_rhosts
 
 TESTS = tst-pam_rhosts
 
+if HAVE_DOC
 man_MANS = pam_rhosts.8
+endif
 
 XMLS = README.xml pam_rhosts.8.xml
 

--- a/modules/pam_rootok/Makefile.am
+++ b/modules/pam_rootok/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_rootok
 
+if HAVE_DOC
 man_MANS = pam_rootok.8
+endif
 XMLS = README.xml pam_rootok.8.xml
 
 TESTS = tst-pam_rootok

--- a/modules/pam_securetty/Makefile.am
+++ b/modules/pam_securetty/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_securetty
 
 TESTS = tst-pam_securetty
 
+if HAVE_DOC
 man_MANS = pam_securetty.8
+endif
 XMLS = README.xml pam_securetty.8.xml
 
 securelibdir = $(SECUREDIR)

--- a/modules/pam_selinux/Makefile.am
+++ b/modules/pam_selinux/Makefile.am
@@ -10,7 +10,9 @@ EXTRA_DIST = README $(XMLS) pam_selinux.8 pam_selinux_check.8 \
 
 if HAVE_LIBSELINUX
   TESTS = tst-pam_selinux
+if HAVE_DOC
   man_MANS = pam_selinux.8
+endif
 endif
 
 XMLS = README.xml pam_selinux.8.xml

--- a/modules/pam_sepermit/Makefile.am
+++ b/modules/pam_sepermit/Makefile.am
@@ -10,7 +10,9 @@ EXTRA_DIST = README $(XMLS) pam_sepermit.8 sepermit.conf sepermit.conf.5 tst-pam
 
 if HAVE_LIBSELINUX
   TESTS = tst-pam_sepermit
+if HAVE_DOC
   man_MANS = pam_sepermit.8 sepermit.conf.5
+endif
 endif
 
 XMLS = README.xml pam_sepermit.8.xml sepermit.conf.5.xml

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_shells
 
+if HAVE_DOC
 man_MANS = pam_shells.8
+endif
 XMLS = README.xml pam_shells.8.xml
 
 TESTS = tst-pam_shells

--- a/modules/pam_succeed_if/Makefile.am
+++ b/modules/pam_succeed_if/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README ${MANS} ${XMLS} tst-pam_succeed_if
 
 TESTS = tst-pam_succeed_if
 
+if HAVE_DOC
 man_MANS = pam_succeed_if.8
+endif
 
 XMLS = README.xml pam_succeed_if.8.xml
 

--- a/modules/pam_tally/Makefile.am
+++ b/modules/pam_tally/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_tally
 
+if HAVE_DOC
 man_MANS = pam_tally.8
+endif
 XMLS = README.xml pam_tally.8.xml
 
 TESTS = tst-pam_tally

--- a/modules/pam_tally2/Makefile.am
+++ b/modules/pam_tally2/Makefile.am
@@ -8,7 +8,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_tally2
 
+if HAVE_DOC
 man_MANS = pam_tally2.8
+endif
 XMLS = README.xml pam_tally2.8.xml
 
 TESTS = tst-pam_tally2

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) time.conf tst-pam_time
 
+if HAVE_DOC
 man_MANS = time.conf.5 pam_time.8
+endif
 XMLS = README.xml time.conf.5.xml pam_time.8.xml
 
 TESTS = tst-pam_time

--- a/modules/pam_timestamp/Makefile.am
+++ b/modules/pam_timestamp/Makefile.am
@@ -7,7 +7,9 @@ CLEANFILES = *~
 MAINTAINERCLEANFILES = $(MANS) README
 
 XMLS = README.xml pam_timestamp.8.xml pam_timestamp_check.8.xml
+if HAVE_DOC
 man_MANS = pam_timestamp.8 pam_timestamp_check.8
+endif
 dist_TESTS = tst-pam_timestamp
 nodist_TESTS = hmacfile
 TESTS = $(dist_TESTS) $(nodist_TESTS)

--- a/modules/pam_tty_audit/Makefile.am
+++ b/modules/pam_tty_audit/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST = README pam_tty_audit.8 $(XMLS) tst-pam_tty_audit
 
 if HAVE_AUDIT_TTY_STATUS
   TESTS = tst-pam_tty_audit
+if HAVE_DOC
   man_MANS = pam_tty_audit.8
+endif
 endif
 XMLS = README.xml pam_tty_audit.8.xml
 

--- a/modules/pam_umask/Makefile.am
+++ b/modules/pam_umask/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_umask
 
+if HAVE_DOC
 man_MANS = pam_umask.8
+endif
 
 XMLS = README.xml pam_umask.8.xml
 

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -8,7 +8,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 EXTRA_DIST = README md5.c md5_crypt.c lckpwdf.-c $(MANS) CHANGELOG \
 		tst-pam_unix $(XMLS)
 
+if HAVE_DOC
 man_MANS = pam_unix.8 unix_chkpwd.8 unix_update.8
+endif
 XMLS = README.xml pam_unix.8.xml unix_chkpwd.8.xml unix_update.8.xml
 
 TESTS = tst-pam_unix

--- a/modules/pam_userdb/Makefile.am
+++ b/modules/pam_userdb/Makefile.am
@@ -8,7 +8,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 EXTRA_DIST = README $(XMLS) pam_userdb.8 create.pl tst-pam_userdb
 
 if HAVE_LIBDB
+if HAVE_DOC
   man_MANS = pam_userdb.8
+endif
   TESTS = tst-pam_userdb
 endif
 

--- a/modules/pam_warn/Makefile.am
+++ b/modules/pam_warn/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README $(MANS) $(XMLS) tst-pam_warn
 
+if HAVE_DOC
 man_MANS = pam_warn.8
+endif
 XMLS = README.xml pam_warn.8.xml
 
 TESTS = tst-pam_warn

--- a/modules/pam_wheel/Makefile.am
+++ b/modules/pam_wheel/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README ${MANS} $(XMLS) tst-pam_wheel
 
+if HAVE_DOC
 man_MANS = pam_wheel.8
+endif
 XMLS = README.xml pam_wheel.8.xml
 
 TESTS = tst-pam_wheel

--- a/modules/pam_xauth/Makefile.am
+++ b/modules/pam_xauth/Makefile.am
@@ -7,7 +7,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = README ${MANS} $(XMLS) tst-pam_xauth
 
+if HAVE_DOC
 man_MANS = pam_xauth.8
+endif
 XMLS = README.xml pam_xauth.8.xml
 
 TESTS = tst-pam_xauth


### PR DESCRIPTION
Allow the user to disable documentation through --disable-doc (enabled
by default), this is especially useful when cross-compiling for embedded
targets

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>