### PR TITLE
pam_timestamp: Fix // in TIMESTAMPDIR

### DIFF
--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -71,7 +71,7 @@
  * for the timestamp_timeout parameter. */
 #define DEFAULT_TIMESTAMP_TIMEOUT (5 * 60)
 #define MODULE "pam_timestamp"
-#define TIMESTAMPDIR _PATH_VARRUN "/" MODULE
+#define TIMESTAMPDIR _PATH_VARRUN MODULE
 #define TIMESTAMPKEY TIMESTAMPDIR "/_pam_timestamp_key"
 
 /* Various buffers we use need to be at least as large as either PATH_MAX or


### PR DESCRIPTION
_PATH_VARRUN already provides trailing slash for building paths

Fixes:

    $ strings /usr/lib64/security/pam_timestamp.so | grep /run/
    /var/run//pam_timestamp
    /var/run//pam_timestamp/_pam_timestamp_key