### PR TITLE
pam_access: handle the 'LOCAL' keyword more securely

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -623,6 +623,8 @@ from_match (pam_handle_t *pamh UNUSED, char *tok, struct login_info *item)
     } else if (item->from_remote_host == 0) {	/* local: no PAM_RHOSTS */
 	if (strcasecmp(tok, "LOCAL") == 0)
 	    return (YES);
+    } else if (strcasecmp(tok, "LOCAL") == 0) {
+        return NO;
     } else if (tok[(tok_len = strlen(tok)) - 1] == '.') {
       struct addrinfo hint;
 


### PR DESCRIPTION
Previously, for remote connections (e.g. SSH) it slipped through to 'network_netmask_match', where it was rejected just luckily, because it does does not mach a netmask pattern or an IP address.

This can become a security issue, when Linux vendors extend 'network_netmask_match', e.g. with hostname resolution (like SUSE did in SLES 15). So better prefer the code to be locally correct.