### PR TITLE
pam_access: Support UID and GID in access.conf

### DIFF
--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -67,10 +67,10 @@
     <para>
       The second field, the
       <replaceable>users</replaceable>/<replaceable>group</replaceable>
-      field, should be a list of one or more login names, group names, or
+      field, should be a list of one or more login names, group names, uid, gid, or
       <emphasis>ALL</emphasis> (which always matches). To differentiate
       user entries from group entries, group entries should be written
-      with brackets, e.g. <emphasis>(group)</emphasis>.
+      with brackets, e.g. <emphasis>(group)</emphasis> or <emphasis>(gid)</emphasis>.
     </para>
 
     <para>
@@ -179,6 +179,12 @@
     </para>
     <para>-:root:ALL</para>
 
+    <para>
+      An user with uid <emphasis>1003</emphasis> and a group with gid
+      <emphasis>1000</emphasis> should be allowed to get access
+      from all other sources.
+    </para>
+    <para>+:(1000) 1003:ALL</para>
     <para>
       User <emphasis>foo</emphasis> and members of netgroup
       <emphasis>admins</emphasis> should be allowed to get access


### PR DESCRIPTION
pam_access: Support UID and GID in access.conf fix [#114](https://github.com/linux-pam/linux-pam/issues/114).

eg:access.conf
-:ALL EXECPT (1000) 1002 :LOCAL
