### PR TITLE
configure.ac: fix build failure without libcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -428,7 +428,11 @@ AS_IF([test "x$ac_cv_header_xcrypt_h" = "xyes"],
   [crypt_libs="crypt"])
 
 BACKUP_LIBS=$LIBS
-AC_SEARCH_LIBS([crypt],[$crypt_libs], LIBCRYPT="${ac_cv_search_crypt}", LIBCRYPT="")
+AC_SEARCH_LIBS([crypt],[$crypt_libs])
+case "$ac_cv_search_crypt" in
+	-l*) LIBCRYPT="$ac_cv_search_crypt" ;;
+	*) LIBCRYPT="" ;;
+esac
 AC_CHECK_FUNCS(crypt_r crypt_gensalt_r)
 LIBS=$BACKUP_LIBS
 AC_SUBST(LIBCRYPT)


### PR DESCRIPTION
Since commit 522246d20e4cd92fadc2d760228cb7e78cbeb4c5, the build fails
if "none required" is returned by AC_SEARCH_LIBS for libcrypt:

```
libtool: link: /home/test/autobuild/run/instance-2/output-1/host/bin/powerpc-linux-gcc -I../../libpam/include -I../../libpamc/include -DCHKPWD_HELPER=\"/sbin/unix_chkpwd\" -DUPDATE_HELPER=\"/sbin/unix_update\" -W -Wall -Wbad-function-cast -Wcast-align -Wcast-qual -Wmissing-declarations -Wmissing-prototypes -Wpointer-arith -Wreturn-type -Wstrict-prototypes -Wwrite-strings -Winline -Wshadow -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -o bigcrypt bigcrypt-bigcrypt.o bigcrypt-bigcrypt_main.o none required
powerpc-linux-gcc.br_real: error: none: No such file or directory
powerpc-linux-gcc.br_real: error: required: No such file or directory
```

Fixes:
 - http://autobuild.buildroot.org/results/92b3dd7c984d2b843ac9aacacd69eec99f28743e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>