### PR TITLE
libpam: Fix undefined reference to `libintl_dgettext` on musl

### DIFF
--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -21,7 +21,7 @@ noinst_HEADERS = pam_prelude.h pam_private.h pam_tokens.h \
 		include/pam_inline.h include/test_assert.h
 
 libpam_la_LDFLAGS = -no-undefined -version-info 85:1:85
-libpam_la_LIBADD = @LIBAUDIT@ $(LIBPRELUDE_LIBS) $(ECONF_LIBS) @LIBDL@
+libpam_la_LIBADD = @LIBAUDIT@ $(LIBPRELUDE_LIBS) $(ECONF_LIBS) @LIBDL@ @LTLIBINTL@
 
 if HAVE_VERSIONING
   libpam_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libpam.map


### PR DESCRIPTION
```
libtool: link: armv7a-unknown-linux-musleabihf-gcc -shared  -fPIC -DPIC  .libs/pam_account.o .libs/pam_auth.o .libs/pam_data.o .libs/pam_delay.o .libs/pam_dispatch.o .libs/pam_end.o .libs/pam_env.o .libs/pam_get_authtok.o .libs/pam_handlers.o .libs/pam_item.o .libs/pam_misc.o .libs/pam_password.o .libs/pam_prelude.o .libs/pam_session.o .libs/pam_start.o .libs/pam_strerror.o .libs/pam_vprompt.o .libs/pam_syslog.o .libs/pam_dynamic.o .libs/pam_audit.o .libs/pam_modutil_check_user.o .libs/pam_modutil_cleanup.o .libs/pam_modutil_getpwnam.o .libs/pam_modutil_ioloop.o .libs/pam_modutil_getgrgid.o .libs/pam_modutil_getpwuid.o .libs/pam_modutil_getgrnam.o .libs/pam_modutil_getspnam.o .libs/pam_modutil_getlogin.o .libs/pam_modutil_ingroup.o .libs/pam_modutil_priv.o .libs/pam_modutil_sanitize.o .libs/pam_modutil_searchkey.o   -Wl,--as-needed  -O2 -Wl,--version-script=/usr/armv7a-unknown-linux-musleabihf/tmp/portage/sys-libs/pam-1.5.1_p20210622-r1/work/linux-pam-fe1307512fb8892b5ceb3d884c793af8dbd4c16a/libpam/libpam.map -Wl,-O1 -Wl,--no-undefined -Wl,-O1   -Wl,-soname -Wl,libpam.so.0 -o .libs/libpam.so.0.85.1
/usr/libexec/gcc/armv7a-unknown-linux-musleabihf/ld: .libs/pam_get_authtok.o: in function `pam_get_authtok_internal':
pam_get_authtok.c:(.text+0x39c): undefined reference to `libintl_dgettext'
/usr/libexec/gcc/armv7a-unknown-linux-musleabihf/ld: pam_get_authtok.c:(.text+0x464): undefined reference to `libintl_dgettext'
```
Downstream Gentoo bug: https://bugs.gentoo.org/832573