### PR TITLE
run-xtests.sh: check whether files exist

### DIFF
--- a/xtests/run-xtests.sh
+++ b/xtests/run-xtests.sh
@@ -18,10 +18,12 @@ all=0
 
 mkdir -p /etc/security
 for config in access.conf group.conf time.conf limits.conf ; do
-	cp /etc/security/$config /etc/security/$config-pam-xtests
+	[ -f "/etc/security/$config" ] &&
+		mv /etc/security/$config /etc/security/$config-pam-xtests
 	install -m 644 "${SRCDIR}"/$config /etc/security/$config
 done
-mv /etc/security/opasswd /etc/security/opasswd-pam-xtests
+[ -f /etc/security/opasswd ] &&
+	mv /etc/security/opasswd /etc/security/opasswd-pam-xtests
 
 for testname in $XTESTS ; do
 	  for cfg in "${SRCDIR}"/$testname*.pamd ; do
@@ -47,11 +49,15 @@ for testname in $XTESTS ; do
 	  all=`expr $all + 1`
 	  rm -f /etc/pam.d/$testname*
 done
-mv /etc/security/access.conf-pam-xtests /etc/security/access.conf
-mv /etc/security/group.conf-pam-xtests /etc/security/group.conf
-mv /etc/security/time.conf-pam-xtests /etc/security/time.conf
-mv /etc/security/limits.conf-pam-xtests /etc/security/limits.conf
-mv /etc/security/opasswd-pam-xtests /etc/security/opasswd
+
+for config in access.conf group.conf time.conf limits.conf opasswd ; do
+	if [ -f "/etc/security/$config-pam-xtests" ]; then
+		mv /etc/security/$config-pam-xtests /etc/security/$config
+	else
+		rm -f /etc/security/$config
+	fi
+done
+
 if test "$failed" -ne 0; then
 	  echo "==================="
 	  echo "$failed of $all tests failed"


### PR DESCRIPTION
Fixes:
```
# ./run-xtests.sh . tst-pam_access1
 mv: cannot stat '/etc/security/opasswd': No such file or directory
 PASS: tst-pam_access1
 mv: cannot stat '/etc/security/opasswd-pam-xtests': No such file or directory
 ==================
 1 tests passed
 0 tests not run
 ==================
```

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>