### PR TITLE
pam_securetty: don't complain about missing config

### DIFF
--- a/modules/pam_securetty/pam_securetty.c
+++ b/modules/pam_securetty/pam_securetty.c
@@ -111,7 +111,8 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
 #ifdef VENDORDIR
       if (errno == ENOENT) {
 	if (stat(SECURETTY2_FILE, &ttyfileinfo)) {
-	  pam_syslog(pamh, LOG_NOTICE,
+	  if (ctrl & PAM_DEBUG_ARG)
+	    pam_syslog(pamh, LOG_DEBUG,
 		     "Couldn't open %s: %m", SECURETTY2_FILE);
 	  return PAM_SUCCESS; /* for compatibility with old securetty handling,
 				 this needs to succeed.  But we still log the
@@ -120,7 +121,8 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
 	securettyfile = SECURETTY2_FILE;
       } else {
 #endif
-	pam_syslog(pamh, LOG_NOTICE, "Couldn't open %s: %m", SECURETTY_FILE);
+	if (ctrl & PAM_DEBUG_ARG)
+	  pam_syslog(pamh, LOG_DEBUG, "Couldn't open %s: %m", SECURETTY_FILE);
 	return PAM_SUCCESS; /* for compatibility with old securetty handling,
 			       this needs to succeed.  But we still log the
 			       error. */


### PR DESCRIPTION
Not shipping a config file should be perfectly valid for distros while
still having eg login pre-configured to honor securetty when present.
PAM itself doesn't ship any template either. So avoid spamming the log
file if /etc/securetty wasn't found.