### PR TITLE
3 covscan issues

### DIFF
--- a/libpam/pam_dispatch.c
+++ b/libpam/pam_dispatch.c
@@ -424,7 +424,6 @@ int _pam_dispatch(pam_handle_t *pamh, int flags, int choice)
     /* call the list of module functions */
     pamh->choice = choice;
     retval = _pam_dispatch_aux(pamh, flags, h, resumed, use_cached_chain);
-    resumed = PAM_FALSE;
 
     __PAM_TO_APP(pamh);
 

--- a/modules/pam_faillock/main.c
+++ b/modules/pam_faillock/main.c
@@ -157,7 +157,7 @@ do_user(struct options *opts, const char *user)
 		unsigned int i;
 
 		memset(&tallies, 0, sizeof(tallies));
-		if ((rv=read_tally(fd, &tallies)) == -1) {
+		if (read_tally(fd, &tallies) == -1) {
 			fprintf(stderr, "%s: Error reading the tally file for %s:",
 				opts->progname, user);
 			perror(NULL);

--- a/modules/pam_ftp/pam_ftp.c
+++ b/modules/pam_ftp/pam_ftp.c
@@ -133,6 +133,8 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	retval = pam_set_item(pamh, PAM_USER, (const void *)anon_user);
 	if (retval != PAM_SUCCESS || anon_user == NULL) {
 	    pam_syslog(pamh, LOG_ERR, "user resetting failed");
+	    free(anon_user);
+
 	    return PAM_USER_UNKNOWN;
 	}
 	free(anon_user);


### PR DESCRIPTION
libpam/pam_dispatch: remove store statement since the value is never
read.

modules/pam_faillock/main.c: remove store statement since the value is
only read in the enclosing expression.

modules/pam_ftp/pam_ftp.c: free anon_user before returning as it may be
still in use.