### PR TITLE
pam_selinux update

### DIFF
--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -73,25 +73,22 @@
 #endif
 
 /* Send audit message */
-static
-
-int send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
-		       const char *selected_context)
+static void
+send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
+		   const char *selected_context)
 {
-	int rc=0;
 #ifdef HAVE_LIBAUDIT
 	char *msg = NULL;
 	int audit_fd = audit_open();
 	char *default_raw = NULL;
 	char *selected_raw = NULL;
 	const void *tty = NULL, *rhost = NULL;
-	rc = -1;
 	if (audit_fd < 0) {
 		if (errno == EINVAL || errno == EPROTONOSUPPORT ||
                                         errno == EAFNOSUPPORT)
-                        return 0; /* No audit support in kernel */
+                        return; /* No audit support in kernel */
 		pam_syslog(pamh, LOG_ERR, "Error connecting to audit system.");
-		return rc;
+		return;
 	}
 	(void)pam_get_item(pamh, PAM_TTY, &tty);
 	(void)pam_get_item(pamh, PAM_RHOST, &rhost);
@@ -114,7 +111,6 @@ int send_audit_message(pam_handle_t *pamh, int success, const char *default_cont
 		pam_syslog(pamh, LOG_ERR, "Error sending audit message.");
 		goto out;
 	}
-	rc = 0;
       out:
 	free(msg);
 	freecon(default_raw);
@@ -123,8 +119,8 @@ int send_audit_message(pam_handle_t *pamh, int success, const char *default_cont
 #else
 	pam_syslog(pamh, LOG_NOTICE, "pam: default-context=%s selected-context=%s success %d", default_context, selected_context, success);
 #endif
-	return rc;
 }
+
 static int
 send_text (pam_handle_t *pamh, const char *text, int debug)
 {

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -75,15 +75,15 @@
 /* Send audit message */
 static
 
-int send_audit_message(pam_handle_t *pamh, int success, security_context_t default_context,
-		       security_context_t selected_context)
+int send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
+		       const char *selected_context)
 {
 	int rc=0;
 #ifdef HAVE_LIBAUDIT
 	char *msg = NULL;
 	int audit_fd = audit_open();
-	security_context_t default_raw=NULL;
-	security_context_t selected_raw=NULL;
+	char *default_raw = NULL;
+	char *selected_raw = NULL;
 	const void *tty = NULL, *rhost = NULL;
 	rc = -1;
 	if (audit_fd < 0) {
@@ -158,10 +158,10 @@ query_response (pam_handle_t *pamh, const char *text, const char *def,
   return rc;
 }
 
-static security_context_t
-config_context (pam_handle_t *pamh, security_context_t defaultcon, int use_current_range, int debug)
+static char *
+config_context (pam_handle_t *pamh, const char *defaultcon, int use_current_range, int debug)
 {
-  security_context_t newcon=NULL;
+  char *newcon = NULL;
   context_t new_context;
   int mls_enabled = is_selinux_mls_enabled();
   char *response=NULL;
@@ -205,7 +205,7 @@ config_context (pam_handle_t *pamh, security_context_t defaultcon, int use_curre
 	if (mls_enabled)
 	  {
 	    if (use_current_range) {
-	        security_context_t mycon = NULL;
+	        char *mycon = NULL;
 	        context_t my_context;
 
 		if (getcon(&mycon) != 0)
@@ -274,10 +274,10 @@ config_context (pam_handle_t *pamh, security_context_t defaultcon, int use_curre
   return NULL;
 }
 
-static security_context_t
-context_from_env (pam_handle_t *pamh, security_context_t defaultcon, int env_params, int use_current_range, int debug)
+static char *
+context_from_env (pam_handle_t *pamh, const char *defaultcon, int env_params, int use_current_range, int debug)
 {
-  security_context_t newcon = NULL;
+  char *newcon = NULL;
   context_t new_context;
   context_t my_context = NULL;
   int mls_enabled = is_selinux_mls_enabled();
@@ -311,7 +311,7 @@ context_from_env (pam_handle_t *pamh, security_context_t defaultcon, int env_par
     }
 
     if (use_current_range) {
-        security_context_t mycon = NULL;
+        char *mycon = NULL;
 
 	if (getcon(&mycon) != 0)
 	    goto fail_set;
@@ -374,11 +374,11 @@ context_from_env (pam_handle_t *pamh, security_context_t defaultcon, int env_par
 
 #define DATANAME "pam_selinux_context"
 typedef struct {
-  security_context_t exec_context;
-  security_context_t prev_exec_context;
-  security_context_t default_user_context;
-  security_context_t tty_context;
-  security_context_t prev_tty_context;
+  char *exec_context;
+  char *prev_exec_context;
+  char *default_user_context;
+  char *tty_context;
+  char *prev_tty_context;
   char *tty_path;
 } module_data_t;
 
@@ -419,7 +419,7 @@ get_item(const pam_handle_t *pamh, int item_type)
 }
 
 static int
-set_exec_context(const pam_handle_t *pamh, security_context_t context)
+set_exec_context(const pam_handle_t *pamh, const char *context)
 {
   if (setexeccon(context) == 0)
     return 0;
@@ -429,7 +429,7 @@ set_exec_context(const pam_handle_t *pamh, security_context_t context)
 }
 
 static int
-set_file_context(const pam_handle_t *pamh, security_context_t context,
+set_file_context(const pam_handle_t *pamh, const char *context,
 		 const char *file)
 {
   if (!file)
@@ -453,7 +453,7 @@ compute_exec_context(pam_handle_t *pamh, module_data_t *data,
 #endif
   char *seuser = NULL;
   char *level = NULL;
-  security_context_t *contextlist = NULL;
+  char **contextlist = NULL;
   int num_contexts = 0;
   const struct passwd *pwd;
 

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -74,7 +74,7 @@
 
 /* Send audit message */
 static void
-send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
+send_audit_message(const pam_handle_t *pamh, int success, const char *default_context,
 		   const char *selected_context)
 {
 #ifdef HAVE_LIBAUDIT
@@ -85,10 +85,11 @@ send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
 	const void *tty = NULL, *rhost = NULL;
 	if (audit_fd < 0) {
 		if (errno == EINVAL || errno == EPROTONOSUPPORT ||
-                                        errno == EAFNOSUPPORT)
-                        return; /* No audit support in kernel */
+                                        errno == EAFNOSUPPORT) {
+			goto fallback; /* No audit support in kernel */
+		}
 		pam_syslog(pamh, LOG_ERR, "Error connecting to audit system: %m");
-		return;
+		goto fallback;
 	}
 	(void)pam_get_item(pamh, PAM_TTY, &tty);
 	(void)pam_get_item(pamh, PAM_RHOST, &rhost);
@@ -105,21 +106,27 @@ send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
 		     selected_raw ? selected_raw : (selected_context ? selected_context : "?")) < 0) {
 		msg = NULL; /* asprintf leaves msg in undefined state on failure */
 		pam_syslog(pamh, LOG_ERR, "Error allocating memory.");
-		goto out;
+		goto fallback;
 	}
 	if (audit_log_user_message(audit_fd, AUDIT_USER_ROLE_CHANGE,
 				   msg, rhost, NULL, tty, success) <= 0) {
 		pam_syslog(pamh, LOG_ERR, "Error sending audit message: %m");
-		goto out;
+		goto fallback;
 	}
-      out:
+	goto cleanup;
+
+      fallback:
+#endif /* HAVE_LIBAUDIT */
+        pam_syslog(pamh, LOG_NOTICE, "pam: default-context=%s selected-context=%s success %d", default_context, selected_context, success);
+
+#ifdef HAVE_LIBAUDIT
+      cleanup:
 	free(msg);
 	freecon(default_raw);
 	freecon(selected_raw);
-	close(audit_fd);
-#else
-	pam_syslog(pamh, LOG_NOTICE, "pam: default-context=%s selected-context=%s success %d", default_context, selected_context, success);
-#endif
+	if (audit_fd != -1)
+		close(audit_fd);
+#endif /* HAVE_LIBAUDIT */
 }
 
 static int

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -103,6 +103,7 @@ send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
 	if (asprintf(&msg, "pam: default-context=%s selected-context=%s",
 		     default_raw ? default_raw : (default_context ? default_context : "?"),
 		     selected_raw ? selected_raw : (selected_context ? selected_context : "?")) < 0) {
+		msg = NULL; /* asprintf leaves msg in undefined state on failure */
 		pam_syslog(pamh, LOG_ERR, "Error allocating memory.");
 		goto out;
 	}

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -239,11 +239,11 @@ config_context (pam_handle_t *pamh, const char *defaultcon, int use_current_rang
 	    goto fail_set;
 	  context_free(new_context);
 
-    /* we have to check that this user is allowed to go into the
-        range they have specified ... role is tied to an seuser, so that'll
-        be checked at setexeccon time */
-    if (mls_enabled &&
-        selinux_check_access(defaultcon, newcon, "context", "contains", NULL) != 0) {
+	  /* we have to check that this user is allowed to go into the
+	     range they have specified ... role is tied to an seuser, so that'll
+	     be checked at setexeccon time */
+	  if (mls_enabled &&
+	      selinux_check_access(defaultcon, newcon, "context", "contains", NULL) != 0) {
 	    pam_syslog(pamh, LOG_NOTICE, "Security context %s is not allowed for %s", defaultcon, newcon);
 
 	    send_audit_message(pamh, 0, defaultcon, newcon);

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -87,17 +87,17 @@ send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
 		if (errno == EINVAL || errno == EPROTONOSUPPORT ||
                                         errno == EAFNOSUPPORT)
                         return; /* No audit support in kernel */
-		pam_syslog(pamh, LOG_ERR, "Error connecting to audit system.");
+		pam_syslog(pamh, LOG_ERR, "Error connecting to audit system: %m");
 		return;
 	}
 	(void)pam_get_item(pamh, PAM_TTY, &tty);
 	(void)pam_get_item(pamh, PAM_RHOST, &rhost);
 	if (selinux_trans_to_raw_context(default_context, &default_raw) < 0) {
-		pam_syslog(pamh, LOG_ERR, "Error translating default context.");
+		pam_syslog(pamh, LOG_ERR, "Error translating default context '%s'.", default_context);
 		default_raw = NULL;
 	}
 	if (selinux_trans_to_raw_context(selected_context, &selected_raw) < 0) {
-		pam_syslog(pamh, LOG_ERR, "Error translating selected context.");
+		pam_syslog(pamh, LOG_ERR, "Error translating selected context '%s'.", selected_context);
 		selected_raw = NULL;
 	}
 	if (asprintf(&msg, "pam: default-context=%s selected-context=%s",
@@ -108,7 +108,7 @@ send_audit_message(pam_handle_t *pamh, int success, const char *default_context,
 	}
 	if (audit_log_user_message(audit_fd, AUDIT_USER_ROLE_CHANGE,
 				   msg, rhost, NULL, tty, success) <= 0) {
-		pam_syslog(pamh, LOG_ERR, "Error sending audit message.");
+		pam_syslog(pamh, LOG_ERR, "Error sending audit message: %m");
 		goto out;
 	}
       out:


### PR DESCRIPTION
* fall back to log to syslog if audit logging fails
* substitute legacy security_context_t type
* fix indentation 