### PR TITLE
Only include vendordir in manual page if set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -507,9 +507,9 @@ AC_ARG_ENABLE([vendordir],
 if test -n "$enable_vendordir"; then
   AC_DEFINE_UNQUOTED([VENDORDIR], ["$enable_vendordir"],
 		     [Directory for distribution provided configuration files])
-  STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir'"
+  STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir'"
 else
-  STRINGPARAM_VENDORDIR="--stringparam vendordir '<vendordir>'"
+  STRINGPARAM_VENDORDIR="--stringparam profile.condition 'without_vendordir'"
 fi
 AC_SUBST([STRINGPARAM_VENDORDIR])
 

--- a/doc/man/pam.8.xml
+++ b/doc/man/pam.8.xml
@@ -158,15 +158,14 @@ closing hook for modules to affect the services available to a user.</para>
           </para>
         </listitem>
       </varlistentry>
-      <varlistentry>
+      <varlistentry condition="with_vendordir">
         <term><filename>%vendordir%/pam.d</filename></term>
         <listitem>
           <para>
             the <emphasis remap='B'>Linux-PAM</emphasis> vendor configuration
 	    directory. Files in <filename>/etc/pam.d</filename> and
 	    <filename>/usr/lib/pam.d</filename> override files with the same
-	    name in this directory. Only available if Linux-PAM was compiled
-	    with vendordir enabled.
+	    name in this directory.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Compile in %vendordir%/pam.d section only if vendordir was enabled.