### PR TITLE
pam_namespace: use vendor specific namespace.conf and namespace.init as fallback

### DIFF
--- a/modules/pam_namespace/namespace.conf.5.xml
+++ b/modules/pam_namespace/namespace.conf.5.xml
@@ -30,11 +30,27 @@
       directory path and the instance directory path as its arguments.
     </para>
 
-    <para>
+    <para condition="without_vendordir">
       The <filename>/etc/security/namespace.conf</filename> file specifies
       which directories are polyinstantiated, how they are polyinstantiated,
       how instance directories would be named, and any users for whom
       polyinstantiation would not be performed.
+    </para>
+
+    <para condition="with_vendordir">
+      The <filename>/etc/security/namespace.conf</filename> file
+      ( or <filename>%vendordir%/security/namespace.conf</filename> if it does
+      not exist) specifies which directories are polyinstantiated, how they are
+      polyinstantiated, how instance directories would be named, and any users
+      for whom polyinstantiation would not be performed.
+      Then individual <filename>*.conf</filename> files from the
+      <filename>/etc/security/namespace.d/</filename> and
+      <filename>%vendordir%/security/namespace.d</filename> directories are taken too.
+      If <filename>/etc/security/namespace.d/@filename@.conf</filename> exists, then
+      <filename>%vendordir%/security/namespace.d/@filename@.conf</filename> will not be used.
+      All <filename>namespace.d/*.conf</filename> files are sorted by their
+      <filename>@filename@.conf</filename> in lexicographic order regardless of which
+      of the directories they reside in.
     </para>
 
     <para>

--- a/modules/pam_namespace/pam_namespace.8.xml
+++ b/modules/pam_namespace/pam_namespace.8.xml
@@ -74,6 +74,12 @@
       and the user name as its arguments.
     </para>
 
+    <para condition="with_vendordir">
+      If <filename>/etc/security/namespace.init</filename> does not exist,
+      <filename>%vendordir%/security/namespace.init</filename> is the
+      alternative to be used for it.
+    </para>
+
     <para>
       The pam_namespace module disassociates the session namespace from
       the parent namespace. Any mounts/unmounts performed in the parent
@@ -313,6 +319,14 @@
         </listitem>
       </varlistentry>
 
+      <varlistentry condition="with_vendordir">
+        <term><filename>%vendordir%/security/namespace.conf</filename></term>
+        <listitem>
+          <para>Default configuration file if
+	  <filename>/etc/security/namespace.conf</filename> does not exist.</para>
+        </listitem>
+      </varlistentry>
+
       <varlistentry>
         <term><filename>/etc/security/namespace.d</filename></term>
         <listitem>
@@ -320,10 +334,26 @@
         </listitem>
       </varlistentry>
 
+      <varlistentry condition="with_vendordir">
+        <term><filename>%vendordir%/security/namespace.d</filename></term>
+        <listitem>
+          <para>Directory for additional vendor specific configuration files.</para>
+        </listitem>
+      </varlistentry>
+
       <varlistentry>
         <term><filename>/etc/security/namespace.init</filename></term>
         <listitem>
           <para>Init script for instance directories</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry condition="with_vendordir">
+        <term><filename>%vendordir%/security/namespace.init</filename></term>
+        <listitem>
+          <para>Vendor init script for instance directories if
+	  /etc/security/namespace.init does not exist.
+	  </para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/modules/pam_namespace/pam_namespace.h
+++ b/modules/pam_namespace/pam_namespace.h
@@ -94,6 +94,12 @@
 #define NAMESPACE_INIT_SCRIPT (SCONFIGDIR "/namespace.init")
 #define NAMESPACE_D_DIR (SCONFIGDIR "/namespace.d/")
 #define NAMESPACE_D_GLOB (SCONFIGDIR "/namespace.d/*.conf")
+#ifdef VENDOR_SCONFIGDIR
+#define VENDOR_NAMESPACE_INIT_SCRIPT (VENDOR_SCONFIGDIR "/namespace.init")
+#define VENDOR_PAM_NAMESPACE_CONFIG (VENDOR_SCONFIGDIR "/namespace.conf")
+#define VENDOR_NAMESPACE_D_DIR (VENDOR_SCONFIGDIR "/namespace.d/")
+#define VENDOR_NAMESPACE_D_GLOB (VENDOR_SCONFIGDIR "/namespace.d/*.conf")
+#endif
 
 /* module flags */
 #define PAMNS_DEBUG           0x00000100 /* Running in debug mode */


### PR DESCRIPTION
Use the vendor directory as fallback for a distribution provided default config and scripts if there is no configuration in /etc.

pam_namespace.c: Take care about the fallback configuration in vendor directory.
pam_namespace.h: Defining vendor specific files and directories.
pam_namespace.8.xml: Added description for vendor directories and files.
namespace.conf.5.xml: Added description for vendor directories and files.