### PR TITLE
Clarify the effect of 'done' in documentation

### DIFF
--- a/doc/man/pam.conf-syntax.xml
+++ b/doc/man/pam.conf-syntax.xml
@@ -273,8 +273,9 @@
         <term>die</term>
         <listitem>
            <para>
-             equivalent to bad with the side effect of terminating the
-             module stack and PAM immediately returning to the application.
+             equivalent to <emphasis>bad</emphasis> with the side effect of
+             terminating the module stack and PAM immediately returning to
+             the application.
           </para>
         </listitem>
       </varlistentry>
@@ -297,8 +298,9 @@
         <term>done</term>
         <listitem>
            <para>
-             equivalent to ok with the side effect of terminating the module
-             stack and PAM immediately returning to the application.
+             equivalent to <emphasis>ok</emphasis> with the side effect of
+             terminating the module stack and PAM immediately returning to the
+             application unless there was a non-ignored module failure before.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
The done action does not terminate the stack processing in case
there is a failing module with bad action up in the stack.

* doc/man/pam.conf-syntax.xml: Clarify the effect of 'done'.

Fixes #307