### PR TITLE
man: fix build if man pages cannot be re-generated

### DIFF
--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -7,24 +7,6 @@ MAINTAINERCLEANFILES = $(MANS)
 
 EXTRA_DIST = $(MANS) $(XMLS)
 
-man_MANS = pam.3 PAM.8 pam.8 pam.conf.5 pam.d.5 \
-	pam_acct_mgmt.3 pam_authenticate.3 \
-	pam_chauthtok.3 pam_close_session.3 pam_conv.3 \
-	pam_end.3 pam_error.3 \
-	pam_fail_delay.3 pam_xauth_data.3 \
-	pam_get_authtok.3 pam_get_authtok_noverify.3 pam_get_authtok_verify.3 \
-	pam_get_data.3 pam_get_item.3 pam_get_user.3 \
-	pam_getenv.3 pam_getenvlist.3 \
-	pam_info.3 \
-	pam_open_session.3 \
-	pam_prompt.3 pam_putenv.3 \
-	pam_set_data.3 pam_set_item.3 pam_syslog.3 \
-	pam_setcred.3 pam_sm_acct_mgmt.3 pam_sm_authenticate.3 \
-	pam_sm_close_session.3 pam_sm_open_session.3 pam_sm_setcred.3 \
-	pam_sm_chauthtok.3 pam_start.3 pam_strerror.3 \
-	pam_verror.3 pam_vinfo.3 pam_vprompt.3 pam_vsyslog.3 \
-	misc_conv.3 pam_misc_paste_env.3 pam_misc_drop_env.3 \
-	pam_misc_setenv.3
 XMLS = pam.3.xml pam.8.xml \
 	pam_acct_mgmt.3.xml pam_authenticate.3.xml \
 	pam_chauthtok.3.xml pam_close_session.3.xml pam_conv.3.xml \
@@ -46,6 +28,25 @@ XMLS = pam.3.xml pam.8.xml \
 	pam_misc_setenv.3.xml
 
 if ENABLE_REGENERATE_MAN
+man_MANS = pam.3 PAM.8 pam.8 pam.conf.5 pam.d.5 \
+	pam_acct_mgmt.3 pam_authenticate.3 \
+	pam_chauthtok.3 pam_close_session.3 pam_conv.3 \
+	pam_end.3 pam_error.3 \
+	pam_fail_delay.3 pam_xauth_data.3 \
+	pam_get_authtok.3 pam_get_authtok_noverify.3 pam_get_authtok_verify.3 \
+	pam_get_data.3 pam_get_item.3 pam_get_user.3 \
+	pam_getenv.3 pam_getenvlist.3 \
+	pam_info.3 \
+	pam_open_session.3 \
+	pam_prompt.3 pam_putenv.3 \
+	pam_set_data.3 pam_set_item.3 pam_syslog.3 \
+	pam_setcred.3 pam_sm_acct_mgmt.3 pam_sm_authenticate.3 \
+	pam_sm_close_session.3 pam_sm_open_session.3 pam_sm_setcred.3 \
+	pam_sm_chauthtok.3 pam_start.3 pam_strerror.3 \
+	pam_verror.3 pam_vinfo.3 pam_vprompt.3 pam_vsyslog.3 \
+	misc_conv.3 pam_misc_paste_env.3 pam_misc_drop_env.3 \
+	pam_misc_setenv.3
+
 PAM.8: pam.8
 pam_get_authtok_noverify.3: pam_get_authtok.3
 pam_get_authtok_verify.3: pam_get_authtok.3

--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = access.conf.5 pam_access.8
-endif
 XMLS = README.xml access.conf.5.xml pam_access.8.xml
 dist_check_SCRIPTS = tst-pam_access
 TESTS = $(dist_check_SCRIPTS)
@@ -31,6 +28,7 @@ pam_access_la_LIBADD = $(top_builddir)/libpam/libpam.la
 dist_secureconf_DATA = access.conf
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = access.conf.5 pam_access.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_debug/Makefile.am
+++ b/modules/pam_debug/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_debug.8
-endif
 XMLS = README.xml pam_debug.8.xml
 dist_check_SCRIPTS = tst-pam_debug
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_debug-retval
 tst_pam_debug_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_debug.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_deny/Makefile.am
