### PR TITLE
pam_unix: modernize example in manual page

### DIFF
--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -467,7 +467,7 @@ account    required   pam_unix.so
 # Change the user's password, but at first check the strength
 # with pam_cracklib(8)
 password   required   pam_cracklib.so retry=3 minlen=6 difok=3
-password   required   pam_unix.so use_authtok nullok md5
+password   required   pam_unix.so use_authtok nullok yescrypt
 session    required   pam_unix.so
       </programlisting>
     </para>


### PR DESCRIPTION
According to crypt(5), md5 should not be used for new hashes. Let's
give a more modern example with sha512 and 500000 rounds (default 5000
is too weak).

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>