### PR TITLE
pam_setquota: Minor whitespace, spelling and mail address fixes

### DIFF
--- a/modules/pam_setquota/pam_setquota.8.xml
+++ b/modules/pam_setquota/pam_setquota.8.xml
@@ -109,7 +109,7 @@
             <para>
              Describe the start of the UID range the policy is applied to.
              (Defaults to UID_MIN from login.defs or the uidmin value defined
-             at compile-time if UID_MIN is undefined)
+             at compile-time if UID_MIN is undefined.)
             </para>
           </listitem>
         </varlistentry>
@@ -292,9 +292,9 @@
        Ruslan Savchenko &lt;savrus@mexmat.net&gt;.
       </para>
       <para>
-       Further modifications were made by Shane Tzen&lt;shane@ict.usc.edu&gt;,
-       Sven Hartge &lt;sven@svenharte.de&gt;
-       and Keller Fuchs &lt;kellerfuchs@hashbang.sh&gt;
+       Further modifications were made by Shane Tzen &lt;shane@ict.usc.edu&gt;,
+       Sven Hartge &lt;sven@svenhartge.de&gt;
+       and Keller Fuchs &lt;kellerfuchs@hashbang.sh&gt;.
       </para>
   </refsect1>
 


### PR DESCRIPTION
I noticed some very minor errors in the pam_setquota.8 man-page, for example I somehow managed to mistype my own name in my mail address.

This PR fixes this, a missing . and some whitespace issues.