+++ b/modules/pam_deny/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_deny.8
-endif
 XMLS = README.xml pam_deny.8.xml
 dist_check_SCRIPTS = tst-pam_deny
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_deny-retval
 tst_pam_deny_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_deny.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_echo/Makefile.am
+++ b/modules/pam_echo/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_echo.8
-endif
 XMLS = README.xml pam_echo.8.xml
 dist_check_SCRIPTS = tst-pam_echo
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_echo-retval
 tst_pam_echo_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_echo.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_env.conf.5 pam_env.8 environment.5
-endif
 XMLS = README.xml pam_env.conf.5.xml pam_env.8.xml
 dist_check_SCRIPTS = tst-pam_env
 TESTS = $(dist_check_SCRIPTS)
@@ -31,6 +28,7 @@ dist_secureconf_DATA = pam_env.conf
 dist_sysconf_DATA = environment
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_env.conf.5 pam_env.8 environment.5
 dist_noinst_DATA = README
 environment.5: pam_env.conf.5.xml
 -include $(top_srcdir)/Make.xml.rules

--- a/modules/pam_exec/Makefile.am
+++ b/modules/pam_exec/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_exec.8
-endif
 XMLS = README.xml pam_exec.8.xml
 dist_check_SCRIPTS = tst-pam_exec
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_exec.la
 pam_exec_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_exec.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_faildelay/Makefile.am
+++ b/modules/pam_faildelay/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_faildelay.8
-endif
 XMLS = README.xml pam_faildelay.8.xml
 dist_check_SCRIPTS = tst-pam_faildelay
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_faildelay-retval
 tst_pam_faildelay_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_faildelay.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_faillock/Makefile.am
+++ b/modules/pam_faillock/Makefile.am
@@ -9,9 +9,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_faillock.8 faillock.8 faillock.conf.5
-endif
 XMLS = README.xml pam_faillock.8.xml faillock.8.xml faillock.conf.5.xml
 
 dist_check_SCRIPTS = tst-pam_faillock
@@ -45,6 +42,7 @@ pam_faillock_la_SOURCES = pam_faillock.c faillock.c
 faillock_SOURCES = main.c faillock.c
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_faillock.8 faillock.8 faillock.conf.5
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_filter/Makefile.am
+++ b/modules/pam_filter/Makefile.am
@@ -9,9 +9,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_filter.8
-endif
 XMLS = README.xml pam_filter.8.xml
 dist_check_SCRIPTS = tst-pam_filter
 TESTS = $(dist_check_SCRIPTS)
@@ -32,6 +29,7 @@ pam_filter_la_LIBADD = $(top_builddir)/libpam/libpam.la
 securelib_LTLIBRARIES = pam_filter.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_filter.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_ftp/Makefile.am
+++ b/modules/pam_ftp/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_ftp.8
-endif
 XMLS = README.xml pam_ftp.8.xml
 dist_check_SCRIPTS = tst-pam_ftp
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_ftp.la
 pam_ftp_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_ftp.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = group.conf.5 pam_group.8
-endif
 XMLS = README.xml group.conf.5.xml pam_group.8.xml
 dist_check_SCRIPTS = tst-pam_group
 TESTS = $(dist_check_SCRIPTS)
@@ -30,6 +27,7 @@ pam_group_la_LIBADD = $(top_builddir)/libpam/libpam.la
 dist_secureconf_DATA = group.conf
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = group.conf.5 pam_group.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_issue/Makefile.am
+++ b/modules/pam_issue/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_issue.8
-endif
 XMLS = README.xml pam_issue.8.xml
 dist_check_SCRIPTS = tst-pam_issue
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_issue.la
 pam_issue_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_issue.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_keyinit/Makefile.am
+++ b/modules/pam_keyinit/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS =  pam_keyinit.8
-endif
 XMLS = README.xml pam_keyinit.8.xml
 dist_check_SCRIPTS = tst-pam_keyinit
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_keyinit.la
 pam_keyinit_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS =  pam_keyinit.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_lastlog/Makefile.am
