### PR TITLE
Use correct path for pam_namespace.service file

### DIFF
--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -18,7 +18,7 @@ TESTS = $(dist_check_SCRIPTS)
 securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 namespaceddir = $(SCONFIGDIR)/namespace.d
-servicedir = $(prefix)/lib/systemd
+servicedir = $(prefix)/lib/systemd/system
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
         -DSECURECONF_DIR=\"$(SCONFIGDIR)/\" $(WARN_CFLAGS)


### PR DESCRIPTION
Currently pam_namespace.service is installed into /usr/lib/systemd, not /usr/lib/systemd/system where it belongs.