### PR TITLE
Use cached 'crypt' library result correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -408,7 +408,7 @@ AS_IF([test "x$ac_cv_header_xcrypt_h" = "xyes"],
   [crypt_libs="crypt"])
 
 BACKUP_LIBS=$LIBS
-AC_SEARCH_LIBS([crypt],[$crypt_libs], LIBCRYPT="${ac_lib:+-l$ac_lib}", LIBCRYPT="")
+AC_SEARCH_LIBS([crypt],[$crypt_libs], LIBCRYPT="${ac_cv_search_crypt}", LIBCRYPT="")
 AC_CHECK_FUNCS(crypt_r crypt_gensalt_r)
 LIBS=$BACKUP_LIBS
 AC_SUBST(LIBCRYPT)


### PR DESCRIPTION
Configure script incorrectly used a non-cached variable (ac_lib) in the
cached code path. This results in no -lcrypt being defined resulting in
link errors on a re-build.

Update configure.ac to use ac_cv_search_crypt (via ac_res) to setup the
correct library arguments.

Signed-off-by: Mark Wutzke <mark.wutzke@alliedtelesis.co.nz>
Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>