+++ b/modules/pam_lastlog/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_lastlog.8
-endif
 XMLS = README.xml pam_lastlog.8.xml
 dist_check_SCRIPTS = tst-pam_lastlog
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_lastlog.la
 pam_lastlog_la_LIBADD = $(top_builddir)/libpam/libpam.la -lutil
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_lastlog.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = limits.conf.5 pam_limits.8
-endif
 XMLS = README.xml limits.conf.5.xml pam_limits.8.xml
 dist_check_SCRIPTS = tst-pam_limits
 TESTS = $(dist_check_SCRIPTS)
@@ -35,6 +32,7 @@ install-data-local:
 	mkdir -p $(DESTDIR)$(limits_conf_dir)
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = limits.conf.5 pam_limits.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_listfile/Makefile.am
+++ b/modules/pam_listfile/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_listfile.8
-endif
 XMLS = README.xml pam_listfile.8.xml
 dist_check_SCRIPTS = tst-pam_listfile
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_listfile.la
 pam_listfile_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_listfile.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_localuser/Makefile.am
+++ b/modules/pam_localuser/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_localuser.8
-endif
 XMLS = README.xml pam_localuser.8.xml
 dist_check_SCRIPTS = tst-pam_localuser
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_localuser-retval
 tst_pam_localuser_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_localuser.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_loginuid/Makefile.am
+++ b/modules/pam_loginuid/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_loginuid.8
-endif
 XMLS = README.xml pam_loginuid.8.xml
 dist_check_SCRIPTS = tst-pam_loginuid
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_loginuid.la
 pam_loginuid_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBAUDIT@
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_loginuid.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_mail/Makefile.am
+++ b/modules/pam_mail/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_mail.8
-endif
 XMLS = README.xml pam_mail.8.xml
 dist_check_SCRIPTS = tst-pam_mail
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_mail.la
 pam_mail_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_mail.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_mkhomedir/Makefile.am
+++ b/modules/pam_mkhomedir/Makefile.am
@@ -8,9 +8,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_mkhomedir.8 mkhomedir_helper.8
-endif
 XMLS = README.xml pam_mkhomedir.8.xml mkhomedir_helper.8.xml
 dist_check_SCRIPTS = tst-pam_mkhomedir
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -39,6 +36,7 @@ check_PROGRAMS = tst-pam_mkhomedir-retval
 tst_pam_mkhomedir_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_mkhomedir.8 mkhomedir_helper.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_motd/Makefile.am
+++ b/modules/pam_motd/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_motd.8
-endif
 XMLS = README.xml pam_motd.8.xml
 dist_check_SCRIPTS = tst-pam_motd
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_motd.la
 pam_motd_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_motd.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -8,9 +8,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = namespace.conf.5 pam_namespace.8 pam_namespace_helper.8
-endif
 XMLS = README.xml namespace.conf.5.xml pam_namespace.8.xml pam_namespace_helper.8.xml
 dist_check_SCRIPTS = tst-pam_namespace
 TESTS = $(dist_check_SCRIPTS)
@@ -43,6 +40,7 @@ install-data-local:
 sbin_SCRIPTS = pam_namespace_helper
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = namespace.conf.5 pam_namespace.8 pam_namespace_helper.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_nologin/Makefile.am
+++ b/modules/pam_nologin/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_nologin.8
-endif
 XMLS = README.xml pam_nologin.8.xml
 dist_check_SCRIPTS = tst-pam_nologin
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_nologin-retval
 tst_pam_nologin_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_nologin.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_permit/Makefile.am
+++ b/modules/pam_permit/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_permit.8
-endif
 XMLS = README.xml pam_permit.8.xml
 dist_check_SCRIPTS = tst-pam_permit
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_permit-retval
 tst_pam_permit_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_permit.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -8,9 +8,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_pwhistory.8 pwhistory_helper.8
-endif
 XMLS = README.xml pam_pwhistory.8.xml pwhistory_helper.8.xml
 dist_check_SCRIPTS = tst-pam_pwhistory
 TESTS = $(dist_check_SCRIPTS)
