### PR TITLE
libpam: fix resource leaks

### DIFF
--- a/libpam/pam_modutil_ingroup.c
+++ b/libpam/pam_modutil_ingroup.c
@@ -83,11 +83,16 @@ pam_modutil_user_in_group_nam_nam(pam_handle_t *pamh,
 {
 	struct passwd *pwd;
 	struct group *grp;
+	int result;
 
 	pwd = pam_modutil_getpwnam(pamh, user);
 	grp = pam_modutil_getgrnam(pamh, group);
 
-	return pam_modutil_user_in_group_common(pamh, pwd, grp);
+	result = pam_modutil_user_in_group_common(pamh, pwd, grp);
+	free(pwd);
+	free(grp);
+
+	return result;
 }
 
 int
@@ -96,11 +101,16 @@ pam_modutil_user_in_group_nam_gid(pam_handle_t *pamh,
 {
 	struct passwd *pwd;
 	struct group *grp;
+	int result;
 
 	pwd = pam_modutil_getpwnam(pamh, user);
 	grp = pam_modutil_getgrgid(pamh, group);
 
-	return pam_modutil_user_in_group_common(pamh, pwd, grp);
+	result = pam_modutil_user_in_group_common(pamh, pwd, grp);
+	free(pwd);
+	free(grp);
+
+	return result;
 }
 
 int
@@ -109,11 +119,16 @@ pam_modutil_user_in_group_uid_nam(pam_handle_t *pamh,
 {
 	struct passwd *pwd;
 	struct group *grp;
+	int result;
 
 	pwd = pam_modutil_getpwuid(pamh, user);
 	grp = pam_modutil_getgrnam(pamh, group);
 
-	return pam_modutil_user_in_group_common(pamh, pwd, grp);
+	result = pam_modutil_user_in_group_common(pamh, pwd, grp);
+	free(pwd);
+	free(grp);
+
+	return result;
 }
 
 int
@@ -122,9 +137,14 @@ pam_modutil_user_in_group_uid_gid(pam_handle_t *pamh,
 {
 	struct passwd *pwd;
 	struct group *grp;
+	int result;
 
 	pwd = pam_modutil_getpwuid(pamh, user);
 	grp = pam_modutil_getgrgid(pamh, group);
 
-	return pam_modutil_user_in_group_common(pamh, pwd, grp);
+	result = pam_modutil_user_in_group_common(pamh, pwd, grp);
+	free(pwd);
+	free(grp);
+
+	return result;
 }


### PR DESCRIPTION
Error: RESOURCE_LEAK (CWE-772): [#def3]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:88: alloc_fn: Storage is returned from allocation function "pam_modutil_getgrnam".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:88: var_assign: Assigning: "grp" = storage returned from "pam_modutil_getgrnam(pamh, group)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:90: noescape: Resource "grp" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:90: leaked_storage: Variable "grp" going out of scope leaks the storage it points to.
   88|   	grp = pam_modutil_getgrnam(pamh, group);
   89|
   90|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
   91|   }
   92|

Error: RESOURCE_LEAK (CWE-772): [#def4]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:87: alloc_fn: Storage is returned from allocation function "pam_modutil_getpwnam".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:87: var_assign: Assigning: "pwd" = storage returned from "pam_modutil_getpwnam(pamh, user)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:90: noescape: Resource "pwd" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:90: leaked_storage: Variable "pwd" going out of scope leaks the storage it points to.
   88|   	grp = pam_modutil_getgrnam(pamh, group);
   89|
   90|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
   91|   }
   92|

Error: RESOURCE_LEAK (CWE-772): [#def5]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:101: alloc_fn: Storage is returned from allocation function "pam_modutil_getgrgid".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:101: var_assign: Assigning: "grp" = storage returned from "pam_modutil_getgrgid(pamh, group)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:103: noescape: Resource "grp" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:103: leaked_storage: Variable "grp" going out of scope leaks the storage it points to.
  101|   	grp = pam_modutil_getgrgid(pamh, group);
  102|
  103|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
  104|   }
  105|

Error: RESOURCE_LEAK (CWE-772): [#def6]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:100: alloc_fn: Storage is returned from allocation function "pam_modutil_getpwnam".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:100: var_assign: Assigning: "pwd" = storage returned from "pam_modutil_getpwnam(pamh, user)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:103: noescape: Resource "pwd" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:103: leaked_storage: Variable "pwd" going out of scope leaks the storage it points to.
  101|   	grp = pam_modutil_getgrgid(pamh, group);
  102|
  103|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
  104|   }
  105|

Error: RESOURCE_LEAK (CWE-772): [#def7]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:114: alloc_fn: Storage is returned from allocation function "pam_modutil_getgrnam".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:114: var_assign: Assigning: "grp" = storage returned from "pam_modutil_getgrnam(pamh, group)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:116: noescape: Resource "grp" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:116: leaked_storage: Variable "grp" going out of scope leaks the storage it points to.
  114|   	grp = pam_modutil_getgrnam(pamh, group);
  115|
  116|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
  117|   }
  118|

Error: RESOURCE_LEAK (CWE-772): [#def8]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:113: alloc_fn: Storage is returned from allocation function "pam_modutil_getpwuid".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:113: var_assign: Assigning: "pwd" = storage returned from "pam_modutil_getpwuid(pamh, user)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:116: noescape: Resource "pwd" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:116: leaked_storage: Variable "pwd" going out of scope leaks the storage it points to.
  114|   	grp = pam_modutil_getgrnam(pamh, group);
  115|
  116|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
  117|   }
  118|

Error: RESOURCE_LEAK (CWE-772): [#def9]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:127: alloc_fn: Storage is returned from allocation function "pam_modutil_getgrgid".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:127: var_assign: Assigning: "grp" = storage returned from "pam_modutil_getgrgid(pamh, group)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:129: noescape: Resource "grp" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:129: leaked_storage: Variable "grp" going out of scope leaks the storage it points to.
  127|   	grp = pam_modutil_getgrgid(pamh, group);
  128|
  129|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
  130|   }

Error: RESOURCE_LEAK (CWE-772): [#def10]
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:126: alloc_fn: Storage is returned from allocation function "pam_modutil_getpwuid".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:126: var_assign: Assigning: "pwd" = storage returned from "pam_modutil_getpwuid(pamh, user)".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:129: noescape: Resource "pwd" is not freed or pointed-to in "pam_modutil_user_in_group_common".
Linux-PAM-1.5.1/libpam/pam_modutil_ingroup.c:129: leaked_storage: Variable "pwd" going out of scope leaks the storage it points to.
  127|   	grp = pam_modutil_getgrgid(pamh, group);
  128|
  129|-> 	return pam_modutil_user_in_group_common(pamh, pwd, grp);
  130|   }

Signed-off-by: Iker Pedrosa <ipedrosa@redhat.com>