### PR TITLE
Add muse CI configuration

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,0 +1,2 @@
+setup = ".muse/setup.sh"
+build = "make"

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+apt update && apt install -y autopoint
+sed -i 's/libxcrypt-dev//' ./ci/install-dependencies.sh
+./ci/install-dependencies.sh
+./autogen.sh
+./configure --disable-doc --disable-dependency-tracking


### PR DESCRIPTION
Muse is a new CI service (disclaimer: founder here) to automate and remove a lot of the boilerplate involved in running code analysis.  Open source tools like error prone, infer, semgrep, and cobra can be run via Muse with a lot less difficulty than a from-scratch attempt on most repos. 

For pam the run isn't entirely automated - most C projects have dependencies after all - but once we get things compiling on ubuntu 20.04 it "just works" and [produces results like these](https://console.muse.dev/result/TomMD/linux-pam/01ER0ZDWTW62XG94TWSDAA2ST6).  The intent isn't for developers to read the console unless they are doing bug triage.  Normal PR workflow proceeds as normal and Muse will [comment with any new bugs](https://github.com/curl/curl/pull/5971#discussion_r490252196).

If this would be helpful then [the installation is via github](https://github.com/marketplace/muse-dev).  And conversely if it isn't helpful (or interesting) then I'm all ears for your thoughts and feedback.