### PR TITLE
pam_faillock: use vendor specific faillock.conf as fallback

### DIFF
--- a/modules/pam_faillock/faillock.h
+++ b/modules/pam_faillock/faillock.h
@@ -68,6 +68,9 @@ struct tally_data {
 
 #define FAILLOCK_DEFAULT_TALLYDIR "/var/run/faillock"
 #define FAILLOCK_DEFAULT_CONF SCONFIGDIR "/faillock.conf"
+#ifdef VENDOR_SCONFIGDIR
+#define VENDOR_FAILLOCK_DEFAULT_CONF VENDOR_SCONFIGDIR "/faillock.conf"
+#endif
 
 int open_tally(const char *dir, const char *user, uid_t uid, int create);
 int read_tally(int fd, struct tally_data *tallies);

--- a/modules/pam_faillock/pam_faillock.8.xml
+++ b/modules/pam_faillock/pam_faillock.8.xml
@@ -134,9 +134,16 @@
                  <option>conf=/path/to/config-file</option>
                </term>
                <listitem>
-                 <para>
+                 <para condition="without_vendordir">
                    Use another configuration file instead of the default
                    <filename>/etc/security/faillock.conf</filename>.
+                 </para>
+                 <para condition="with_vendordir">
+                   Use another configuration file instead of the default
+                   which is to use the file
+                   <filename>/etc/security/faillock.conf</filename> or,
+                   if that one is not present, the file
+                   <filename>%vendordir%/security/faillock.conf</filename>.
                  </para>
                </listitem>
             </varlistentry>
@@ -326,6 +333,15 @@ session  required       pam_selinux.so open
         <term><filename>/etc/security/faillock.conf</filename></term>
         <listitem>
           <para>the config file for pam_faillock options</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry condition="with_vendordir">
+        <term><filename>%vendordir%/security/faillock.conf</filename></term>
+        <listitem>
+          <para>
+            the config file for pam_faillock options. It will be used if
+            <filename>/etc/security/faillock.conf</filename> does not exist.
+          </para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -192,6 +192,15 @@ read_config_file(pam_handle_t *pamh, struct options *opts, const char *cfgfile)
 	char linebuf[FAILLOCK_CONF_MAX_LINELEN+1];
 
 	f = fopen(cfgfile, "r");
+#ifdef VENDOR_FAILLOCK_DEFAULT_CONF
+	if (f == NULL && errno == ENOENT && cfgfile == default_faillock_conf) {
+	  /*
+	   * If the default configuration file in /etc does not exist,
+	   * try the vendor configuration file as fallback.
+	   */
+	  f = fopen(VENDOR_FAILLOCK_DEFAULT_CONF, "r");
+	}
+#endif
 	if (f == NULL) {
 		/* ignore non-existent default config file */
 		if (errno == ENOENT && cfgfile == default_faillock_conf)


### PR DESCRIPTION
Use the vendor directory (/usr/etc) as fallback for a distribution provided default config if there is no configuration in /etc.

- pam_faillock.c, faillock.h : Take care about the fallback configuration in /usr/etc.
- pam_faillock.8.xml:  added /usr/etc description