### PR TITLE
Updating man pages to indicate account leakage without silent

### DIFF
--- a/modules/pam_tally/pam_tally.8.xml
+++ b/modules/pam_tally/pam_tally.8.xml
@@ -168,7 +168,7 @@
               </term>
               <listitem>
                 <para>
-                  Don't print informative messages. Without <emphasis>silent</emphasis> leaks presence of accounts on the system.
+                    Don't print informative messages. The messages printed without the <emphasis>silent</emphasis> option leak presence of accounts on the system because they are not printed for non-existing accounts.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally/pam_tally.8.xml
+++ b/modules/pam_tally/pam_tally.8.xml
@@ -168,7 +168,7 @@
               </term>
               <listitem>
                 <para>
-                    Don't print informative messages. The messages printed without the <emphasis>silent</emphasis> option leak presence of accounts on the system because they are not printed for non-existing accounts.
+                  Don't print informative messages. The messages printed without the <emphasis>silent</emphasis> option leak presence of accounts on the system because they are not printed for non-existing accounts.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally/pam_tally.8.xml
+++ b/modules/pam_tally/pam_tally.8.xml
@@ -168,7 +168,7 @@
               </term>
               <listitem>
                 <para>
-                  Don't print informative messages.
+                  Don't print informative messages. Without <emphasis>silent</emphasis> leaks presence of accounts on the system.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally2/pam_tally2.8.xml
+++ b/modules/pam_tally2/pam_tally2.8.xml
@@ -158,7 +158,7 @@
               </term>
               <listitem>
                 <para>
-                  Don't print informative messages. Without <emphasis>silent</emphasis> leaks presence of accounts on the system.
+                  Don't print informative messages. Lock messages can be printed without the <emphasis>silent</emphasis> option. Similar messages are not printed for non-existing accounts.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally2/pam_tally2.8.xml
+++ b/modules/pam_tally2/pam_tally2.8.xml
@@ -158,7 +158,7 @@
               </term>
               <listitem>
                 <para>
-                  Don't print informative messages. Lock messages can be printed without the <emphasis>silent</emphasis> option. Similar messages are not printed for non-existing accounts.
+                  Don't print informative messages. The messages printed without the <emphasis>silent</emphasis> option leak presence of accounts on the system because they are not printed for non-existing accounts.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_tally2/pam_tally2.8.xml
+++ b/modules/pam_tally2/pam_tally2.8.xml
@@ -158,7 +158,7 @@
               </term>
               <listitem>
                 <para>
-                  Don't print informative messages.
+                  Don't print informative messages. Without <emphasis>silent</emphasis> leaks presence of accounts on the system.
                 </para>
               </listitem>
             </varlistentry>


### PR DESCRIPTION
Update man page to indicate silent hides account lock notices.

Closes #160.