### PR TITLE
pam_rooktok: fix build warning if HAVE_LIBAUDIT has not been defined

### DIFF
--- a/modules/pam_rootok/pam_rootok.c
+++ b/modules/pam_rootok/pam_rootok.c
@@ -53,11 +53,10 @@ static int
 PAM_FORMAT((printf, 2, 3))
 log_callback (int type UNUSED, const char *fmt, ...)
 {
-    int audit_fd;
     va_list ap;
 
 #ifdef HAVE_LIBAUDIT
-    audit_fd = audit_open();
+    int audit_fd = audit_open();
 
     if (audit_fd >= 0) {
 	char *buf;


### PR DESCRIPTION
Do not report that the variable audit_fd is unused if HAVE_LIBAUDIT has not been defined.