### PR TITLE
pam_time supports dynamically loading configuration file at runtime

### DIFF
--- a/modules/pam_time/pam_time.8.xml
+++ b/modules/pam_time/pam_time.8.xml
@@ -23,6 +23,9 @@
     <cmdsynopsis id="pam_time-cmdsynopsis">
       <command>pam_time.so</command>
       <arg choice="opt">
+	conffile=conf-file
+      </arg>
+      <arg choice="opt">
         debug
       </arg>
       <arg choice="opt">
@@ -45,7 +48,7 @@
     </para>
     <para>
       By default rules for time/port access are taken from config file
-      <filename>/etc/security/time.conf</filename>.
+      <filename>/etc/security/time.conf</filename>. An alternate file can be specified with the conffile option.
     </para>
     <para>
       If Linux PAM is compiled with audit support the module will report
@@ -56,6 +59,16 @@
   <refsect1 id="pam_time-options">
     <title>OPTIONS</title>
     <variablelist>
+     <varlistentry>
+	<term>
+	  <option>conffile=/path/to/time.conf</option>
+        </term>
+        <listitem>
+	  <para>
+            Indicate an alternative time.conf style configuration file to override the default.
+	  </para>
+        </listitem>
+      </varlistentry>
 
       <varlistentry>
         <term>

--- a/modules/pam_time/pam_time.c
+++ b/modules/pam_time/pam_time.c
@@ -57,10 +57,10 @@ typedef enum { AND, OR } operator;
 #include <security/pam_modutil.h>
 
 static int
-_pam_parse (const pam_handle_t *pamh, int argc, const char **argv)
+_pam_parse (const pam_handle_t *pamh, int argc, const char **argv, const char **conffile)
 {
     int ctrl = 0;
-
+    *conffile = PAM_TIME_CONF ;
     /* step through arguments */
     for (; argc-- > 0; ++argv) {
 
@@ -70,7 +70,15 @@ _pam_parse (const pam_handle_t *pamh, int argc, const char **argv)
 	    ctrl |= PAM_DEBUG_ARG;
 	} else if (!strcmp(*argv, "noaudit")) {
 	    ctrl |= PAM_NO_AUDIT;
-	} else {
+	} else if (!strncmp(*argv,"conffile=",9)) {
+	    if ((*argv)[9] == '\0') {
+		    pam_syslog(pamh, LOG_ERR,
+                       "conffile= specification missing argument - ignored");
+            } else {
+		  *conffile = 9+*argv;
+		  D(("new Configuration File: %s", *conffile));
+	    }
+        } else {
 	    pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
 	}
     }
@@ -108,7 +116,7 @@ trim_spaces(char *buf, char *from)
 #define STATE_EOF      3 /* end of file or error */
 
 static int
-read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state)
+read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state, const char *file)
 {
     char *to;
     char *src;
@@ -127,9 +135,9 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state)
 	}
 	*from = 0;
         *state = STATE_NL;
