### PR TITLE
Include pam_xauth_data.3.xml in source archive

### DIFF
--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -43,7 +43,7 @@ XMLS = pam.3.xml pam.8.xml \
 	pam_item_types_std.inc.xml pam_item_types_ext.inc.xml \
 	pam.conf-desc.xml pam.conf-dir.xml pam.conf-syntax.xml \
 	misc_conv.3.xml pam_misc_paste_env.3.xml pam_misc_drop_env.3.xml \
-	pam_misc_setenv.3.xml
+	pam_misc_setenv.3.xml pam_xauth_data.3.xml
 
 if ENABLE_REGENERATE_MAN
 PAM.8: pam.8


### PR DESCRIPTION
pam_xauth_data.3.xml is missing in the source archive, so you cannot rebuild all manual pages.