### PR TITLE
pam_motd: unset prompt value to drop privileges

### DIFF
--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -288,7 +288,7 @@ static int drop_privileges(pam_handle_t *pamh, struct pam_modutil_privs *privs)
     const char *username;
     int retval;
 
-    retval = pam_get_user(pamh, &username, "key user");
+    retval = pam_get_user(pamh, &username, NULL);
 
     if (retval == PAM_SUCCESS) {
         pw = pam_modutil_getpwnam (pamh, username);


### PR DESCRIPTION
modules/pam_motd/pam_motd.c: set NULL value instead of "key user" for the
prompt when dropping privileges.