### PR TITLE
pam_env: allow environment files without EOL at EOF

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -311,7 +311,7 @@ static int _assemble_line(FILE *f, char *buffer, int buf_len)
 	    D(("_assemble_line: corrupted or binary file"));
 	    return -1;
 	}
-	if (p[strlen(p)-1] != '\n') {
+	if (p[strlen(p)-1] != '\n' && !feof(f)) {
 	    D(("_assemble_line: line too long"));
 	    return -1;
 	}


### PR DESCRIPTION
Fixes #263

* modules/pam_env/pam_env.c (_assemble_line): Do not error out if at feof()