### PR TITLE
pam_faillock: increase the limit of failed attempts before lockout

### DIFF
--- a/modules/pam_faillock/faillock.conf
+++ b/modules/pam_faillock/faillock.conf
@@ -28,8 +28,8 @@
 #
 # Deny access if the number of consecutive authentication failures
 # for this user during the recent interval exceeds n tries.
-# The default is 3.
-# deny = 3
+# The default is 20.
+# deny = 20
 #
 # The length of the interval during which the consecutive
 # authentication failures must happen for the user account

--- a/modules/pam_faillock/faillock.conf.5.xml
+++ b/modules/pam_faillock/faillock.conf.5.xml
@@ -112,7 +112,7 @@
                 <para>
                   Deny access if the number of consecutive authentication failures
                   for this user during the recent interval exceeds
-                  <replaceable>n</replaceable>. The default is 3.
+                  <replaceable>n</replaceable>. The default is 20.
                 </para>
               </listitem>
             </varlistentry>

--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -117,7 +117,7 @@ args_parse(pam_handle_t *pamh, int argc, const char **argv,
 	memset(opts, 0, sizeof(*opts));
 
 	opts->dir = strdup(FAILLOCK_DEFAULT_TALLYDIR);
-	opts->deny = 3;
+	opts->deny = 20;
 	opts->fail_interval = 900;
 	opts->unlock_time = 600;
 	opts->root_unlock_time = MAX_TIME_INTERVAL+1;


### PR DESCRIPTION
Right now, any 3 failed passwords within a 15 minute window lock you out of the computer.
This seems very excessive, even for a something like a 4 digit pin password.

As a simple change to balance being a human with security, this proposed change bumps the default to 20 within the window