### PR TITLE
Fix covscan BUFFER_SIZE issues

### DIFF
--- a/libpam/pam_modutil_getlogin.c
+++ b/libpam/pam_modutil_getlogin.c
@@ -49,7 +49,7 @@ pam_modutil_getlogin(pam_handle_t *pamh)
     logname = NULL;
 
     setutent();
-    strncpy(line.ut_line, curr_tty, sizeof(line.ut_line));
+    strncpy(line.ut_line, curr_tty, sizeof(line.ut_line) - 1);
 
     if ((ut = getutline(&line)) == NULL) {
 	goto clean_up_and_go_home;

--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -562,7 +562,7 @@ write_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 		tallies->records[oldest].status |= TALLY_STATUS_RHOST;
 	}
 
-	strncpy(tallies->records[oldest].source, source, sizeof(tallies->records[oldest].source));
+	strncpy(tallies->records[oldest].source, source, sizeof(tallies->records[oldest].source) - 1);
 	/* source does not have to be null terminated */
 
 	tallies->records[oldest].time = opts->now;


### PR DESCRIPTION
Error: BUFFER_SIZE (CWE-170): [#def2]
Linux-PAM-1.5.1/libpam/pam_modutil_getlogin.c:52: buffer_size_warning: Calling "strncpy" with a maximum size argument of 32 bytes on destination array "line.ut_line" of size 32 bytes might leave the destination string unterminated.
   50|
   51|       setutent();
   52|->     strncpy(line.ut_line, curr_tty, sizeof(line.ut_line));
   53|
   54|       if ((ut = getutline(&line)) == NULL) {

Error: BUFFER_SIZE (CWE-170): [#def25]
Linux-PAM-1.5.1/modules/pam_faillock/pam_faillock.c:565: buffer_size_warning: Calling "strncpy" with a maximum size argument of 52 bytes on destination array "tallies->records[oldest].source" of size 52 bytes might leave the destination string unterminated.
  563|   	}
  564|
  565|-> 	strncpy(tallies->records[oldest].source, source, sizeof(tallies->records[oldest].source));
  566|   	/* source does not have to be null terminated */
  567|