### PR TITLE
pam_time: use vendor specific time.conf as fallback

### DIFF
--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -12,7 +12,7 @@ dist_man_MANS = time.conf.5 pam_time.8
 endif
 XMLS = README.xml time.conf.5.xml pam_time.8.xml
 dist_check_SCRIPTS = tst-pam_time
-TESTS = $(dist_check_SCRIPTS)
+TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
@@ -27,6 +27,9 @@ pam_time_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 securelib_LTLIBRARIES = pam_time.la
 dist_secureconf_DATA = time.conf
+
+check_PROGRAMS = tst-pam_time-retval
+tst_pam_time_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_time/pam_time.8.xml
+++ b/modules/pam_time/pam_time.8.xml
@@ -51,6 +51,11 @@
       <filename>/etc/security/time.conf</filename>.
       An alternative file can be specified with the <emphasis>conffile</emphasis> option.
     </para>
+    <para condition="with_vendordir">
+      If there is no explicitly specified configuration file and
+      <filename>/etc/security/time.conf</filename> does not exist,
+      <filename>%vendordir%/security/time.conf</filename> is used.
+    </para>
     <para>
       If Linux PAM is compiled with audit support the module will report
       when it denies access.

--- a/modules/pam_time/pam_time.c
+++ b/modules/pam_time/pam_time.c
@@ -34,6 +34,9 @@
 #endif
 
 #define PAM_TIME_CONF	(SCONFIGDIR "/time.conf")
+#ifdef VENDOR_SCONFIGDIR
+#define VENDOR_PAM_TIME_CONF (VENDOR_SCONFIGDIR "/time.conf")
+#endif
 
 #define PAM_TIME_BUFLEN        1000
 #define FIELD_SEPARATOR        ';'   /* this is new as of .02 */
@@ -78,6 +81,19 @@ _pam_parse (const pam_handle_t *pamh, int argc, const char **argv, const char **
 	    pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
 	}
     }
+
+#ifdef VENDOR_PAM_TIME_CONF
+    if (*conffile == PAM_TIME_CONF) {
+	/*
+	 * Check whether PAM_TIME_CONF file is available.
+	 * If it does not exist, fall back to VENDOR_PAM_TIME_CONF file.
+	 */
+	struct stat buffer;
+	if (stat(*conffile, &buffer) != 0 && errno == ENOENT) {
+	    *conffile = VENDOR_PAM_TIME_CONF;
+	}
+    }
+#endif
 
     return ctrl;
 }

--- a/modules/pam_time/tst-pam_time-retval.c
+++ b/modules/pam_time/tst-pam_time-retval.c
@@ -1,0 +1,107 @@
+/*
+ * Check pam_time return values.
+ *
+ * Copyright (c) 2020-2022 Dmitry V. Levin <ldv@altlinux.org>
+ * Copyright (c) 2022 Stefan Schubert <schubi@suse.de>
+ */
+
+#include "test_assert.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <security/pam_appl.h>
+
+#define MODULE_NAME "pam_time"
+#define TEST_NAME "tst-" MODULE_NAME "-retval"
+
+static const char service_file[] = TEST_NAME ".service";
+static const char config_file[] = TEST_NAME ".conf";
+static struct pam_conv conv;
+
+int
+main(void)
+{
+	pam_handle_t *pamh = NULL;
+	FILE *fp;
+	char cwd[PATH_MAX];
+
+	ASSERT_NE(NULL, getcwd(cwd, sizeof(cwd)));
+
+	/* PAM_USER_UNKNOWN */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0,
+		  fprintf(fp, "#%%PAM-1.0\n"
+			      "auth required %s/.libs/%s.so\n"
+			      "account required %s/.libs/%s.so\n"
+			      "password required %s/.libs/%s.so\n"
+			      "session required %s/.libs/%s.so\n",
+			  cwd, MODULE_NAME,
+			  cwd, MODULE_NAME,
+			  cwd, MODULE_NAME,
+			  cwd, MODULE_NAME));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "", &conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_USER_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	ASSERT_NE(NULL, fp = fopen(config_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "# only root can access %s\n"
+				 "%s ; * ; !root ; !Al0000-2400\n",
+			     service_file, service_file));
+	ASSERT_EQ(0, fclose(fp));
+
+	/* conffile= specifies an existing file */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0,
+		  fprintf(fp, "#%%PAM-1.0\n"
+			      "auth required %s/.libs/%s.so conffile=%s\n"
+			      "account required %s/.libs/%s.so conffile=%s\n"
+			      "password required %s/.libs/%s.so conffile=%s\n"
+			      "session required %s/.libs/%s.so conffile=%s\n",
+			  cwd, MODULE_NAME, config_file,
+			  cwd, MODULE_NAME, config_file,
+			  cwd, MODULE_NAME, config_file,
+			  cwd, MODULE_NAME, config_file));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "root", &conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "noone", &conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_PERM_DENIED, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	/* cleanup */
+	ASSERT_EQ(0, unlink(config_file));
+	ASSERT_EQ(0, unlink(service_file));
+
+	return 0;
+}


### PR DESCRIPTION
Use the vendor directory as fallback for a distribution provided default config if there is no configuration in /etc.

* Makefile.am: compile testcases

* pam_time.8.xml: add description for vendor directory.

* pam_time.c: Take care about the fallback configuration in vendor directory.

* tst-pam_time-retval.c: General testcases for pam_time.
