### PR TITLE
"Unlimited" is not a valid value for RLIMIT_NOFILE.

### DIFF
--- a/modules/pam_limits/limits.conf.5.xml
+++ b/modules/pam_limits/limits.conf.5.xml
@@ -283,6 +283,8 @@
       <emphasis>unlimited</emphasis> or <emphasis>infinity</emphasis> indicating no limit,
       except for <emphasis remap='B'>priority</emphasis>, <emphasis remap='B'>nice</emphasis>,
       and <emphasis remap='B'>nonewprivs</emphasis>.
+      If <emphasis remap='B'>nofile</emphasis> is to be set to one of these values,
+      it will be set to the contents of /proc/sys/fs/nr_open instead (see setrlimit(3)).
     </para>
     <para>
       If a hard limit or soft limit of a resource is set to a valid value,

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -714,7 +714,7 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 		pam_syslog(pamh, LOG_WARNING,
 			   "Cannot set \"nofile\" to a sensible value");
 	    else if (ctrl & PAM_DEBUG_ARG)
-		pam_syslog(pamh, LOG_DEBUG, "Setting \"nofile\" limit to %lu", (long unsigned) rlimit_value);
+		pam_syslog(pamh, LOG_DEBUG, "Setting \"nofile\" limit to %llu", (unsigned long long) rlimit_value);
 	}
 	break;
     }

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -507,14 +507,18 @@ value_from_proc_sys_fs(const char *name, rlim_t *valuep)
     if ((fp = fopen(pathname, "r")) != NULL) {
 	if (fgets(buf, sizeof(buf), fp) != NULL) {
 	    char *endptr;
+	    rlim_t value;
 
 #ifdef __USE_FILE_OFFSET64
-	    *valuep = strtoull(buf, &endptr, 10);
+	    value = strtoull(buf, &endptr, 10);
 #else
-	    *valuep = strtoul(buf, &endptr, 10);
+	    value = strtoul(buf, &endptr, 10);
 #endif
 
-	    retval = (endptr != buf);
+	    if (endptr != buf) {
+		*valuep = value;
+		retval = 1;
+	    }
 	}
 
 	fclose(fp);

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -510,7 +510,7 @@ value_from_file(const char *pathname, rlim_t *valuep)
 	    value = strtoull(buf, &endptr, 10);
 	    if (endptr != buf &&
 		(value != ULLONG_MAX || errno == 0) &&
-                (unsigned long long) (rlim_t) value == value)) {
+                (unsigned long long) (rlim_t) value == value) {
 		*valuep = (rlim_t) value;
 		retval = 1;
 	    }

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -711,7 +711,8 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 		pam_syslog(pamh, LOG_WARNING,
 			   "Cannot set \"nofile\" to a sensible value");
 	    else if (ctrl & PAM_DEBUG_ARG)
-		pam_syslog(pamh, LOG_DEBUG, "Setting \"nofile\" limit to %llu", (unsigned long long) rlimit_value);
+		pam_syslog(pamh, LOG_DEBUG, "Setting \"nofile\" limit to %llu",
+			   (unsigned long long) rlimit_value);
 	}
 	break;
     }

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -507,16 +507,14 @@ value_from_proc_sys_fs(const char *name, rlim_t *valuep)
     if ((fp = fopen(pathname, "r")) != NULL) {
 	if (fgets(buf, sizeof(buf), fp) != NULL) {
 	    char *endptr;
-	    rlim_t value;
+	    unsigned long long value;
 
-#ifdef __USE_FILE_OFFSET64
+	    errno = 0;
 	    value = strtoull(buf, &endptr, 10);
-#else
-	    value = strtoul(buf, &endptr, 10);
-#endif
-
-	    if (endptr != buf) {
-		*valuep = value;
+	    if (endptr != buf &&
+		(value != ULLONG_MAX || errno == 0) &&
+                (unsigned long long) (rlim_t) value == value)) {
+		*valuep = (rlim_t) value;
 		retval = 1;
 	    }
 	}

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -488,21 +488,18 @@ static int init_limits(pam_handle_t *pamh, struct pam_limit_s *pl, int ctrl)
 }
 
 /*
- * Read the contents of /proc/sys/fs/<name>
+ * Read the contents of <pathname> and return it in *valuep
  * return 1 if conversion succeeds, result is in *valuep
- * return 0 if conversion fails.
+ * return 0 if conversion fails, *valuep is untouched.
  */
 static int
-value_from_proc_sys_fs(const char *name, rlim_t *valuep)
+value_from_file(const char *pathname, rlim_t *valuep)
 {
-    char pathname[128];
     char buf[128];
     FILE *fp;
     int retval;
 
     retval = 0;
-
-    snprintf(pathname, sizeof(pathname), "/proc/sys/fs/%s", name);
 
     if ((fp = fopen(pathname, "r")) != NULL) {
 	if (fgets(buf, sizeof(buf), fp) != NULL) {
@@ -710,7 +707,7 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 	 * the value in /proc/sys/fs/nr_open instead.
 	 */
 	if (rlimit_value == RLIM_INFINITY) {
-	    if (!value_from_proc_sys_fs("nr_open", &rlimit_value))
+	    if (!value_from_file("/proc/sys/fs/nr_open", &rlimit_value))
 		pam_syslog(pamh, LOG_WARNING,
 			   "Cannot set \"nofile\" to a sensible value");
 	    else if (ctrl & PAM_DEBUG_ARG)

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -711,7 +711,7 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 	    if (!value_from_proc_sys_fs("nr_open", &rlimit_value))
 		pam_syslog(pamh, LOG_WARNING,
 			   "Cannot set \"nofile\" to a sensible value");
-	    else
+	    else if (ctrl & PAM_DEBUG_ARG)
 		pam_syslog(pamh, LOG_DEBUG, "Setting \"nofile\" limit to %lu", (long unsigned) rlimit_value);
 	}
 	break;


### PR DESCRIPTION
pam_limits: Specifying "unlimited" (or any of its synonyms) for "nofile" in the limits.conf file will prevent users to log in as `RLIM_INFINITY` is not a valid value for `RLIMIT_NOFILE` as this exceeds the maximum defined by /proc/sys/fs/nr_open (see `man setrlimit`).
Therefore, if this is given, the contents of /proc/sys/fs/nr_open is used instead as the new limit. If this cannot be read, `RLIM_INFINITY` is used because this is what the user configured.