### PR TITLE
libpamc: Use ISO C99 uintX_t types instead of u_intX_t

### DIFF
--- a/libpamc/include/security/pam_client.h
+++ b/libpamc/include/security/pam_client.h
@@ -16,6 +16,7 @@ extern "C" {
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 /* opaque agent handling structure */
@@ -23,7 +24,7 @@ extern "C" {
 typedef struct pamc_handle_s *pamc_handle_t;
 
 /* binary prompt structure pointer */
-typedef struct { u_int32_t length; u_int8_t control; } *pamc_bp_t;
+typedef struct { uint32_t length; uint8_t control; } *pamc_bp_t;
 
 /*
  * functions provided by libpamc
@@ -90,10 +91,10 @@ char **pamc_list_agents(pamc_handle_t pch);
 # define PAM_BP_FREE        free
 #endif /* PAM_BP_FREE */
 
-#define __PAM_BP_WOCTET(x,y)  (*((y) + (u_int8_t *)(x)))
-#define __PAM_BP_ROCTET(x,y)  (*((y) + (const u_int8_t *)(x)))
+#define __PAM_BP_WOCTET(x,y)  (*((y) + (uint8_t *)(x)))
+#define __PAM_BP_ROCTET(x,y)  (*((y) + (const uint8_t *)(x)))
 
-#define PAM_BP_MIN_SIZE       (sizeof(u_int32_t) + sizeof(u_int8_t))
+#define PAM_BP_MIN_SIZE       (sizeof(uint32_t) + sizeof(uint8_t))
 #define PAM_BP_MAX_LENGTH     0x20000                   /* an advisory limit */
 #define PAM_BP_WCONTROL(x)    (__PAM_BP_WOCTET(x,4))
 #define PAM_BP_RCONTROL(x)    (__PAM_BP_ROCTET(x,4))
@@ -102,8 +103,8 @@ char **pamc_list_agents(pamc_handle_t pch);
 			       (__PAM_BP_ROCTET(x,2)<< 8)+      \
 			       (__PAM_BP_ROCTET(x,3)    ))
 #define PAM_BP_LENGTH(x)      (PAM_BP_SIZE(x) - PAM_BP_MIN_SIZE)
-#define PAM_BP_WDATA(x)       (PAM_BP_MIN_SIZE + (u_int8_t *) (x))
-#define PAM_BP_RDATA(x)       (PAM_BP_MIN_SIZE + (const u_int8_t *) (x))
+#define PAM_BP_WDATA(x)       (PAM_BP_MIN_SIZE + (uint8_t *) (x))
+#define PAM_BP_RDATA(x)       (PAM_BP_MIN_SIZE + (const uint8_t *) (x))
 
 /* Note, this macro always '\0' terminates renewed packets */
 
@@ -111,13 +112,13 @@ char **pamc_list_agents(pamc_handle_t pch);
 do {                                                                       \
     if ((old_p) != NULL) {                                                 \
 	if (*(old_p)) {                                                    \
-	    u_int32_t __size;                                              \
+	    uint32_t __size;                                              \
             __size = PAM_BP_SIZE(*(old_p));                                \
 	    memset(*(old_p), 0, __size);                                   \
 	    PAM_BP_FREE(*(old_p));                                         \
 	}                                                                  \
 	if (cntrl) {                                                       \
-	    u_int32_t __size;                                              \
+	    uint32_t __size;                                              \
                                                                            \
 	    __size = PAM_BP_MIN_SIZE + data_length;                        \
 	    if ((*(old_p) = PAM_BP_CALLOC(1, 1+__size))) {                 \
@@ -140,7 +141,7 @@ do {                                                                       \
 #define PAM_BP_FILL(prmpt, offset, length, data)                           \
 do {                                                                       \
     size_t bp_length;                                                      \
-    u_int8_t *prompt = (u_int8_t *) (prmpt);                               \
+    uint8_t *prompt = (uint8_t *) (prmpt);                               \
     bp_length = PAM_BP_LENGTH(prompt);                                     \
     if (bp_length < ((length)+(offset))) {                                 \
 	PAM_BP_ASSERT("attempt to write over end of prompt");              \
@@ -151,7 +152,7 @@ do {                                                                       \
 #define PAM_BP_EXTRACT(prmpt, offset, length, data)                        \
 do {                                                                       \
     size_t __bp_length;                                                    \
-    const u_int8_t *__prompt = (const u_int8_t *) (prmpt);                 \
+    const uint8_t *__prompt = (const uint8_t *) (prmpt);                 \
     __bp_length = PAM_BP_LENGTH(__prompt);                                 \
     if (((offset) < 0) || (__bp_length < ((length)+(offset)))              \
 	|| ((length) < 0)) {                                               \

--- a/libpamc/libpamc.h
+++ b/libpamc/libpamc.h
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <sys/wait.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <ctype.h>

--- a/libpamc/pamc_converse.c
+++ b/libpamc/pamc_converse.c
@@ -34,8 +34,8 @@ static int __pamc_select_agent(pamc_handle_t pch, char *agent_id)
 
 int pamc_converse(pamc_handle_t pch, pamc_bp_t *prompt_p)
 {
-    u_int32_t size, offset=0;
-    u_int8_t control, raw[PAM_BP_MIN_SIZE];
+    uint32_t size, offset=0;
+    uint8_t control, raw[PAM_BP_MIN_SIZE];
 
     D(("called"));
 
@@ -110,7 +110,7 @@ int pamc_converse(pamc_handle_t pch, pamc_bp_t *prompt_p)
     /* pump all of the prompt into the agent */
     do {
 	int rval = write(pch->current->writer,
-			 offset + (const u_int8_t *) (*prompt_p),
+			 offset + (const uint8_t *) (*prompt_p),
 			 size - offset);
 	if (rval == -1) {
 	    switch (errno) {
@@ -172,7 +172,7 @@ int pamc_converse(pamc_handle_t pch, pamc_bp_t *prompt_p)
        value from the previous loop */
 
     while (offset < size) {
-	int rval = read(pch->current->reader, offset + (u_int8_t *) *prompt_p,
+	int rval = read(pch->current->reader, offset + (uint8_t *) *prompt_p,
 			size-offset);
 
 	if (rval == -1) {

--- a/libpamc/test/regress/test.libpamc.c
+++ b/libpamc/test/regress/test.libpamc.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <security/pam_client.h>
 #include <ctype.h>
@@ -157,7 +158,7 @@ char *create_digest(int length, const char *raw)
     return temp_packet.buffer;
 }
 
-void packet_to_prompt(pamc_bp_t *prompt_p, u_int8_t control,
+void packet_to_prompt(pamc_bp_t *prompt_p, uint8_t control,
 		      struct internal_packet *packet)
 {
     PAM_BP_RENEW(prompt_p, control, packet->at);

--- a/modules/pam_timestamp/sha1.c
+++ b/modules/pam_timestamp/sha1.c
@@ -56,34 +56,34 @@ padding[SHA1_BLOCK_SIZE] = {
 	   0, 0, 0, 0, 0, 0, 0, 0,     0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-static u_int32_t
-F(u_int32_t b, u_int32_t c, u_int32_t d)
+static uint32_t
+F(uint32_t b, uint32_t c, uint32_t d)
 {
 	return (b & c) | ((~b) & d);
 }
 
-static u_int32_t
-G(u_int32_t b, u_int32_t c, u_int32_t d)
+static uint32_t
+G(uint32_t b, uint32_t c, uint32_t d)
 {
 	return b ^ c ^ d;
 }
 
-static u_int32_t
-H(u_int32_t b, u_int32_t c, u_int32_t d)
+static uint32_t
+H(uint32_t b, uint32_t c, uint32_t d)
 {
 	return (b & c) | (b & d) | (c & d);
 }
 
-static u_int32_t
-RL(u_int32_t n, u_int32_t s)
+static uint32_t
+RL(uint32_t n, uint32_t s)
 {
 	return (n << s) | (n >> (32 - s));
 }
 
-static u_int32_t
-sha1_round(u_int32_t (*FUNC)(u_int32_t, u_int32_t, u_int32_t),
-      u_int32_t a, u_int32_t b, u_int32_t c, u_int32_t d, u_int32_t e,
-      u_int32_t i, u_int32_t n)
+static uint32_t
+sha1_round(uint32_t (*FUNC)(uint32_t, uint32_t, uint32_t),
+      uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e,
+      uint32_t i, uint32_t n)
 {
 	return RL(a, 5) + FUNC(b, c, d) + e + i + n;
 }
@@ -100,10 +100,10 @@ sha1_init(struct sha1_context *ctx)
 }
 
 static void
-sha1_process(struct sha1_context *ctx, u_int32_t buffer[SHA1_BLOCK_SIZE / 4])
+sha1_process(struct sha1_context *ctx, uint32_t buffer[SHA1_BLOCK_SIZE / 4])
 {
-	u_int32_t a, b, c, d, e, temp;
-	u_int32_t data[80];
+	uint32_t a, b, c, d, e, temp;
+	uint32_t data[80];
 	int i;
 
 	for (i = 0; i < 16; i++) {
@@ -150,14 +150,14 @@ void
 sha1_update(struct sha1_context *ctx, const unsigned char *data, size_t length)
 {
 	size_t i = 0, l = length, c, t;
-	u_int32_t count = 0;
+	uint32_t count = 0;
 
 	/* Process any pending + data blocks. */
 	while (l + ctx->pending_count >= SHA1_BLOCK_SIZE) {
 		c = ctx->pending_count;
 		t = SHA1_BLOCK_SIZE - c;
 		memcpy(ctx->pending + c, &data[i], t);
-		sha1_process(ctx, (u_int32_t*) ctx->pending);
+		sha1_process(ctx, (uint32_t*) ctx->pending);
 		i += t;
 		l -= t;
 		ctx->pending_count = 0;
@@ -188,7 +188,7 @@ sha1_output(struct sha1_context *ctx, unsigned char *out)
 
 	/* Output the sum. */
 	if (out != NULL) {
-		u_int32_t c;
+		uint32_t c;
 		memcpy(&ctx2, ctx, sizeof(ctx2));
 
 		/* Pad this block. */
@@ -197,10 +197,10 @@ sha1_output(struct sha1_context *ctx, unsigned char *out)
 		       padding, SHA1_BLOCK_SIZE - c);
 
 		/* Do we need to process two blocks now? */
-		if (c >= (SHA1_BLOCK_SIZE - (sizeof(u_int32_t) * 2))) {
+		if (c >= (SHA1_BLOCK_SIZE - (sizeof(uint32_t) * 2))) {
 			/* Process this block. */
 			sha1_process(&ctx2,
-				    (u_int32_t*) ctx2.pending);
+				    (uint32_t*) ctx2.pending);
 			/* Set up another block. */
 			ctx2.pending_count = 0;
 			memset(ctx2.pending, 0, SHA1_BLOCK_SIZE);
@@ -218,10 +218,10 @@ sha1_output(struct sha1_context *ctx, unsigned char *out)
 		ctx2.counts[0] = htonl(ctx2.counts[0]);
 		ctx2.counts[1] = htonl(ctx2.counts[1]);
 		memcpy(ctx2.pending + 56,
-		       &ctx2.counts[1], sizeof(u_int32_t));
+		       &ctx2.counts[1], sizeof(uint32_t));
 		memcpy(ctx2.pending + 60,
-		       &ctx2.counts[0], sizeof(u_int32_t));
-		sha1_process(&ctx2, (u_int32_t*) ctx2.pending);
+		       &ctx2.counts[0], sizeof(uint32_t));
+		sha1_process(&ctx2, (uint32_t*) ctx2.pending);
 
 		/* Output the data. */
 		out[ 3] = (ctx2.a >>  0) & 0xff;

--- a/modules/pam_timestamp/sha1.h
+++ b/modules/pam_timestamp/sha1.h
@@ -38,6 +38,7 @@
 #ifndef pam_timestamp_sha1_h
 #define pam_timestamp_sha1_h
 
+#include <stdint.h>
 #include <sys/types.h>
 
 #define SHA1_BLOCK_SIZE 64
@@ -45,9 +46,9 @@
 struct sha1_context {
 	size_t count;
 	unsigned char pending[SHA1_BLOCK_SIZE];
-	u_int32_t counts[2];
+	uint32_t counts[2];
 	size_t pending_count;
-	u_int32_t a, b, c, d, e;
+	uint32_t a, b, c, d, e;
 };
 
 #define SHA1_OUTPUT_SIZE 20


### PR DESCRIPTION
Fixes issue of compiling against musl libc.