### PR TITLE
libpam_misc:misc_conv() buffer length

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -634,9 +634,9 @@ esac
 
 AC_ARG_WITH([misc-conv-bufsize],
 AS_HELP_STRING([--with-misc-conv-bufsize=<number>],
-    [Size of input buffer for libpam_misc's misc_conv() conversation function, default=512]),
+    [Size of input buffer for libpam_misc's misc_conv() conversation function, default=4096]),
     [],
-    [with_misc_conv_bufsize=512])
+    [with_misc_conv_bufsize=4096])
 AC_DEFINE_UNQUOTED(PAM_MISC_CONV_BUFSIZE, $with_misc_conv_bufsize, [libpam_misc misc_conv() buffer size.])
 
 AM_CONDITIONAL([COND_BUILD_PAM_KEYINIT], [test "$have_key_syscalls" = 1])

--- a/configure.ac
+++ b/configure.ac
@@ -632,6 +632,13 @@ case "$enable_unix" in
   *) AC_MSG_ERROR([bad value $enable_unix for --enable-unix option]) ;;
 esac
 
+AC_ARG_WITH([misc-conv-bufsize],
+AS_HELP_STRING([--with-misc-conv-bufsize=<number>],
+    [Size of input buffer for libpam_misc's misc_conv() conversation function, default=512]),
+    [],
+    [with_misc_conv_bufsize=512])
+AC_DEFINE_UNQUOTED(PAM_MISC_CONV_BUFSIZE, $with_misc_conv_bufsize, [libpam_misc misc_conv() buffer size.])
+
 AM_CONDITIONAL([COND_BUILD_PAM_KEYINIT], [test "$have_key_syscalls" = 1])
 AM_CONDITIONAL([COND_BUILD_PAM_LASTLOG], [test "$ac_cv_func_logwtmp" = yes])
 AM_CONDITIONAL([COND_BUILD_PAM_NAMESPACE], [test "$ac_cv_func_unshare" = yes])

--- a/libpam_misc/misc_conv.c
+++ b/libpam_misc/misc_conv.c
@@ -18,7 +18,7 @@
 #include <security/pam_appl.h>
 #include <security/pam_misc.h>
 
-#define INPUTSIZE PAM_MAX_RESP_SIZE          /* maximum length of input+1 */
+#define INPUTSIZE PAM_MISC_CONV_BUFSIZE      /* maximum length of input+1 */
 #define CONV_ECHO_ON  1                            /* types of echo state */
 #define CONV_ECHO_OFF 0
 


### PR DESCRIPTION
# Short version

The `libpam_misc:misc_conv()` password buffer is fixed at 512 bytes long.  This PR is two commits:

1. Add a `--with-misc-conv-bufsize` configure CLI option to allow setting the `misc_conv()` buffer size to an arbitrary value (e.g., 4096), but keep the default length at 512 bytes.
2. Change the default length of the `misc_conv()` buffer to 4096 bytes.

The PR is two commits just to show that the 2nd commit could be omitted if there would be problems increasing the default buffer length.

# More detail

We have an internal use case to use Linux PAM for a cryptographic challenge/response login.  It looks something like this:

```
$ ssh someuser@somehost 
Challenge: ...a very long text blob...
Response: <wait for user input>
```

The user copies the challenge blob to an internal authorization system.  If the user is authorized, a response text blob will be generated (typically ~1KB in length).  The user then pastes the response blob to the `ssh` login "Response:" prompt.  Our PAM module validates the response, and returns PAM_SUCCESS on success, or an appropriate failure code.

This works great in an ssh context, because `sshd` provides its own PAM conversation callback function with a variable-length buffer (specifically: `sshd` does not use `libpam_misc:misc_conv()`).  It can handle ~1KB text blobs, for example.

However, the Linux `login` process -- used for console logins -- uses `libpam_misc:misc_conv()`.  Our challenge-response PAM module therefore fails because `misc_conv()` truncates the conversation response buffer to 512 bytes.  It is worth noting that copy-and-paste is available in some flavors of console login, such as KVM consoles and serial-over-LAN console logins.  Hence, we're interested in making our challenge-response PAM module work properly even for console logins.

If the Linux PAM community is open to the concept, the first commit provides a configure CLI option to set the size of `libpam_misc`'s `misc_conv()` buffer to an arbitrary value, but keeps the default length at 512.  This would be a "good enough" solution for our use case: we can recompile `libpam_misc` for our systems that use this challenge-response mechanism, and possibly even convince Linux distros to also use `--with-misc-conv-bufsize=4096` when building their PAM packages.

But if possible, it would be great if the default `misc_conv()` buffer size could be increased -- e.g., to 4K, as in the second commit.  This would enable us to (eventually) use `libpam_misc` out of the box with any Linux distro that updates to a release that contains this commit.
