### PR TITLE
Remove redundant header file inclusion

### DIFF
--- a/modules/pam_issue/pam_issue.c
+++ b/modules/pam_issue/pam_issue.c
@@ -22,7 +22,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <string.h>
 #include <unistd.h>
 #include <sys/utsname.h>
 #include <utmp.h>

--- a/modules/pam_loginuid/pam_loginuid.c
+++ b/modules/pam_loginuid/pam_loginuid.c
@@ -42,7 +42,6 @@
 #ifdef HAVE_LIBAUDIT
 #include <libaudit.h>
 #include <sys/select.h>
-#include <errno.h>
 #endif
 
 /*

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -63,14 +63,12 @@
 
 #include <selinux/selinux.h>
 #include <selinux/get_context_list.h>
-#include <selinux/selinux.h>
 #include <selinux/context.h>
 #include <selinux/get_default_type.h>
 
 #ifdef HAVE_LIBAUDIT
 #include <libaudit.h>
 #include <sys/select.h>
-#include <errno.h>
 #endif
 
 /* Send audit message */

--- a/modules/pam_sepermit/pam_sepermit.c
+++ b/modules/pam_sepermit/pam_sepermit.c
@@ -53,7 +53,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <pwd.h>
 #include <dirent.h>
 
 #define PAM_SM_AUTH

--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <syslog.h>
 #include <unistd.h>

--- a/modules/pam_tally2/pam_tally2.c
+++ b/modules/pam_tally2/pam_tally2.c
@@ -64,7 +64,6 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <signal.h>
 #include "tallylog.h"
 

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -56,7 +56,6 @@
 #include <sys/stat.h>
 
 #include <signal.h>
-#include <errno.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
 

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -50,7 +50,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
-#include <unistd.h>
 
 #define PAM_SM_SESSION
 
@@ -62,7 +61,6 @@
 #ifdef WITH_SELINUX
 #include <selinux/selinux.h>
 #include <selinux/label.h>
-#include <sys/stat.h>
 #endif
 
 #include "pam_cc_compat.h"


### PR DESCRIPTION
There are some source code including the same header file redundantly.
We remove these redundant header file inclusion.