### PR TITLE
pam_limits: adjust docu if config file is missing

### DIFF
--- a/modules/pam_limits/pam_limits.8.xml
+++ b/modules/pam_limits/pam_limits.8.xml
@@ -61,7 +61,6 @@
       If there is no explicitly specified configuration file and
       <filename>/etc/security/limits.conf</filename> does not exist,
       <filename>%vendordir%/security/limits.conf</filename> is used.
-      If this file does not exist, too, an error is thrown.
     </para>
     <para>
       The module must not be called by a multithreaded application.


### PR DESCRIPTION
This adjustes the documentation for the changes from PR#418
We no longer fail if the config file does not exist.