### PR TITLE
pam_env: deprecation notice of reading the user environment

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ Release 1.5.0
 * Removed deprecated pam_cracklib module, use pam_passwdqc (from passwdqc project)
   or pam_pwquality (from libpwquality project) instead.
 * Removed deprecated pam_tally and pam_tally2 modules, use pam_faillock instead.
+* pam_env: Reading of the user environment is deprecated and will be removed
+	   at some point in the future.
 
 Release 1.4.0
 * Multiple minor bug fixes and documentation improvements

--- a/modules/pam_env/pam_env.8.xml
+++ b/modules/pam_env/pam_env.8.xml
@@ -163,6 +163,11 @@
             behavior of subsequent modules in the stack without the consent
             of the system administrator.
           </para>
+          <para>
+            Due to problematic security this functionality is deprecated
+            since the 1.5.0 version and will be removed completely at some
+            point in the future.
+          </para>
         </listitem>
       </varlistentry>
 

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -120,6 +120,9 @@ _pam_parse (const pam_handle_t *pamh, int argc, const char **argv,
 	  pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
     }
 
+    if (*user_readenv)
+	pam_syslog(pamh, LOG_DEBUG, "deprecated reading of user environment enabled");
+
     return ctrl;
 }
 


### PR DESCRIPTION
* modules/pam_env/pam_env.8.xml: Add the notice to the manual.
* modules/pam_env/pam_env.c (_pam_parse): Log deprecation warning
  if debug enabled.

Or should the deprecation warning be there also without the debug arg?