### PR TITLE
Prevent SEGFAULT for unknown UID

### DIFF
--- a/modules/pam_unix/unix_chkpwd.c
+++ b/modules/pam_unix/unix_chkpwd.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 	  user = getuidname(getuid());
 	  /* if the caller specifies the username, verify that user
 	     matches it */
-	  if (strcmp(user, argv[1])) {
+	  if (user == NULL || strcmp(user, argv[1])) {
 	    user = argv[1];
 	    /* no match -> permanently change to the real user and proceed */
 	    if (setuid(getuid()) != 0)


### PR DESCRIPTION
When running systemd service with DynamicUser being set, the dynamic UID
might be not mapped to user name (/etc/nsswitch.conf is not configured
with systemd nss module).

The getuidname() routine might return NULL and this is not checked by callee.

Signed-off-by: Anton D. Kachalov <rnouse@google.com>