### PR TITLE
Permit unix_chkpwd & pam_unix.so to run without being setuid-root.

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -241,12 +241,16 @@ PAMH_ARG_DECL(int get_account_info,
 			 * ...and shadow password file entry for this user,
 			 * if shadowing is enabled
 			 */
-#ifndef HELPER_COMPILE
-			if (geteuid() || SELINUX_ENABLED)
-				return PAM_UNIX_RUN_HELPER;
-#endif
 			*spwdent = pam_modutil_getspnam(pamh, name);
-			if (*spwdent == NULL || (*spwdent)->sp_pwdp == NULL)
+			if (*spwdent == NULL) {
+#ifndef HELPER_COMPILE
+				/* still a chance the user can authenticate */
+				if (errno == EACCES || SELINUX_ENABLED)
+					return PAM_UNIX_RUN_HELPER;
+#endif
+				return PAM_AUTHINFO_UNAVAIL;
+			}
+			if ((*spwdent)->sp_pwdp == NULL)
 				return PAM_AUTHINFO_UNAVAIL;
 		}
 	} else {


### PR DESCRIPTION
Remove the hard-coding of the idea that the only way pam_unix.so can
read the shadow file is if it can, in some way, run setuid-root.
Linux capabilities only require cap_dac_override to read the /etc/shadow
file.

This change achieves two things: it opens a path for a linux-pam
application to run without being setuid-root; further, it allows
unix_chkpwd to run non-setuid-root if it is installed:

   sudo setcap cap_dac_override=ep unix_chkpwd

If we wanted to link against libcap, we could install this binary with
cap_dac_override=p, and use cap_set_proc() to raise the effective bit
at runtime. However, some distributions already link unix_chkpwd
against libcap-ng for some, likely spurious, reason so "ep" is fine
for now.

Signed-off-by: Andrew G. Morgan <morgan@kernel.org>