### PR TITLE
pam_pwhistory: Enable alternate location for password history file

### DIFF
--- a/modules/pam_pwhistory/opasswd.h
+++ b/modules/pam_pwhistory/opasswd.h
@@ -57,10 +57,10 @@ void
 helper_log_err(int err, const char *format, ...);
 #endif
 
-PAMH_ARG_DECL(int
-check_old_pass, const char *user, const char *newpass, int debug);
+PAMH_ARG_DECL(int check_old_pass, const char *user, const char *newpass,
+              const char *filename, int debug);
 
-PAMH_ARG_DECL(int
-save_old_pass, const char *user, int howmany, int debug);
+PAMH_ARG_DECL(int save_old_pass, const char *user, int howmany,
+              const char *filename, int debug);
 
 #endif /* __OPASSWD_H__ */

--- a/modules/pam_pwhistory/pam_pwhistory.8.xml
+++ b/modules/pam_pwhistory/pam_pwhistory.8.xml
@@ -36,6 +36,9 @@
       <arg choice="opt">
         authtok_type=<replaceable>STRING</replaceable>
       </arg>
+      <arg choice="opt">
+	      file=<replaceable>/path/filename</replaceable>
+      </arg>
 
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -137,6 +140,19 @@
           </listitem>
         </varlistentry>
 
+        <varlistentry>
+          <term>
+            <option>file=<replaceable>/path/filename</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+              Store password history in file <filename>/path/filename</filename>
+              rather than the default location. The default location is
+	      <filename>/etc/security/opasswd</filename>.
+            </para>
+          </listitem>
+        </varlistentry>
+
     </variablelist>
   </refsect1>
 
@@ -213,7 +229,7 @@ password     required       pam_unix.so        use_authtok
       <varlistentry>
         <term><filename>/etc/security/opasswd</filename></term>
         <listitem>
-          <para>File with password history</para>
+          <para>Default file with password history</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/modules/pam_pwhistory/pwhistory_helper.c
+++ b/modules/pam_pwhistory/pwhistory_helper.c
@@ -51,7 +51,7 @@
 
 
 static int
-check_history(const char *user, const char *debug)
+check_history(const char *user, const char *filename, const char *debug)
 {
   char pass[PAM_MAX_RESP_SIZE + 1];
   char *passwords[] = { pass };
@@ -68,7 +68,7 @@ check_history(const char *user, const char *debug)
       return PAM_AUTHTOK_ERR;
     }
 
-  retval = check_old_pass(user, pass, dbg);
+  retval = check_old_pass(user, pass, filename, dbg);
 
   memset(pass, '\0', PAM_MAX_RESP_SIZE);	/* clear memory of the password */
 
@@ -76,13 +76,13 @@ check_history(const char *user, const char *debug)
 }
 
 static int
-save_history(const char *user, const char *howmany, const char *debug)
+save_history(const char *user, const char *filename, const char *howmany, const char *debug)
 {
   int num = atoi(howmany);
   int dbg = atoi(debug); /* no need to be too fancy here */
   int retval;
 
-  retval = save_old_pass(user, num, dbg);
+  retval = save_old_pass(user, num, filename, dbg);
 
   return retval;
 }
@@ -92,13 +92,14 @@ main(int argc, char *argv[])
 {
   const char *option;
   const char *user;
+  const char *filename;
 
   /*
    * we establish that this program is running with non-tty stdin.
    * this is to discourage casual use.
    */
 
-  if (isatty(STDIN_FILENO) || argc < 4)
+  if (isatty(STDIN_FILENO) || argc < 5)
     {
       fprintf(stderr,
             "This binary is not designed for running in this way.\n");
@@ -107,11 +108,12 @@ main(int argc, char *argv[])
 
   option = argv[1];
   user = argv[2];
+  filename = argv[3];
 
-  if (strcmp(option, "check") == 0 && argc == 4)
-    return check_history(user, argv[3]);
-  else if (strcmp(option, "save") == 0 && argc == 5)
-    return save_history(user, argv[3], argv[4]);
+  if (strcmp(option, "check") == 0 && argc == 5)
+    return check_history(user, filename, argv[4]);
+  else if (strcmp(option, "save") == 0 && argc == 6)
+    return save_history(user, filename, argv[4], argv[5]);
 
   fprintf(stderr, "This binary is not designed for running in this way.\n");
 


### PR DESCRIPTION
Sometimes, especially in embedded devices, the /etc directory can be
read-only and/or not saved over upgrades. In order to ensure password
policies are maintained across upgrades and the module functions on
read-only file systems, allow the location of the password history file
to be set in the PAM configuration.

Signed-off-by: Edward <jinzhou.zhu1@ge.com>
[Martyn Welch: Updated commit message and ported to latest version]
Signed-off-by: Martyn Welch <martyn.welch@collabora.com>