-	fd = open(PAM_TIME_CONF, O_RDONLY);
+	fd = open(file, O_RDONLY);
 	if (fd < 0) {
-	    pam_syslog(pamh, LOG_ERR, "error opening %s: %m", PAM_TIME_CONF);
+	    pam_syslog(pamh, LOG_ERR, "error opening %s: %m", file);
 	    _pam_drop(*buf);
 	    *state = STATE_EOF;
 	    return -1;
@@ -145,7 +153,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state)
     while (fd != -1 && to - *buf < PAM_TIME_BUFLEN) {
 	i = pam_modutil_read(fd, to, PAM_TIME_BUFLEN - (to - *buf));
 	if (i < 0) {
-	    pam_syslog(pamh, LOG_ERR, "error reading %s: %m", PAM_TIME_CONF);
+	    pam_syslog(pamh, LOG_ERR, "error reading %s: %m", file);
 	    close(fd);
 	    memset(*buf, 0, PAM_TIME_BUFLEN);
 	    _pam_drop(*buf);
@@ -506,7 +514,7 @@ check_time(pam_handle_t *pamh, const void *AT, const char *times,
 
 static int
 check_account(pam_handle_t *pamh, const char *service,
-	      const char *tty, const char *user)
+	      const char *tty, const char *user, const char *file)
 {
      int from=0, state=STATE_NL, fd=-1;
      char *buffer=NULL;
@@ -520,7 +528,7 @@ check_account(pam_handle_t *pamh, const char *service,
 
 	  /* here we get the service name field */
 
-	  fd = read_field(pamh, fd, &buffer, &from, &state);
+	  fd = read_field(pamh, fd, &buffer, &from, &state, file);
 	  if (!buffer || !buffer[0]) {
 	       /* empty line .. ? */
 	       continue;
@@ -529,7 +537,7 @@ check_account(pam_handle_t *pamh, const char *service,
 
 	  if (state != STATE_FIELD) {
 	       pam_syslog(pamh, LOG_ERR,
-			  "%s: malformed rule #%d", PAM_TIME_CONF, count);
+			  "%s: malformed rule #%d", file, count);
 	       continue;
 	  }
 
@@ -538,10 +546,10 @@ check_account(pam_handle_t *pamh, const char *service,
 
 	  /* here we get the terminal name field */
 
-	  fd = read_field(pamh, fd, &buffer, &from, &state);
+	  fd = read_field(pamh, fd, &buffer, &from, &state, file);
 	  if (state != STATE_FIELD) {
 	       pam_syslog(pamh, LOG_ERR,
-			  "%s: malformed rule #%d", PAM_TIME_CONF, count);
+			  "%s: malformed rule #%d", file, count);
 	       continue;
 	  }
 	  good &= logic_field(pamh, tty, buffer, count, is_same);
@@ -549,10 +557,10 @@ check_account(pam_handle_t *pamh, const char *service,
 
 	  /* here we get the username field */
 
-	  fd = read_field(pamh, fd, &buffer, &from, &state);
+	  fd = read_field(pamh, fd, &buffer, &from, &state, file);
 	  if (state != STATE_FIELD) {
 	       pam_syslog(pamh, LOG_ERR,
-			  "%s: malformed rule #%d", PAM_TIME_CONF, count);
+			  "%s: malformed rule #%d", file, count);
 	       continue;
 	  }
 	  /* If buffer starts with @, we are using netgroups */
@@ -568,10 +576,10 @@ check_account(pam_handle_t *pamh, const char *service,
 
 	  /* here we get the time field */
 
-	  fd = read_field(pamh, fd, &buffer, &from, &state);
+	  fd = read_field(pamh, fd, &buffer, &from, &state, file);
 	  if (state == STATE_FIELD) {
 	       pam_syslog(pamh, LOG_ERR,
-			  "%s: poorly terminated rule #%d", PAM_TIME_CONF, count);
+			  "%s: poorly terminated rule #%d", file, count);
 	       continue;
 	  }
 
@@ -601,10 +609,15 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
     const void *service=NULL, *void_tty=NULL;
     const char *tty;
     const char *user=NULL;
+    const char *conf_file = NULL ;
     int ctrl;
     int rv;
 
-    ctrl = _pam_parse(pamh, argc, argv);
+    ctrl = _pam_parse(pamh, argc, argv, &conf_file);
+
+	if (ctrl & PAM_DEBUG_ARG) {
+	    pam_syslog(pamh, LOG_DEBUG, "conffile=%s", conf_file);
+	}
 
     /* set service name */
 
@@ -653,7 +666,7 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
     D(("user=%s", user));
     D(("tty=%s", tty));
 
-    rv = check_account(pamh, service, tty, user);
+    rv = check_account(pamh, service, tty, user, conf_file);
     if (rv != PAM_SUCCESS) {
 #ifdef HAVE_LIBAUDIT
 	if (!(ctrl & PAM_NO_AUDIT)) {


### PR DESCRIPTION
pam_time supports dynamically loading configuration file at runtime
fix #163 
eg
account  required       pam_time.so debug conffile=/etc/test/testtime.conf

