### PR TITLE
faillock: create dir before create tally file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -613,6 +613,16 @@ test -n "$opt_kerneloverflowuid" ||
           opt_kerneloverflowuid=65534
 AC_DEFINE_UNQUOTED(PAM_USERTYPE_OVERFLOW_UID, $opt_kerneloverflowuid, [Kernel overflow uid.])
 
+AC_ARG_WITH([systemdunitdir],
+AS_HELP_STRING([--with-systemdunitdir=DIR], [path to systemd service directory]),
+    [],
+    [
+    PKG_CHECK_EXISTS([systemd],
+      [with_systemdunitdir=$($PKG_CONFIG --variable=systemdunitdir systemd)],
+      [with_systemdunitdir='${prefix}/lib/systemd/system'])
+    ])
+AC_SUBST([systemdunitdir], [$with_systemdunitdir])
+
 AC_ARG_ENABLE([unix],
               [AS_HELP_STRING([--disable-unix],
                               [do not build pam_unix module])],

--- a/modules/pam_faillock/faillock.c
+++ b/modules/pam_faillock/faillock.c
@@ -74,6 +74,9 @@ open_tally (const char *dir, const char *user, uid_t uid, int create)
 
 	if (create) {
 		flags |= O_CREAT;
+		if (access(dir, F_OK) != 0) {
+			mkdir(dir, 0755);
+		}
 	}
 
 	fd = open(path, flags, 0660);

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -18,7 +18,7 @@ TESTS = $(dist_check_SCRIPTS)
 securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 namespaceddir = $(SCONFIGDIR)/namespace.d
-servicedir = $(prefix)/lib/systemd/system
+servicedir = $(systemdunitdir)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
         -DSECURECONF_DIR=\"$(SCONFIGDIR)/\" $(WARN_CFLAGS)


### PR DESCRIPTION
the default tallydir is "/var/run/faillock", and usually,
/var/run is mounted on tempfs. so faillock maybe not existed.
When we set flag to O_CREAT, and hope to create tallyfile,
but since the dir is not existed, open function will failed,
and faillock not works well. so fixed by when we want to create
tallyfile, and the dir is not existed, create it first.

Signed-off-by: Changqing Li <changqing.li@windriver.com>