### PR TITLE
pam_faillock: change /run/faillock/$USER permissions to 0660

### DIFF
--- a/modules/pam_faillock/faillock.c
+++ b/modules/pam_faillock/faillock.c
@@ -76,7 +76,7 @@ open_tally (const char *dir, const char *user, uid_t uid, int create)
 		flags |= O_CREAT;
 	}
 
-	fd = open(path, flags, 0600);
+	fd = open(path, flags, 0660);
 
 	free(path);
 
@@ -87,6 +87,18 @@ open_tally (const char *dir, const char *user, uid_t uid, int create)
 		if (fstat(fd, &st) == 0) {
 			if (st.st_uid != uid) {
 				ignore_return(fchown(fd, uid, -1));
+			}
+
+			/*
+			 * If umask is set to 022, as will probably in most systems, then the
+			 * group will not be able to write to the file. So, change the file
+			 * permissions just in case.
+			 * Note: owners of this file are user:root, so if the permissions are
+			 * not changed the root process writing to this file will require
+			 * CAP_DAC_OVERRIDE.
+			 */
+			if (!(st.st_mode & S_IWGRP)) {
+				ignore_return(fchmod(fd, 0660));
 			}
 		}
 	}


### PR DESCRIPTION
Nowadays, /run/faillock/$USER files have user:root ownership and 0600 permissions. This forces the process that writes to these files to have CAP_DAC_OVERRIDE capabilites. Just by changing the permissions to 0660 the capability can be removed, which leads to a more secure system.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1661822