### PR TITLE
pam_pwhistory: added helper to handle SELinux

### DIFF
--- a/modules/pam_pwhistory/.gitignore
+++ b/modules/pam_pwhistory/.gitignore
@@ -1,0 +1,1 @@
+pwhistory_helper

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2008, 2009 Thorsten Kukuk <kukuk@suse.de>
+# Copyright (c) 2013 Red Hat, Inc.
 #
 
 CLEANFILES = *~
@@ -8,9 +9,9 @@ MAINTAINERCLEANFILES = $(MANS) README
 EXTRA_DIST = $(XMLS)
 
 if HAVE_DOC
-dist_man_MANS = pam_pwhistory.8
+dist_man_MANS = pam_pwhistory.8 pwhistory_helper.8
 endif
-XMLS = README.xml pam_pwhistory.8.xml
+XMLS = README.xml pam_pwhistory.8.xml pwhistory_helper.8.xml
 dist_check_SCRIPTS = tst-pam_pwhistory
 TESTS = $(dist_check_SCRIPTS)
 
@@ -18,17 +19,25 @@ securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
-AM_LDFLAGS = -no-undefined -avoid-version -module
+	$(WARN_CFLAGS) -DPWHISTORY_HELPER=\"$(sbindir)/pwhistory_helper\"
+
+pam_pwhistory_la_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
-  AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
+  pam_pwhistory_la_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
 
 noinst_HEADERS = opasswd.h
 
 securelib_LTLIBRARIES = pam_pwhistory.la
-pam_pwhistory_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@
+pam_pwhistory_la_CFLAGS = $(AM_CFLAGS)
+pam_pwhistory_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@ @LIBSELINUX@
 pam_pwhistory_la_SOURCES = pam_pwhistory.c opasswd.c
+
+sbin_PROGRAMS = pwhistory_helper
+pwhistory_helper_CFLAGS = $(AM_CFLAGS) -DHELPER_COMPILE=\"pwhistory_helper\" @PIE_CFLAGS@
+pwhistory_helper_SOURCES = pwhistory_helper.c opasswd.c
+pwhistory_helper_LDFLAGS = @PIE_LDFLAGS@
+pwhistory_helper_LDADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_pwhistory/opasswd.h
+++ b/modules/pam_pwhistory/opasswd.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008 Thorsten Kukuk <kukuk@suse.de>
+ * Copyright (c) 2013 Red Hat, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,10 +37,30 @@
 #ifndef __OPASSWD_H__
 #define __OPASSWD_H__
 
-extern int check_old_pass (pam_handle_t *pamh, const char *user,
-			   const char *newpass, int debug);
-extern int save_old_pass (pam_handle_t *pamh, const char *user,
-			  uid_t uid, const char *oldpass,
-			  int howmany, int debug);
+#define PAM_PWHISTORY_RUN_HELPER PAM_CRED_INSUFFICIENT
+
+#ifdef WITH_SELINUX
+#include <selinux/selinux.h>
+#define SELINUX_ENABLED (is_selinux_enabled()>0)
+#else
+#define SELINUX_ENABLED 0
+#endif
+
+#ifdef HELPER_COMPILE
+#define PAMH_ARG_DECL(fname, ...) fname(__VA_ARGS__)
+#else
+#define PAMH_ARG_DECL(fname, ...) fname(pam_handle_t *pamh, __VA_ARGS__)
+#endif
+
+#ifdef HELPER_COMPILE
+void
+helper_log_err(int err, const char *format, ...);
+#endif
+
+PAMH_ARG_DECL(int
+check_old_pass, const char *user, const char *newpass, int debug);
+
+PAMH_ARG_DECL(int
+save_old_pass, const char *user, int howmany, int debug);
 
 #endif /* __OPASSWD_H__ */

