### PR TITLE
Use vendor specific limits.conf as fallback

### DIFF
--- a/modules/pam_limits/pam_limits.8.xml
+++ b/modules/pam_limits/pam_limits.8.xml
@@ -57,6 +57,12 @@
       If a config file is explicitly specified with a module option then the
       files in the above directory are not parsed.
     </para>
+    <para condition="with_vendordir">
+      If there is no explicitly specified configuration file and 
+      <filename>/etc/security/limits.conf</filename> does not exist,
+      <filename>%vendordir%/security/limits.conf</filename> is used.
+      If this file does not exist, too, an error is thrown.
+    </para>
     <para>
       The module must not be called by a multithreaded application.
     </para>

--- a/modules/pam_limits/pam_limits.8.xml
+++ b/modules/pam_limits/pam_limits.8.xml
@@ -58,7 +58,7 @@
       files in the above directory are not parsed.
     </para>
     <para condition="with_vendordir">
-      If there is no explicitly specified configuration file and 
+      If there is no explicitly specified configuration file and
       <filename>/etc/security/limits.conf</filename> does not exist,
       <filename>%vendordir%/security/limits.conf</filename> is used.
       If this file does not exist, too, an error is thrown.

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -817,21 +817,21 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
     fil = fopen(CONF_FILE, "r");
     if (fil == NULL) {
       int err = errno;
-#ifdef VENDORDIR
 
+#ifdef VENDORDIR
       /* if the specified file does not exist, and it is not provided by
-	 the user, try the vendor file as fallback. */
-      if (pl->conf_file == NULL)
-	fil = fopen(VENDORDIR"/security/limits.conf", "r");
+         the user, try the vendor file as fallback. */
+      if (pl->conf_file == NULL && err == ENOENT)
+        fil = fopen(VENDORDIR"/security/limits.conf", "r");
 
       if (fil == NULL)
 #endif
-	{
-	  pam_syslog (pamh, LOG_WARNING,
-		      "cannot read settings from %s: %s", CONF_FILE,
-		      strerror(err));
-	  return PAM_SERVICE_ERR;
-	}
+        {
+          pam_syslog (pamh, LOG_WARNING,
+                      "cannot read settings from %s: %s", CONF_FILE,
+                      strerror(err));
+          return PAM_SERVICE_ERR;
+        }
     }
 
     /* start the show */

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -816,9 +816,22 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
         pam_syslog(pamh, LOG_DEBUG, "reading settings from '%s'", CONF_FILE);
     fil = fopen(CONF_FILE, "r");
     if (fil == NULL) {
-        pam_syslog (pamh, LOG_WARNING,
-		    "cannot read settings from %s: %m", CONF_FILE);
-        return PAM_SERVICE_ERR;
+      int err = errno;
+#ifdef VENDORDIR
+
+      /* if the specified file does not exist, and it is not provided by
+	 the user, try the vendor file as fallback. */
+      if (pl->conf_file == NULL)
+	fil = fopen(VENDORDIR"/security/limits.conf", "r");
+
+      if (fil == NULL)
+#endif
+	{
+	  pam_syslog (pamh, LOG_WARNING,
+		      "cannot read settings from %s: %s", CONF_FILE,
+		      strerror(err));
+	  return PAM_SERVICE_ERR;
+	}
     }
 
     /* start the show */


### PR DESCRIPTION
pam_limits.so fails if it cannot read /etc/security/limits.conf. This is especially a problem if you use image based installations and updates (so image = /usr, not image = raw disk image). Use the vendor directory as fallback for a distribution provided default config.