### PR TITLE
Faillock: Use pluralization via dngettext or fallback

### DIFF
--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -620,7 +620,22 @@ faillock_message(pam_handle_t *pamh, struct options *opts)
 		if (left > 0) {
 			left = (left + 59)/60; /* minutes */
 
-			pam_info(pamh, _("(%d minutes left to unlock)"), (int)left);
+#if defined HAVE_DNGETTEXT && defined ENABLE_NLS
+			pam_info(
+				pamh,
+				dngettext(PACKAGE,
+					"(%d minute left to unlock)",
+					"(%d minutes left to unlock)",
+					(int)left),
+				(int)left);
+#else
+			if (left == 1)
+				/* TRANSLATORS: only used if dngettext is not supported. */
+				pam_info(pamh, _("(%d minute left to unlock)"), (int)left);
+			else
+				/* TRANSLATORS: only used if dngettext is not supported. */
+				pam_info(pamh, _("(%d minutes left to unlock)"), (int)left);
+#endif
 		}
 	}
 }


### PR DESCRIPTION
Haven't done C in a long time, so I might need some help / CI checks with this :)

Fixes https://github.com/linux-pam/linux-pam/issues/322#issuecomment-764192605