@@ -40,6 +37,7 @@ pwhistory_helper_LDFLAGS = @EXE_LDFLAGS@
 pwhistory_helper_LDADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_pwhistory.8 pwhistory_helper.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_rhosts/Makefile.am
+++ b/modules/pam_rhosts/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_rhosts.8
-endif
 XMLS = README.xml pam_rhosts.8.xml
 dist_check_SCRIPTS = tst-pam_rhosts
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_rhosts.la
 pam_rhosts_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_rhosts.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_rootok/Makefile.am
+++ b/modules/pam_rootok/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_rootok.8
-endif
 XMLS = README.xml pam_rootok.8.xml
 dist_check_SCRIPTS = tst-pam_rootok
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_rootok-retval
 tst_pam_rootok_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_rootok.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_securetty/Makefile.am
+++ b/modules/pam_securetty/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_securetty.8
-endif
 XMLS = README.xml pam_securetty.8.xml
 dist_check_SCRIPTS = tst-pam_securetty
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_securetty.la
 pam_securetty_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_securetty.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_setquota/Makefile.am
+++ b/modules/pam_setquota/Makefile.am
@@ -3,9 +3,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_setquota.8
-endif
 XMLS = README.xml pam_setquota.8.xml
 dist_check_SCRIPTS = tst-pam_setquota
 TESTS = $(dist_check_SCRIPTS)
@@ -24,6 +21,7 @@ securelib_LTLIBRARIES = pam_setquota.la
 pam_setquota_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_setquota.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_shells.8
-endif
 XMLS = README.xml pam_shells.8.xml
 dist_check_SCRIPTS = tst-pam_shells
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_shells.la
 pam_shells_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_shells.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_stress/Makefile.am
+++ b/modules/pam_stress/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_stress.8
-endif
 XMLS = README.xml pam_stress.8.xml
 dist_check_SCRIPTS = tst-pam_stress
 TESTS = $(dist_check_SCRIPTS)
@@ -27,6 +24,7 @@ securelib_LTLIBRARIES = pam_stress.la
 pam_stress_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_stress.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_succeed_if/Makefile.am
+++ b/modules/pam_succeed_if/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_succeed_if.8
-endif
 XMLS = README.xml pam_succeed_if.8.xml
 dist_check_SCRIPTS = tst-pam_succeed_if
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_succeed_if.la
 pam_succeed_if_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_succeed_if.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = time.conf.5 pam_time.8
-endif
 XMLS = README.xml time.conf.5.xml pam_time.8.xml
 dist_check_SCRIPTS = tst-pam_time
 TESTS = $(dist_check_SCRIPTS)
@@ -29,6 +26,7 @@ securelib_LTLIBRARIES = pam_time.la
 dist_secureconf_DATA = time.conf
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = time.conf.5 pam_time.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_timestamp/Makefile.am
+++ b/modules/pam_timestamp/Makefile.am
@@ -8,9 +8,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_timestamp.8 pam_timestamp_check.8
-endif
 XMLS = README.xml pam_timestamp.8.xml pam_timestamp_check.8.xml
 dist_check_SCRIPTS = tst-pam_timestamp
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -46,6 +43,7 @@ hmacfile_LDADD = $(top_builddir)/libpam/libpam.la
 check_PROGRAMS = hmacfile
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_timestamp.8 pam_timestamp_check.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_tty_audit/Makefile.am
+++ b/modules/pam_tty_audit/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_tty_audit.8
-endif
 XMLS = README.xml pam_tty_audit.8.xml
 dist_check_SCRIPTS = tst-pam_tty_audit
 TESTS = $(dist_check_SCRIPTS)
@@ -27,6 +24,7 @@ pam_tty_audit_la_LIBADD = $(top_builddir)/libpam/libpam.la
 securelib_LTLIBRARIES = pam_tty_audit.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_tty_audit.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_umask/Makefile.am
+++ b/modules/pam_umask/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_umask.8
-endif
 XMLS = README.xml pam_umask.8.xml
 dist_check_SCRIPTS = tst-pam_umask
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_umask.la
 pam_umask_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_umask.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = md5.c md5_crypt.c lckpwdf.-c $(XMLS) CHANGELOG
 
