### PR TITLE
Check the return value of localtime in faillock

### DIFF
--- a/modules/pam_faillock/main.c
+++ b/modules/pam_faillock/main.c
@@ -174,6 +174,11 @@ do_user(struct options *opts, const char *user)
 			time_t when = tallies.records[i].time;
 
 			tm = localtime(&when);
+			if(tm == NULL) {
+				fprintf(stderr, "%s: Invalid timestamp in the tally record\n",
+					opts->progname);
+				continue;
+			}
 			strftime(timebuf, sizeof(timebuf), "%Y-%m-%d %H:%M:%S", tm);
 			printf("%-19s %-5s %-52.52s %s\n", timebuf,
 				status & TALLY_STATUS_RHOST ? "RHOST" : (status & TALLY_STATUS_TTY ? "TTY" : "SVC"),


### PR DESCRIPTION
`faillock` doesn't check the return value of `localtime` which might lead to a null pointer dereference and segfault when calling `strftime`. As the tally files are writable by the users in question, they can contain arbitrary data. As an example, to reproduce this you can try setting `tallies.records[i].time` to `0x8000000061dda477`.