### PR TITLE
pam_unix: workaround the problem caused by libnss_systemd

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -245,8 +245,7 @@ PAMH_ARG_DECL(int get_account_info,
 			if (*spwdent == NULL) {
 #ifndef HELPER_COMPILE
 				/* still a chance the user can authenticate */
-				if (errno == EACCES || SELINUX_ENABLED)
-					return PAM_UNIX_RUN_HELPER;
+				return PAM_UNIX_RUN_HELPER;
 #endif
 				return PAM_AUTHINFO_UNAVAIL;
 			}


### PR DESCRIPTION
The getspnam(3) manual page says that errno shall be set to EACCES when
the caller does not have permission to access the shadow password file.
Unfortunately, this contract is broken when libnss_systemd is used in
the nss stack.

Workaround this problem by falling back to the helper invocation when
pam_modutil_getspnam returns NULL regardless of errno.  As pam_unix
already behaves this way when selinux is enabled, it should be OK
for the case when selinux is not enabled, too.

* modules/pam_unix/passverify.c (get_account_info): When
pam_modutil_getspnam returns NULL, unconditionally fall back
to the helper invocation.

Complements: f220cace2053 ("Permit unix_chkpwd & pam_unix.so to run without being setuid-root")
Resolves: https://github.com/linux-pam/linux-pam/issues/379