### PR TITLE
Add pkgconfig files for libpam, libpam_misc and libpamc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.lo
 *.log
 *.o
+*.pc
 *.pdf
 *.so
 *.trs

--- a/configure.ac
+++ b/configure.ac
@@ -646,6 +646,7 @@ AM_CONDITIONAL([COND_BUILD_PAM_USERDB], [test -n "$LIBDB"])
 dnl Files to be created from when we run configure
 AC_CONFIG_FILES([Makefile libpam/Makefile libpamc/Makefile libpamc/test/Makefile \
 	libpam_misc/Makefile conf/Makefile conf/pam_conv1/Makefile \
+	libpam/pam.pc libpam_misc/pam_misc.pc libpamc/pamc.pc \
 	po/Makefile.in \
 	Make.xml.rules \
 	modules/Makefile \

--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -40,3 +40,7 @@ libpam_la_SOURCES = pam_account.c pam_auth.c pam_data.c pam_delay.c \
 	pam_modutil_getgrgid.c pam_modutil_getpwuid.c pam_modutil_getgrnam.c \
 	pam_modutil_getspnam.c pam_modutil_getlogin.c pam_modutil_ingroup.c \
 	pam_modutil_priv.c pam_modutil_sanitize.c pam_modutil_searchkey.c
+
+# Pkg-config script.
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = pam.pc

--- a/libpam/pam.pc.in
+++ b/libpam/pam.pc.in
@@ -1,0 +1,9 @@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: PAM
+Description: The primary Linux-PAM library. It is used by PAM modules and PAM-aware applications.
+URL: http://www.linux-pam.org/
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lpam

--- a/libpam_misc/Makefile.am
+++ b/libpam_misc/Makefile.am
@@ -20,3 +20,7 @@ libpam_misc_la_LIBADD = $(top_builddir)/libpam/libpam.la
 lib_LTLIBRARIES = libpam_misc.la
 
 libpam_misc_la_SOURCES = help_env.c misc_conv.c
+
+# Pkg-config script.
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = pam_misc.pc

--- a/libpam_misc/pam_misc.pc.in
+++ b/libpam_misc/pam_misc.pc.in
@@ -1,0 +1,9 @@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: pam_misc
+Description: Miscellaneous functions that make the job of writing PAM-aware applications easier.
+URL: http://www.linux-pam.org/
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lpam_misc

--- a/libpamc/Makefile.am
+++ b/libpamc/Makefile.am
@@ -22,3 +22,7 @@ endif
 lib_LTLIBRARIES = libpamc.la
 
 libpamc_la_SOURCES = pamc_client.c pamc_converse.c pamc_load.c
+
+# Pkg-config script.
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = pamc.pc

--- a/libpamc/pamc.pc.in
+++ b/libpamc/pamc.pc.in
@@ -1,0 +1,9 @@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libpamc
+URL: http://www.linux-pam.org/
+Description: The PAM client API library and binary prompt support. Rarely used.
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lpamc


### PR DESCRIPTION
This allow applications and PAM modules to automatically find libpam, libpam_misc and libpamc if they are installed instead of having to manually search for them.

I used the documentation at https://autotools.io/pkgconfig to know how to properly generate the files and looked at other projects to see how to have them be installed.

I didn't add a description to pamc.pc.in as I don't know what exactly this library does and didn't find the documentation for it.