### PR TITLE
match the runtime until password prompt of existing and non-existing users

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -1096,6 +1096,12 @@ helper_verify_password(const char *name, const char *p, int nullok)
 	if (pwd == NULL || hash == NULL) {
 		helper_log_err(LOG_NOTICE, "check pass; user unknown");
 		retval = PAM_USER_UNKNOWN;
+	} else if (p[0] == '\0' && nullok) {
+		if (hash[0] == '\0') {
+			retval = PAM_SUCCESS;
+		} else {
+			retval = PAM_AUTH_ERR;
+		}
 	} else {
 		retval = verify_pwd_hash(p, hash, nullok);
 	}

--- a/modules/pam_usertype/pam_usertype.c
+++ b/modules/pam_usertype/pam_usertype.c
@@ -139,8 +139,11 @@ pam_usertype_get_uid(struct pam_usertype_opts *opts,
                        "error retrieving information about user %s", username);
         }
 
+        pam_modutil_getpwnam(pamh, "root");
+
         return PAM_USER_UNKNOWN;
     }
+    pam_modutil_getpwnam(pamh, "pam_usertype_non_existent:");
 
     *_uid = pwd->pw_uid;
 


### PR DESCRIPTION
Taking a look at the time for the password prompt to appear it was possible to determine if a user existed in a system. Solved it by matching the runtime until the password prompt was shown by always checking the password hash for an existing and a non-existing user.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1629598