### PR TITLE
pam_userdb: Prevent garbage characters from db

### DIFF
--- a/modules/pam_userdb/pam_userdb.8.xml
+++ b/modules/pam_userdb/pam_userdb.8.xml
@@ -100,7 +100,8 @@
         </term>
         <listitem>
           <para>
-            Print debug information.
+            Print debug information. Note that password hashes, both from db
+            and computed, will be printed to syslog.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Recently, I debugged some problems stemming from the fact that `db_fetch` output in `.dptr` contained a non-printable character in the end and got passed directly to `crypt_r`. I tested this patch in RHEL-8, but I have no prior experience with pam. I'd be glad for a review.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1791965