-if HAVE_DOC
-dist_man_MANS = pam_unix.8 unix_chkpwd.8 unix_update.8
-endif
 XMLS = README.xml pam_unix.8.xml unix_chkpwd.8.xml unix_update.8.xml
 dist_check_SCRIPTS = tst-pam_unix
 TESTS = $(dist_check_SCRIPTS)
@@ -58,6 +55,7 @@ unix_update_LDFLAGS = @EXE_LDFLAGS@
 unix_update_LDADD = @LIBCRYPT@ @LIBSELINUX@
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_unix.8 unix_chkpwd.8 unix_update.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_userdb/Makefile.am
+++ b/modules/pam_userdb/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS) create.pl
 
-if HAVE_DOC
-dist_man_MANS = pam_userdb.8
-endif
 XMLS = README.xml pam_userdb.8.xml
 dist_check_SCRIPTS = tst-pam_userdb
 TESTS = $(dist_check_SCRIPTS)
@@ -30,6 +27,7 @@ pam_userdb_la_LIBADD = $(top_builddir)/libpam/libpam.la
 noinst_HEADERS = pam_userdb.h
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_userdb.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_usertype/Makefile.am
+++ b/modules/pam_usertype/Makefile.am
@@ -8,9 +8,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_usertype.8
-endif
 XMLS = README.xml pam_usertype.8.xml
 dist_check_SCRIPTS = tst-pam_usertype
 TESTS = $(dist_check_SCRIPTS)
@@ -29,6 +26,7 @@ securelib_LTLIBRARIES = pam_usertype.la
 pam_usertype_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_usertype.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_warn/Makefile.am
+++ b/modules/pam_warn/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_warn.8
-endif
 XMLS = README.xml pam_warn.8.xml
 dist_check_SCRIPTS = tst-pam_warn
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
@@ -31,6 +28,7 @@ check_PROGRAMS = tst-pam_warn-retval
 tst_pam_warn_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_warn.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_wheel/Makefile.am
+++ b/modules/pam_wheel/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_wheel.8
-endif
 XMLS = README.xml pam_wheel.8.xml
 dist_check_SCRIPTS = tst-pam_wheel
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_wheel.la
 pam_wheel_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_wheel.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif

--- a/modules/pam_xauth/Makefile.am
+++ b/modules/pam_xauth/Makefile.am
@@ -7,9 +7,6 @@ MAINTAINERCLEANFILES = $(MANS) README
 
 EXTRA_DIST = $(XMLS)
 
-if HAVE_DOC
-dist_man_MANS = pam_xauth.8
-endif
 XMLS = README.xml pam_xauth.8.xml
 dist_check_SCRIPTS = tst-pam_xauth
 TESTS = $(dist_check_SCRIPTS)
@@ -28,6 +25,7 @@ securelib_LTLIBRARIES = pam_xauth.la
 pam_xauth_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBSELINUX@
 
 if ENABLE_REGENERATE_MAN
+dist_man_MANS = pam_xauth.8
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules
 endif


### PR DESCRIPTION
Build stops with error if man pages cannot be regenerated from XML
sources (e.g. DocBook stylesheets check fails) or if the following
options have been passed to configure:
```
./autogen.sh &&
./configure --enable-doc --disable-regenerate-docu &&
make -j8
...
make[3]: *** No rule to make target 'pam_unix.8', needed by 'all-am'.  Stop.
make[3]: Leaving directory '/tmp/m/bp/modules/pam_unix'
make[2]: *** [Makefile:490: all-recursive] Error 1
make[2]: Leaving directory '/tmp/m/bp/modules'
make[1]: *** [Makefile:489: all-recursive] Error 1
make[1]: Leaving directory '/tmp/m/bp'
make: *** [Makefile:419: all] Error 2
```
The patch fixes this issue and seems doesn't break other combinations:
```
enable-doc   enable-regenerate-docu  OK
enable-doc  disable-regenerate-docu  OK (fails without the patch)
disable-doc  enable-regenerate-docu  OK
disable-doc disable-regenerate-docu  OK
```
Please review.
