### PR TITLE
man: pam_unix(8): documented default "rounds=" value

### DIFF
--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -379,6 +379,13 @@
             blowfish, gost-yescrypt, and yescrypt password hashing
             algorithms to
             <replaceable>n</replaceable>.
+            For SHA256 and SHA512, defaults to SHA_CRYPT_MAX_ROUNDS
+            from <citerefentry>
+            <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+            </citerefentry>, if available.
+            Otherwise, the default depends on <citerefentry>
+            <refentrytitle>crypt</refentrytitle><manvolnum>3</manvolnum>
+            </citerefentry>.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Current manpage for pam_unix does not describe what happens when rounds= is omitted. I've added such a description.