### PR TITLE
pam_wheel: if getlogin fails fallback to PAM_RUSER

### DIFF
--- a/modules/pam_wheel/pam_wheel.8.xml
+++ b/modules/pam_wheel/pam_wheel.8.xml
@@ -122,9 +122,9 @@
         </term>
         <listitem>
           <para>
-            The check for wheel membership will be done against
-            the current uid instead of the original one (useful when
-            jumping with su from one account to another for example).
+            The check will be done against the real uid of the calling process,
+            instead of trying to obtain the user from the login session
+            associated with the terminal in use.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_wheel/pam_wheel.c
+++ b/modules/pam_wheel/pam_wheel.c
@@ -141,6 +141,16 @@ perform_check (pam_handle_t *pamh, int ctrl, const char *use_group)
     } else {
         fromsu = pam_modutil_getlogin(pamh);
 
+        /* if getlogin fails try a fallback to PAM_RUSER */
+        if (fromsu == NULL) {
+            const char *rhostname;
+
+            retval = pam_get_item(pamh, PAM_RHOST, (const void **)&rhostname);
+            if (retval != PAM_SUCCESS || rhostname == NULL) {
+                retval = pam_get_item(pamh, PAM_RUSER, (const void **)&fromsu);
+            }
+        }
+
         if (fromsu != NULL) {
             tpwd = pam_modutil_getpwnam (pamh, fromsu);
         }

--- a/modules/pam_wheel/pam_wheel.c
+++ b/modules/pam_wheel/pam_wheel.c
@@ -130,25 +130,27 @@ perform_check (pam_handle_t *pamh, int ctrl, const char *use_group)
     }
 
     if (ctrl & PAM_USE_UID_ARG) {
-	tpwd = pam_modutil_getpwuid (pamh, getuid());
-	if (!tpwd) {
-	    if (ctrl & PAM_DEBUG_ARG) {
+        tpwd = pam_modutil_getpwuid (pamh, getuid());
+        if (tpwd == NULL) {
+            if (ctrl & PAM_DEBUG_ARG) {
                 pam_syslog(pamh, LOG_NOTICE, "who is running me ?!");
-	    }
-	    return PAM_SERVICE_ERR;
-	}
-	fromsu = tpwd->pw_name;
+            }
+            return PAM_SERVICE_ERR;
+        }
+        fromsu = tpwd->pw_name;
     } else {
-	fromsu = pam_modutil_getlogin(pamh);
-	if (fromsu) {
-	    tpwd = pam_modutil_getpwnam (pamh, fromsu);
-	}
-	if (!fromsu || !tpwd) {
-	    if (ctrl & PAM_DEBUG_ARG) {
-		pam_syslog(pamh, LOG_NOTICE, "who is running me ?!");
-	    }
-	    return PAM_SERVICE_ERR;
-	}
+        fromsu = pam_modutil_getlogin(pamh);
+
+        if (fromsu != NULL) {
+            tpwd = pam_modutil_getpwnam (pamh, fromsu);
+        }
+
+        if (fromsu == NULL || tpwd == NULL) {
+            if (ctrl & PAM_DEBUG_ARG) {
+                pam_syslog(pamh, LOG_NOTICE, "who is running me ?!");
+            }
+            return PAM_SERVICE_ERR;
+        }
     }
 
     /*


### PR DESCRIPTION
modules/pam_wheel/pam_wheel.c: if getlogin fails to obtain the real user
ID, then try with PAM_RUSER. Besides, improve indentation.
modules/pam_wheel/pam_wheel.8.xml: indicate that use_uid option uses the
real uid of the calling process.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1866866