### PR TITLE
check for string_to_security_class failure 

### DIFF
--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -844,6 +844,12 @@ static int form_context(const struct polydir_s *polyptr,
 
 	if (polyptr->method == CONTEXT) {
 		tclass = string_to_security_class("dir");
+		if (tclass == 0) {
+			pam_syslog(idata->pamh, LOG_ERR,
+				   "Error getting dir security class");
+			freecon(scon);
+			return PAM_SESSION_ERR;
+		}
 
 		if (security_compute_member(scon, *origcon, tclass,
 					i_context) < 0) {


### PR DESCRIPTION
Check for the unlikely case [`string_to_security_class(3)`](https://manpages.debian.org/unstable/libselinux1-dev/string_to_security_class.3.en.html) does not find the
associated SELinux security class.
This will only happen if the loaded SELinux policy does not define the
class (which no sane policy does) or querying the selinuxfs
fails.

Suggested by #309