--- a/modules/pam_pwhistory/pwhistory_helper.8.xml
+++ b/modules/pam_pwhistory/pwhistory_helper.8.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+
+<refentry id="pwhistory_helper">
+
+  <refmeta>
+    <refentrytitle>pwhistory_helper</refentrytitle>
+    <manvolnum>8</manvolnum>
+    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+  </refmeta>
+
+  <refnamediv id="pwhistory_helper-name">
+    <refname>pwhistory_helper</refname>
+    <refpurpose>Helper binary that transfers password hashes from passwd or shadow to opasswd</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis id="pwhistory_helper-cmdsynopsis">
+      <command>pwhistory_helper</command>
+      <arg choice="opt">
+        ...
+      </arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1 id="pwhistory_helper-description">
+
+    <title>DESCRIPTION</title>
+
+    <para>
+      <emphasis>pwhistory_helper</emphasis> is a helper program for the
+      <emphasis>pam_pwhistory</emphasis> module that transfers password hashes
+      from passwd or shadow file to the opasswd file and checks a password
+      supplied by user against the existing hashes in the opasswd file.
+    </para>
+
+    <para>
+      The purpose of the helper is to enable tighter confinement of
+      login and password changing services. The helper is thus called only
+      when SELinux is enabled on the system.
+    </para>
+
+    <para>
+      The interface of the helper - command line options, and input/output
+      data format are internal to the <emphasis>pam_pwhistory</emphasis>
+      module and it should not be called directly from applications.
+    </para>
+  </refsect1>
+
+  <refsect1 id='pwhistory_helper-see_also'>
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+	<refentrytitle>pam_pwhistory</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pwhistory_helper-author'>
+    <title>AUTHOR</title>
+      <para>
+        Written by Tomas Mraz based on the code originally in
+        <emphasis>pam_pwhistory and pam_unix</emphasis> modules.
+      </para>
+  </refsect1>
+
+</refentry>

--- a/modules/pam_pwhistory/pwhistory_helper.c
+++ b/modules/pam_pwhistory/pwhistory_helper.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Author: Tomas Mraz <tmraz@redhat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU Public License, in which case the provisions of the GPL are
+ * required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+#include <security/_pam_types.h>
+#include <security/_pam_macros.h>
+#include <security/pam_modutil.h>
+#include "opasswd.h"
+#include "pam_inline.h"
+
+
+static int
+check_history(const char *user, const char *debug)
+{
+  char pass[PAM_MAX_RESP_SIZE + 1];
+  char *passwords[] = { pass };
+  int npass;
+  int dbg = atoi(debug); /* no need to be too fancy here */
+  int retval;
+
+  /* read the password from stdin (a pipe from the pam_pwhistory module) */
+  npass = pam_read_passwords(STDIN_FILENO, 1, passwords);
+
+  if (npass != 1)
+    { /* is it a valid password? */
+      helper_log_err(LOG_DEBUG, "no password supplied");
+      return PAM_AUTHTOK_ERR;
+    }
+
+  retval = check_old_pass(user, pass, dbg);
+
+  memset(pass, '\0', PAM_MAX_RESP_SIZE);	/* clear memory of the password */
+
+  return retval;
+}
+
+static int
+save_history(const char *user, const char *howmany, const char *debug)
+{
+  int num = atoi(howmany);
+  int dbg = atoi(debug); /* no need to be too fancy here */
+  int retval;
+
+  retval = save_old_pass(user, num, dbg);
+
+  return retval;
+}
+
+int
+main(int argc, char *argv[])
+{
+  const char *option;
+  const char *user;
+
+  /*
+   * we establish that this program is running with non-tty stdin.
+   * this is to discourage casual use.
+   */
+
+  if (isatty(STDIN_FILENO) || argc < 4)
+    {
+      fprintf(stderr,
+            "This binary is not designed for running in this way.\n");
+      return PAM_SYSTEM_ERR;
+    }
+
+  option = argv[1];
+  user = argv[2];
+
+  if (strcmp(option, "check") == 0 && argc == 4)
+    return check_history(user, argv[3]);
+  else if (strcmp(option, "save") == 0 && argc == 5)
+    return save_history(user, argv[3], argv[4]);
+
+  fprintf(stderr, "This binary is not designed for running in this way.\n");
+
+  return PAM_SYSTEM_ERR;
+}


### PR DESCRIPTION
The purpose of the helper is to enable tighter confinement of login and
password changing services. The helper is thus called only when SELinux
is enabled on the system.

The issues were solved downstream some time ago and have been widely
tested in different versions of Fedora.