### PR TITLE
pam_usertype: only use SYS_UID_MAX for system users

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,11 +632,6 @@ test -n "$opt_uidmin" ||
           opt_uidmin=1000
 AC_DEFINE_UNQUOTED(PAM_USERTYPE_UIDMIN, $opt_uidmin, [Minimum regular user uid.])
 
-AC_ARG_WITH([sysuidmin], AS_HELP_STRING([--with-sysuidmin=<number>],[default value for system user min uid (101)]), opt_sysuidmin=$withval)
-test -n "$opt_sysuidmin" ||
-          opt_sysuidmin=101
-AC_DEFINE_UNQUOTED(PAM_USERTYPE_SYSUIDMIN, $opt_sysuidmin, [Minimum system user uid.])
-
 AC_ARG_WITH([kernel-overflow-uid], AS_HELP_STRING([--with-kernel-overflow-uid=<number>],[kernel overflow uid, default (uint16_t)-2=65534]), opt_kerneloverflowuid=$withval)
 test -n "$opt_kerneloverflowuid" ||
           opt_kerneloverflowuid=65534

--- a/modules/pam_usertype/pam_usertype.8.xml
+++ b/modules/pam_usertype/pam_usertype.8.xml
@@ -31,7 +31,7 @@
       pam_usertype.so is designed to succeed or fail authentication
       based on type of the account of the authenticated user.
       The type of the account is decided with help of
-      <emphasis>SYS_UID_MIN</emphasis> and <emphasis>SYS_UID_MAX</emphasis>
+      <emphasis>SYS_UID_MAX</emphasis>
       settings in <emphasis>/etc/login.defs</emphasis>. One use is to select
       whether to load other modules based on this test.
     </para>


### PR DESCRIPTION
modules/pam_usertype/pam_usertype.c: stop using SYS_UID_MIN to check if
it is a system account, because all accounts below the SYS_UID_MAX are
system users.
modules/pam_usertype/pam_usertype.8.xml: remove reference to SYS_UID_MIN
as it is no longer user to calculate the system accounts.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1949137