### PR TITLE
libpam: add supplementary groups on priv drop

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ Release 1.5.0
 * Removed deprecated pam_tally and pam_tally2 modules, use pam_faillock instead.
 * pam_env: Reading of the user environment is deprecated and will be removed
 	   at some point in the future.
+* libpam: pam_modutil_drop_priv() now correctly sets the target user's
+          supplementary groups, allowing pam_motd to filter messages accordingly
 
 Release 1.4.0
 * Multiple minor bug fixes and documentation improvements


### PR DESCRIPTION
Replace the setgroups(0, NULL) call in pam_modutil_drop_priv() with a
call to initgroups().  This makes sure that the user's supplementary
groups are also configured.

This fixes the permission check in pam_motd: this feature was intended
to allow setting permissions on a motd file to prevent it from being
shown to users who are not a member of a particular group (for example,
wheel).