### PR TITLE
pam_limits: don't fail on missing config files

### DIFF
--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -831,6 +831,9 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
       if (fil == NULL)
 #endif
         {
+          if (err == ENOENT)
+            return PAM_SUCCESS;
+
           pam_syslog (pamh, LOG_WARNING,
                       "cannot read settings from %s: %s", CONF_FILE,
                       strerror(err));


### PR DESCRIPTION
A config with only comments or an empty one is completely fine for
pam_limits. So don't complain about missing config files either.