### PR TITLE
Introduce SCONFIGDIR and VENDOR_SCONFIGDIR macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,7 +260,7 @@ AC_ARG_ENABLE(sconfigdir,
 	AS_HELP_STRING([--enable-sconfigdir=DIR],[path to module conf files @<:@default=$sysconfdir/security@:>@]),
 	SCONFIGDIR=$enableval, SCONFIGDIR=$sysconfdir/security)
 AC_DEFINE_UNQUOTED([SCONFIGDIR], ["$SCONFIGDIR"],
-		   [Directory for system PAM modules configuration files])
+		   [Directory for PAM modules system configuration files])
 AC_SUBST(SCONFIGDIR)
 
 AC_ARG_ENABLE(pamlocking,

--- a/configure.ac
+++ b/configure.ac
@@ -509,6 +509,8 @@ AC_ARG_ENABLE([vendordir],
 if test -n "$enable_vendordir"; then
   AC_DEFINE_UNQUOTED([VENDORDIR], ["$enable_vendordir"],
 		     [Directory for distribution provided configuration files])
+  AC_DEFINE_UNQUOTED([VENDOR_SCONFIGDIR], ["$enable_vendordir/security"],
+		     [Directory for PAM modules distribution provided configuration files])
   STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir'"
 else
   STRINGPARAM_VENDORDIR="--stringparam profile.condition 'without_vendordir'"

--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,8 @@ AC_MSG_RESULT([Defining \$ISA to "$ISA"])
 AC_ARG_ENABLE(sconfigdir,
 	AS_HELP_STRING([--enable-sconfigdir=DIR],[path to module conf files @<:@default=$sysconfdir/security@:>@]),
 	SCONFIGDIR=$enableval, SCONFIGDIR=$sysconfdir/security)
+AC_DEFINE_UNQUOTED([SCONFIGDIR], ["$SCONFIGDIR"],
+		   [Directory for system PAM modules configuration files])
 AC_SUBST(SCONFIGDIR)
 
 AC_ARG_ENABLE(pamlocking,

--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -18,8 +18,7 @@ securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-DPAM_ACCESS_CONFIG=\"$(SCONFIGDIR)/access.conf\" \
-	-DACCESS_CONF_GLOB=\"$(SCONFIGDIR)/access.d/*.conf\" $(WARN_CFLAGS)
+	    $(WARN_CFLAGS)
 AM_LDFLAGS =  -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -56,6 +56,9 @@
 #include "pam_cc_compat.h"
 #include "pam_inline.h"
 
+#define PAM_ACCESS_CONFIG	(SCONFIGDIR "/access.conf")
+#define ACCESS_CONF_GLOB	(SCONFIGDIR "/access.d/*.conf")
+
 /* login_access.c from logdaemon-5.6 with several changes by A.Nogin: */
 
  /*

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -18,7 +18,7 @@ securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-DDEFAULT_CONF_FILE=\"$(SCONFIGDIR)/pam_env.conf\" $(WARN_CFLAGS)
+	    $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -41,6 +41,8 @@ typedef struct var {
   char *override;
 } VAR;
 
+#define DEFAULT_CONF_FILE	(SCONFIGDIR "/pam_env.conf")
+
 #define BUF_SIZE 8192
 #define MAX_ENV  8192
 

--- a/modules/pam_faillock/faillock.h
+++ b/modules/pam_faillock/faillock.h
@@ -67,7 +67,7 @@ struct tally_data {
 };
 
 #define FAILLOCK_DEFAULT_TALLYDIR "/var/run/faillock"
-#define FAILLOCK_DEFAULT_CONF "/etc/security/faillock.conf"
+#define FAILLOCK_DEFAULT_CONF SCONFIGDIR "/faillock.conf"
 
 int open_tally(const char *dir, const char *user, uid_t uid, int create);
 int read_tally(int fd, struct tally_data *tallies);

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -18,7 +18,7 @@ securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-DPAM_GROUP_CONF=\"$(SCONFIGDIR)/group.conf\" $(WARN_CFLAGS)
+	    $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_group/pam_group.c
+++ b/modules/pam_group/pam_group.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 
+#define PAM_GROUP_CONF		SCONFIGDIR "/group.conf"
 #define PAM_GROUP_BUFLEN        1000
 #define FIELD_SEPARATOR         ';'   /* this is new as of .02 */
 

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -19,8 +19,8 @@ secureconfdir = $(SCONFIGDIR)
 limits_conf_dir = $(SCONFIGDIR)/limits.d
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-DLIMITS_FILE_DIR=\"$(limits_conf_dir)\" \
-	-DLIMITS_FILE=\"$(SCONFIGDIR)/limits.conf\" $(WARN_CFLAGS)
+	    -DLIMITS_FILE_DIR=\"$(limits_conf_dir)\" \
+	    $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -19,7 +19,7 @@ secureconfdir = $(SCONFIGDIR)
 limits_conf_dir = $(SCONFIGDIR)/limits.d
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-DLIMITS_FILE_DIR=\"$(limits_conf_dir)/*.conf\" \
+	-DLIMITS_FILE_DIR=\"$(limits_conf_dir)\" \
 	-DLIMITS_FILE=\"$(SCONFIGDIR)/limits.conf\" $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -123,7 +123,7 @@ struct pam_limit_s {
 #define PAM_SET_ALL         0x0010
 
 /* Limits from globbed files. */
-#define LIMITS_CONF_GLOB LIMITS_FILE_DIR
+#define LIMITS_CONF_GLOB	(LIMITS_FILE_DIR "/*.conf")
 
 #define CONF_FILE (pl->conf_file != NULL)?pl->conf_file:LIMITS_FILE
 

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -823,11 +823,11 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
     if (fil == NULL) {
       int err = errno;
 
-#ifdef VENDORDIR
+#ifdef VENDOR_SCONFIGDIR
       /* if the specified file does not exist, and it is not provided by
          the user, try the vendor file as fallback. */
       if (pl->conf_file == NULL && err == ENOENT)
-        fil = fopen(VENDORDIR"/security/limits.conf", "r");
+        fil = fopen(VENDOR_SCONFIGDIR "/limits.conf", "r");
 
       if (fil == NULL)
 #endif

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -125,7 +125,8 @@ struct pam_limit_s {
 /* Limits from globbed files. */
 #define LIMITS_CONF_GLOB	(LIMITS_FILE_DIR "/*.conf")
 
-#define CONF_FILE (pl->conf_file != NULL)?pl->conf_file:LIMITS_FILE
+#define LIMITS_FILE	(SCONFIGDIR "/limits.conf")
+#define CONF_FILE	((pl->conf_file != NULL) ? pl->conf_file : LIMITS_FILE)
 
 static int
 _pam_parse (const pam_handle_t *pamh, int argc, const char **argv,
@@ -815,7 +816,7 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
     FILE *fil;
     char buf[LINE_LENGTH];
 
-    /* check for the LIMITS_FILE */
+    /* check for the CONF_FILE */
     if (ctrl & PAM_DEBUG_ARG)
         pam_syslog(pamh, LOG_DEBUG, "reading settings from '%s'", CONF_FILE);
     fil = fopen(CONF_FILE, "r");

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -21,7 +21,7 @@ namespaceddir = $(SCONFIGDIR)/namespace.d
 servicedir = $(systemdunitdir)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-        -DSECURECONF_DIR=\"$(SCONFIGDIR)/\" $(WARN_CFLAGS)
+	    $(WARN_CFLAGS)
 AM_LDFLAGS =  -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_namespace/pam_namespace.h
+++ b/modules/pam_namespace/pam_namespace.h
@@ -90,14 +90,10 @@
 /*
  * Module defines
  */
-#ifndef SECURECONF_DIR
-#define SECURECONF_DIR "/etc/security/"
-#endif
-
-#define PAM_NAMESPACE_CONFIG (SECURECONF_DIR "namespace.conf")
-#define NAMESPACE_INIT_SCRIPT (SECURECONF_DIR "namespace.init")
-#define NAMESPACE_D_DIR (SECURECONF_DIR "namespace.d/")
-#define NAMESPACE_D_GLOB (SECURECONF_DIR "namespace.d/*.conf")
+#define PAM_NAMESPACE_CONFIG (SCONFIGDIR "/namespace.conf")
+#define NAMESPACE_INIT_SCRIPT (SCONFIGDIR "/namespace.init")
+#define NAMESPACE_D_DIR (SCONFIGDIR "/namespace.d/")
+#define NAMESPACE_D_GLOB (SCONFIGDIR "/namespace.d/*.conf")
 
 /* module flags */
 #define PAMNS_DEBUG           0x00000100 /* Running in debug mode */

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -74,7 +74,7 @@
 #define RANDOM_DEVICE "/dev/urandom"
 #endif
 
-#define OLD_PASSWORDS_FILE "/etc/security/opasswd"
+#define OLD_PASSWORDS_FILE SCONFIGDIR "/opasswd"
 #define TMP_PASSWORDS_FILE OLD_PASSWORDS_FILE".tmpXXXXXX"
 
 #define DEFAULT_BUFLEN 4096

--- a/modules/pam_sepermit/Makefile.am
+++ b/modules/pam_sepermit/Makefile.am
@@ -21,7 +21,6 @@ sepermitlockdir = ${localstatedir}/run/sepermit
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	-I$(top_srcdir)/libpam_misc/include \
-	-D SEPERMIT_CONF_FILE=\"$(SCONFIGDIR)/sepermit.conf\" \
 	-D SEPERMIT_LOCKDIR=\"$(sepermitlockdir)\" $(WARN_CFLAGS)
 
 pam_sepermit_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBSELINUX@

--- a/modules/pam_sepermit/pam_sepermit.c
+++ b/modules/pam_sepermit/pam_sepermit.c
@@ -63,6 +63,7 @@
 
 #include "pam_inline.h"
 
+#define SEPERMIT_CONF_FILE	(SCONFIGDIR "/sepermit.conf")
 #define MODULE "pam_sepermit"
 #define OPT_DELIM ":"
 

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -18,7 +18,7 @@ securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-DPAM_TIME_CONF=\"$(SCONFIGDIR)/time.conf\" $(WARN_CFLAGS)
+	    $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_time/pam_time.c
+++ b/modules/pam_time/pam_time.c
@@ -33,6 +33,8 @@
 #include <libaudit.h>
 #endif
 
+#define PAM_TIME_CONF	(SCONFIGDIR "/time.conf")
+
 #define PAM_TIME_BUFLEN        1000
 #define FIELD_SEPARATOR        ';'   /* this is new as of .02 */
 

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -334,7 +334,7 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 
 #define PW_TMPFILE              "/etc/npasswd"
 #define SH_TMPFILE              "/etc/nshadow"
-#define OPW_TMPFILE             "/etc/security/nopasswd"
+#define OPW_TMPFILE             SCONFIGDIR "/nopasswd"
 
 /*
  * i64c - convert an integer to a radix 64 character

--- a/modules/pam_unix/passverify.h
+++ b/modules/pam_unix/passverify.h
@@ -8,7 +8,7 @@
 
 #define PAM_UNIX_RUN_HELPER PAM_CRED_INSUFFICIENT
 
-#define OLD_PASSWORDS_FILE      "/etc/security/opasswd"
+#define OLD_PASSWORDS_FILE      SCONFIGDIR "/opasswd"
 
 int
 is_pwd_shadowed(const struct passwd *pwd);


### PR DESCRIPTION
Dmitry V. Levin (6):
      Introduce SCONFIGDIR macro
      modules: use SCONFIGDIR macro
      pam_limits: make LIMITS_FILE_DIR macro consistent
      modules: move SCONFIGDIR-based macro definitions from Makefile.am to the source code
      Introduce VENDOR_SCONFIGDIR macro
      pam_limits: use VENDOR_SCONFIGDIR macro

Assuming that we will have all PAM modules updated to support VENDORDIR,
introduce two macros to make the code more consistent.

Similar to VENDORDIR, SCONFIGDIR is a new macro defined to the
argument of --enable-sconfigdir option.  Unlike --enable-vendordir,
--enable-sconfigdir has a default value, so when --enable-sconfigdir
is not used for build, SCONFIGDIR will be defined to that default value.

Use SCONFIGDIR macro instead of open-coding "/etc/security",
the latter is not correct when configured using --enable-sconfigdir
with an argument different from /etc/security.

VENDOR_SCONFIGDIR macro is a VENDORDIR version of SCONFIGDIR macro,
defined to VENDORDIR"/security" when --enable-vendordir is used for build.