### PR TITLE
configure.ac: fix build with libxcrypt and uclibc-ng

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,10 +362,18 @@ AC_SUBST(LIBAUDIT)
 AC_CHECK_HEADERS(crypt.h)
 
 BACKUP_LIBS=$LIBS
-AC_SEARCH_LIBS([crypt],[crypt])
-case "$ac_cv_search_crypt" in
-	-l*) LIBCRYPT="$ac_cv_search_crypt" ;;
-	*) LIBCRYPT="" ;;
+LIBCRYPT=""
+AC_SEARCH_LIBS([crypt_gensalt_rn],[crypt])
+case "$ac_cv_search_crypt_gensalt_rn" in
+	-l*) LIBCRYPT="$ac_cv_search_crypt_gensalt_rn" ;;
+	no) AC_SEARCH_LIBS([crypt_r],[crypt])
+		case "$ac_cv_search_crypt_r" in
+		-l*) LIBCRYPT="$ac_cv_search_crypt_r" ;;
+		no ) AC_SEARCH_LIBS([crypt],[crypt])
+		case "$ac_cv_search_crypt" in
+			-l*) LIBCRYPT="$ac_cv_search_crypt" ;;
+		esac ;;
+	esac ;;
 esac
 AC_CHECK_FUNCS([crypt_r])
 LIBS=$BACKUP_LIBS


### PR DESCRIPTION
Fix the following build failure with libxcrypt and uclibc-ng:

```
/srv/storage/autobuild/run/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabihf/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: unix_chkpwd-passverify.o: in function `verify_pwd_hash':
passverify.c:(.text+0xab4): undefined reference to `crypt_checksalt'
```

Fixes:
 - http://autobuild.buildroot.org/results/65d68b7c9c7de1c7cb0f941ff9982f93a49a56f8

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>