### PR TITLE
Fix memory leak that occurs in a rare situations

### DIFF
--- a/modules/pam_unix/bigcrypt.c
+++ b/modules/pam_unix/bigcrypt.c
@@ -111,6 +111,9 @@ char *bigcrypt(const char *key, const char *salt)
 #endif
 	if (tmp_ptr == NULL) {
 		free(dec_c2_cryptbuf);
+#ifdef HAVE_CRYPT_R
+		free(cdata);
+#endif
 		return NULL;
 	}
 	/* and place in the static area */
@@ -137,6 +140,9 @@ char *bigcrypt(const char *key, const char *salt)
 			if (tmp_ptr == NULL) {
 				_pam_overwrite(dec_c2_cryptbuf);
 				free(dec_c2_cryptbuf);
+#ifdef HAVE_CRYPT_R
+				free(cdata);
+#endif
 				return NULL;
 			}
 


### PR DESCRIPTION
If crypt_r() fails do not leak cdata.

Bug found with Muse.dev CI tool (specifically, the Infer static analyzer).  Muse's full results are [available](https://console.muse.dev/result/TomMD/linux-pam/01EQY5Q0JNQS8QPHRM5Z6EH7BK?search=bigc&tab=results) but if you are interested I could make a PR adding [the Muse CI configuration](https://github.com/TomMD/linux-pam/tree/master/.muse) to run Infer on each pull request and produce a github comment if there are any new bugs.