### PR TITLE
Update Korean translation

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# Korean translation of Linux-PAM.
 # Copyright (C) YEAR Linux-PAM Project
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the Linux-PAM package.
 #
 # Translators:
 # eukim <eukim@redhat.com>, 2013
@@ -8,67 +8,67 @@
 # eukim <eukim@redhat.com>, 2012
 # Tomáš Mráz <tmraz@fedoraproject.org>, 2016. #zanata
 # simmon <simmon@nplob.com>, 2021.
-# Seong-ho Cho <darkcircle.0426@gmail.com>, 2021.
+# Seong-ho Cho <darkcircle.0426@gmail.com>, 2021-2022.
 msgid ""
 msgstr ""
 "Project-Id-Version: Linux-PAM\n"
 "Report-Msgid-Bugs-To: https://github.com/linux-pam/linux-pam/issues\n"
 "POT-Creation-Date: 2021-07-20 20:00+0000\n"
-"PO-Revision-Date: 2021-10-17 23:05+0000\n"
-"Last-Translator: simmon <simmon@nplob.com>\n"
-"Language-Team: Korean <https://translate.fedoraproject.org/projects/"
-"linux-pam/master/ko/>\n"
+"PO-Revision-Date: 2022-03-10 15:18+0900\n"
+"Last-Translator: Seong-ho Cho <darkcircle.0426@gmail.com>\n"
+"Language-Team: Korean <https://translate.fedoraproject.org/projects/linux-"
+"pam/master/ko/>\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.8\n"
+"X-Generator: Poedit 2.3.1\n"
 
 #: libpam/pam_get_authtok.c:39 modules/pam_exec/pam_exec.c:181
 #: modules/pam_userdb/pam_userdb.c:53
 msgid "Password: "
-msgstr "비밀번호: "
+msgstr "암호: "
 
 #: libpam/pam_get_authtok.c:41
 #, c-format
 msgid "Current %s password: "
-msgstr "현재 %s 비밀번호: "
+msgstr "현재 %s 암호: "
 
 #: libpam/pam_get_authtok.c:42
 msgid "Current password: "
-msgstr "현재 비밀번호: "
+msgstr "현재 암호: "
 
 #: libpam/pam_get_authtok.c:44
 #, c-format
 msgid "New %s password: "
-msgstr "신규 %s 비밀번호: "
+msgstr "새 %s 암호: "
 
 #: libpam/pam_get_authtok.c:45
 msgid "New password: "
-msgstr "신규 비밀번호: "
+msgstr "새 암호: "
 
 #: libpam/pam_get_authtok.c:47
 #, c-format
 msgid "Retype new %s password: "
-msgstr "신규 %s 비밀번호 재 입력: "
+msgstr "새 %s 암호 다시 입력: "
 
 #: libpam/pam_get_authtok.c:48
 msgid "Retype new password: "
-msgstr "신규 비밀번호 재 입력: "
+msgstr "새 암호 다시 입력: "
 
 #: libpam/pam_get_authtok.c:49
 msgid "Sorry, passwords do not match."
-msgstr "죄송합니다, 비밀번호가 일치하지 않습니다."
+msgstr "죄송합니다, 암호가 일치하지 않습니다."
 
 #: libpam/pam_get_authtok.c:142 libpam/pam_get_authtok.c:240
 #, c-format
 msgid "Retype %s"
-msgstr "%s를 재입력합니다"
+msgstr "%s 다시 입력"
 
 #: libpam/pam_get_authtok.c:178 libpam/pam_get_authtok.c:258
 msgid "Password change has been aborted."
-msgstr "비밀번호 변경이 취소되었습니다."
+msgstr "암호 바꾸기를 취소했습니다."
 
 #: libpam/pam_item.c:311
 msgid "login:"
@@ -84,15 +84,15 @@ msgstr "치명적인 오류 - 즉시 중지"
 
 #: libpam/pam_strerror.c:44
 msgid "Failed to load module"
-msgstr "모듈 적재에 실패함"
+msgstr "모듈 적재 실패"
 
 #: libpam/pam_strerror.c:46
 msgid "Symbol not found"
-msgstr "기호를 찾을 수 없음"
+msgstr "심볼을 찾을 수 없음"
 
 #: libpam/pam_strerror.c:48
 msgid "Error in service module"
-msgstr "서비스 모듈에서 오류 발생"
+msgstr "서비스 모듈 오류"
 
 #: libpam/pam_strerror.c:50
 msgid "System error"
@@ -112,7 +112,7 @@ msgstr "인증 실패"
 
 #: libpam/pam_strerror.c:58
 msgid "Insufficient credentials to access authentication data"
-msgstr "인증 자료 접근에 불충분한 인증 정보"
+msgstr "인증 데이터 접근에 부족한 인증 정보"
 
 #: libpam/pam_strerror.c:60
 msgid "Authentication service cannot retrieve authentication info"
@@ -120,31 +120,31 @@ msgstr "인증 서비스에서 인증 정보를 가져올 수 없습니다"
 
 #: libpam/pam_strerror.c:62
 msgid "User not known to the underlying authentication module"
-msgstr "기본 인증 모듈에서 알지 못하는 사용자"
+msgstr "기본 인증 모듈에서 알 수 없는 사용자"
 
 #: libpam/pam_strerror.c:64
 msgid "Have exhausted maximum number of retries for service"
-msgstr "서비스를 최대로 재시도함"
+msgstr "서비스 최대 재시도 횟수를 넘었습니다"
 
 #: libpam/pam_strerror.c:66
 msgid "Authentication token is no longer valid; new one required"
-msgstr "인증 토큰이 더 이상 유효하지 않습니다; 새로운 것이 필요합니다"
+msgstr "인증 토큰이 경과했습니다. 새 인증 토큰이 필요합니다"
 
 #: libpam/pam_strerror.c:68
 msgid "User account has expired"
-msgstr "사용자 계정이 만료됨"
+msgstr "사용자 계정이 만료되었습니다"
 
 #: libpam/pam_strerror.c:70
 msgid "Cannot make/remove an entry for the specified session"
-msgstr "특정 세션을 위한 항목을 생성/삭제 할 수 없음"
+msgstr "특정 세션의 항목을 생성/제거할 수 없습니다"
 
 #: libpam/pam_strerror.c:72
 msgid "Authentication service cannot retrieve user credentials"
-msgstr "인증 서비스에서 사용자 인증을 읽을 수 없음"
+msgstr "인증 서비스에서 사용자 인증을 가져올 수 없습니다"
 
 #: libpam/pam_strerror.c:74
 msgid "User credentials expired"
-msgstr "사용자 인증 만료됨"
+msgstr "사용자 인증이 만료되었습니다"
 
 #: libpam/pam_strerror.c:76
 msgid "Failure setting user credentials"
@@ -152,23 +152,23 @@ msgstr "사용자 인증 설정 실패"
 
 #: libpam/pam_strerror.c:78
 msgid "No module specific data is present"
-msgstr "모듈 특정 자료가 없음"
+msgstr "모듈용 데이터가 없습니다"
 
 #: libpam/pam_strerror.c:80
 msgid "Bad item passed to pam_*_item()"
-msgstr "pam_*_item()에 전달된 잘못된 항목"
+msgstr "pam_*_item()에 잘못된 항목 전달함"
 
 #: libpam/pam_strerror.c:82
 msgid "Conversation error"
-msgstr "대화 오류"
+msgstr "인증 소통 처리 오류"
 
 #: libpam/pam_strerror.c:84
 msgid "Authentication token manipulation error"
-msgstr "인증 토근 조작 오류"
+msgstr "인증 토근 처리 오류"
 
 #: libpam/pam_strerror.c:86
 msgid "Authentication information cannot be recovered"
-msgstr "인증 정보가 복구 될 수 없습니다"
+msgstr "인증 정보를 복구할 수 없습니다"
 
 #: libpam/pam_strerror.c:88
 msgid "Authentication token lock busy"
@@ -176,19 +176,19 @@ msgstr "인증 토큰 잠금 사용 중"
 
 #: libpam/pam_strerror.c:90
 msgid "Authentication token aging disabled"
-msgstr "인증 토큰 기한이 비활성화됨"
+msgstr "인증 토큰 기한이 비활성화 됨"
 
 #: libpam/pam_strerror.c:92
 msgid "Failed preliminary check by password service"
-msgstr "비밀번호 서비스에서 사전 확인 실패함"
+msgstr "암호 서비스에서 사전 확인 실패함"
 
 #: libpam/pam_strerror.c:94
 msgid "The return value should be ignored by PAM dispatch"
-msgstr "반환 값은 PAM 긴급처리에서 무시됩니다"
+msgstr "반환 값은 PAM 전송에서 무시합니다"
 
 #: libpam/pam_strerror.c:96
 msgid "Module is unknown"
-msgstr "모듈을 알 수 없음"
+msgstr "알 수 없는 모듈"
 
 #: libpam/pam_strerror.c:98
 msgid "Authentication token expired"
@@ -196,11 +196,11 @@ msgstr "인증 토큰 만료됨"
 
 #: libpam/pam_strerror.c:100
 msgid "Conversation is waiting for event"
-msgstr "이벤트를 위해 인증 대화를 기다리는 중 입니다"
+msgstr "이벤트에 대한 인증 소통 처리를 기다리는 중"
 
 #: libpam/pam_strerror.c:102
 msgid "Application needs to call libpam again"
-msgstr "libpam을 다시 불러오려면 응용 프로그램이 필요함"
+msgstr "libpam을 다시 호출할 프로그램이 필요합니다"
 
 #: libpam/pam_strerror.c:105
 msgid "Unknown PAM error"
@@ -217,52 +217,53 @@ msgstr "...미안합니다, 시간이 다 되었습니다!\n"
 #: libpam_misc/misc_conv.c:348
 #, c-format
 msgid "erroneous conversation (%d)\n"
-msgstr "잘못된 인증 대화 (%d)\n"
+msgstr "잘못된 인증 소통 처리(%d)\n"
 
 #: modules/pam_exec/pam_exec.c:279
 #, c-format
 msgid "%s failed: exit code %d"
-msgstr "%s 실패함: 종료 코드 %d"
+msgstr "%s 실패: 종료 코드 %d"
 
 #: modules/pam_exec/pam_exec.c:289
 #, c-format
 msgid "%s failed: caught signal %d%s"
-msgstr "%s 실패함: 신호 발견 %d%s"
+msgstr "%s 실패: %d%s 시그널 확인"
 
 #: modules/pam_exec/pam_exec.c:299
 #, c-format
 msgid "%s failed: unknown status 0x%x"
-msgstr "%s 실패함: 알 수 없는 상태 0x%x"
+msgstr "%s 실패: 알 수 없는 상태 0x%x"
 
 #: modules/pam_faillock/main.c:103
 #, c-format
 msgid ""
 "Usage: %s [--dir /path/to/tally-directory] [--user username] [--reset]\n"
 msgstr ""
-"사용법: %s [--dir /path/to/tally-directory] [--user username] [--reset]\n"
+"사용법: %s [--dir /path/to/tally-directory] [--user <사용자이름>] [--"
+"reset]\n"
 
 #: modules/pam_faillock/pam_faillock.c:618
 #, c-format
 msgid "The account is locked due to %u failed logins."
-msgstr "계정은 %u 실패된 로그인으로 인해 잠김 상태가 되었습니다."
+msgstr "로그인에 %u회 실패하여 계정을 잠궜습니다."
 
 #: modules/pam_faillock/pam_faillock.c:627
 #: modules/pam_faillock/pam_faillock.c:633
 #, c-format
 msgid "(%d minute left to unlock)"
 msgid_plural "(%d minutes left to unlock)"
-msgstr[0] "(잠금 해제까지 %d 분 남았습니다)"
+msgstr[0] "(잠금 해제까지 %d분 남았습니다)"
 
 #. TRANSLATORS: only used if dngettext is not supported.
 #: modules/pam_faillock/pam_faillock.c:636
 #, c-format
 msgid "(%d minutes left to unlock)"
-msgstr "(잠금해제까지 %d 분 남았습니다)"
+msgstr "(잠금 해제까지 %d분 남았습니다)"
 
 #. TRANSLATORS: "strftime options for date of last login"
 #: modules/pam_lastlog/pam_lastlog.c:318 modules/pam_lastlog/pam_lastlog.c:579
 msgid " %a %b %e %H:%M:%S %Z %Y"
-msgstr " %a %b %e %H:%M:%S %Z %Y"
+msgstr " %b %e일 (%a) %H:%M:%S %Z %Y"
 
 #. TRANSLATORS: " from <host>"
 #: modules/pam_lastlog/pam_lastlog.c:327 modules/pam_lastlog/pam_lastlog.c:588
@@ -297,78 +298,78 @@ msgstr "마지막 실패한 로그인:%s%s%s"
 msgid "There was %d failed login attempt since the last successful login."
 msgid_plural ""
 "There were %d failed login attempts since the last successful login."
-msgstr[0] "마지막 로그인 이후에 %d 번의 실패한 로그인 시도가 있었습니다."
+msgstr[0] "마지막 로그인 이후 로그인 시도를 %d회 실패했습니다."
 
 #. TRANSLATORS: only used if dngettext is not supported
 #: modules/pam_lastlog/pam_lastlog.c:631
 #, c-format
 msgid "There were %d failed login attempts since the last successful login."
-msgstr "마지막 로그인 이후에 %d 번의 실패한 로그인 시도가 있었습니다."
+msgstr "마지막 로그인 이후 로그인 시도를 %d회 실패했습니다."
 
 #: modules/pam_limits/pam_limits.c:1164
 #, c-format
 msgid "There were too many logins for '%s'."
-msgstr "'%s'를 위해 너무 많은 로그인 시도가 있었습니다."
+msgstr "'%s' 계정에 로그인 시도를 너무 많이 했습니다."
 
 #: modules/pam_mail/pam_mail.c:289
 msgid "You have no mail."
-msgstr "전자우편이 없습니다."
+msgstr "전자메일이 없습니다."
 
 #: modules/pam_mail/pam_mail.c:292
 msgid "You have new mail."
-msgstr "새로운 전자우편이 있습니다."
+msgstr "새로운 전자메일이 있습니다."
 
 #: modules/pam_mail/pam_mail.c:295
 msgid "You have old mail."
-msgstr "오래된 전자우편이 있습니다."
+msgstr "오래된 전자메일이 있습니다."
 
 #: modules/pam_mail/pam_mail.c:299
 msgid "You have mail."
-msgstr "전자우편이 있습니다."
+msgstr "전자메일이 있습니다."
 
 #: modules/pam_mail/pam_mail.c:306
 #, c-format
 msgid "You have no mail in folder %s."
-msgstr "폴더 %s에 전자우편이 없습니다."
+msgstr "%s 폴더에 전자메일이 없습니다."
 
 #: modules/pam_mail/pam_mail.c:310
 #, c-format
 msgid "You have new mail in folder %s."
-msgstr "폴더 %s에 새로운 전자우편이 있습니다."
+msgstr "%s 폴더에 새로운 전자메일이 있습니다."
 
 #: modules/pam_mail/pam_mail.c:314
 #, c-format
 msgid "You have old mail in folder %s."
-msgstr "폴더 %s에 오래된 전자우편이 있습니다."
+msgstr "%s 폴더에 오래된 전자메일이 있습니다."
 
 #: modules/pam_mail/pam_mail.c:319
 #, c-format
 msgid "You have mail in folder %s."
-msgstr "폴더 %s에 전자우편이 있습니다."
+msgstr "%s 폴더에 전자메일이 있습니다."
 
 #: modules/pam_mkhomedir/pam_mkhomedir.c:123
 #, c-format
 msgid "Creating directory '%s'."
-msgstr "디렉토리 '%s'를 생성 중."
+msgstr "'%s' 디렉터리를 만듭니다."
 
 #: modules/pam_mkhomedir/pam_mkhomedir.c:206
 #, c-format
 msgid "Unable to create and initialize directory '%s'."
-msgstr "디렉토리 '%s'를 생성하고 초기화 할 수 없습니다."
+msgstr "'%s' 디렉터리를 만들어 초기화 할 수 없습니다."
 
 #: modules/pam_pwhistory/pam_pwhistory.c:371
 #: modules/pam_unix/pam_unix_passwd.c:589
 msgid "Password has been already used. Choose another."
-msgstr "비밀번호는 이미 사용되고 있습니다. 다른 것을 선택해 주세요."
+msgstr "이미 사용한 암호입니다. 다른 암호를 지정하십시오."
 
 #: modules/pam_pwhistory/pam_pwhistory.c:378
 msgid "Password has been already used."
-msgstr "비밀번호가 이미 사용되고 있습니다."
+msgstr "이미 사용한 암호입니다."
 
 #: modules/pam_selinux/pam_selinux.c:172
 #, c-format
 msgid "The default security context is %s."
-msgstr "기본 보안 문맥은 %s 입니다."
+msgstr "기본 보안 컨텍스트는 %s 입니다."
 
 #: modules/pam_selinux/pam_selinux.c:176
 msgid "Would you like to enter a different role or level?"
@@ -381,7 +382,7 @@ msgstr "역할:"
 #: modules/pam_selinux/pam_selinux.c:193
 #, c-format
 msgid "There is no default type for role %s."
-msgstr "역할 %s 에 대한 기본값 유형이 없습니다."
+msgstr "%s 역할에 대한 기본값 형식이 없습니다."
 
 #: modules/pam_selinux/pam_selinux.c:225
 msgid "level:"
@@ -389,173 +390,95 @@ msgstr "수준:"
 
 #: modules/pam_selinux/pam_selinux.c:259
 msgid "This is not a valid security context."
-msgstr "이는 유효한 보안 문맥이 아닙니다."
+msgstr "올바른 보안 컨텍스트가 아닙니다."
 
 #: modules/pam_selinux/pam_selinux.c:509
 #, c-format
 msgid "A valid context for %s could not be obtained."
-msgstr "%s를 위한 유효한 문맥은 가져올 수 없습니다."
+msgstr "%s의 올바른 컨텍스트를 가져올 수 없습니다."
 
 #: modules/pam_selinux/pam_selinux.c:640
 #, c-format
 msgid "Security context %s has been assigned."
-msgstr "보안 문맥 %s가 할당되었습니다."
+msgstr "%s 보안 컨텍스트를 할당했습니다."
 
 #: modules/pam_selinux/pam_selinux.c:656
 #, c-format
 msgid "Key creation context %s has been assigned."
-msgstr "키 생성 문맥 %s가 할당되었습니다."
+msgstr "%s 키 생성 컨텍스트를 할당했습니다."
 
 #: modules/pam_selinux/pam_selinux_check.c:99
 #, c-format
 msgid "failed to initialize PAM\n"
-msgstr "PAM 초기화에 실패함\n"
+msgstr "PAM 초기화 실패\n"
 
 #: modules/pam_selinux/pam_selinux_check.c:105
 #, c-format
 msgid "failed to pam_set_item()\n"
-msgstr "pam_set_item()에 실패함\n"
+msgstr "pam_set_item() 실패\n"
 
 #: modules/pam_selinux/pam_selinux_check.c:133
 #, c-format
 msgid "login: failure forking: %m"
-msgstr "로그인: 포크 작업 실패함: %m"
+msgstr "로그인: 포크 작업 실패: %m"
 
 #: modules/pam_timestamp/pam_timestamp.c:361
 #, c-format
 msgid "Access has been granted (last access was %ld seconds ago)."
-msgstr "접근이 허용되었습니다 (마지막 접근은 %ld 초 전 이었습니다)."
+msgstr "접근을 허락받았습니다(마지막 접근: %ld초 전)."
 
 #: modules/pam_unix/pam_unix_acct.c:230 modules/pam_unix/pam_unix_acct.c:252
 msgid "Your account has expired; please contact your system administrator."
-msgstr "자신의 계정이 만료되었습니다; 시스템 관리자에게 연락하세요."
+msgstr "계정이 만료되었습니다. 시스템 관리자에게 연락하세요."
 
 #: modules/pam_unix/pam_unix_acct.c:238
 msgid ""
 "You are required to change your password immediately (administrator "
 "enforced)."
-msgstr "비밀번호를 긴급히 변경해 주세요 (관리자가 강제합니다)."
+msgstr "암호를 즉시 바꿔야 합니다(관리자 강제)."
 
 #: modules/pam_unix/pam_unix_acct.c:244
 msgid ""
 "You are required to change your password immediately (password expired)."
-msgstr "비밀번호를 긴급히 변경해 주세요 (비밀번호가 만료됨)."
+msgstr "암호를 즉시 바꿔야 합니다(암호가 만료됨)."
 
 #: modules/pam_unix/pam_unix_acct.c:269 modules/pam_unix/pam_unix_acct.c:276
 #, c-format
 msgid "Warning: your password will expire in %d day."
 msgid_plural "Warning: your password will expire in %d days."
-msgstr[0] "경고: 당신의 비밀번호는 %d 일 이내로 만료됩니다."
+msgstr[0] "경고: 암호가 %d일 이내로 만료됩니다."
 
 #. TRANSLATORS: only used if dngettext is not supported
 #: modules/pam_unix/pam_unix_acct.c:281
 #, c-format
 msgid "Warning: your password will expire in %d days."
-msgstr "경고: 자신의 비밀번호가 %d 일 이내로 만료됩니다."
+msgstr "경고: 암호가 %d일 이내로 만료됩니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:465
 msgid "NIS password could not be changed."
-msgstr "NIS 비밀번호는 변경 될 수 없습니다."
+msgstr "NIS 암호는 바꿀 수 없습니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:563
 msgid "No password has been supplied."
-msgstr "비밀번호가 입력되지 않았습니다."
+msgstr "암호를 입력하지 않았습니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:564
 msgid "The password has not been changed."
-msgstr "비밀번호가 변경되지 않았습니다."
+msgstr "암호가 바뀌지 않았습니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:581
 msgid "You must choose a shorter password."
-msgstr "더 짧은 비밀번호를 선택해야 합니다."
+msgstr "더 짧은 암호를 선택해야 합니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:585
 msgid "You must choose a longer password."
-msgstr "더 긴 비밀번호를 선택해 주세요."
+msgstr "더 긴 암호를 선택해야 합니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:692
 #, c-format
 msgid "Changing password for %s."
-msgstr "%s의 비밀번호를 변경하기."
+msgstr "%s의 암호를 바꿉니다."
 
 #: modules/pam_unix/pam_unix_passwd.c:722
 msgid "You must wait longer to change your password."
-msgstr "비밀번호를 변경하려면 조금 더 기다려야 합니다."
-
-#~ msgid "is the same as the old one"
-#~ msgstr "이전 암호와 같음"
-
-#~ msgid "memory allocation error"
-#~ msgstr "메모리 할당 오류 "
-
-#~ msgid "is a palindrome"
-#~ msgstr "앞뒤 어느쪽에서 읽어도 같은 문맥임"
-
-#~ msgid "case changes only"
-#~ msgstr "대소문자만 변경"
-
-#~ msgid "is too similar to the old one"
-#~ msgstr "이전 암호와 유사함"
-
-#~ msgid "is too simple"
-#~ msgstr "너무 간단함"
-
-#~ msgid "is rotated"
-#~ msgstr "교체됨"
-
-#~ msgid "not enough character classes"
-#~ msgstr "문자 클래스가 부족합니다  "
-
-#~ msgid "contains too many same characters consecutively"
-#~ msgstr "너무 많은 동일한 문자가 연속적으로 포함되어있습니다   "
-
-#~ msgid "contains too long of a monotonic character sequence"
-#~ msgstr "너무 길게 단순한 문자가 연속적으로 포함되어 있습니다 "
-
-#~ msgid "contains the user name in some form"
-#~ msgstr "어떠한 형식으로 사용자 이름을 포함합니다.  "
-
-#~ msgid "BAD PASSWORD: %s"
-#~ msgstr "잘못된 암호: %s"
-
-#, fuzzy
-#~ msgid "The account is temporarily locked (%ld seconds left)."
-#~ msgstr "일시적으로 계정이 잠금되었습니다 (%ld 초 남음)  "
-
-#~ msgid "Authentication error"
-#~ msgstr "인증 오류"
-
-#~ msgid "Service error"
-#~ msgstr "서비스 오류"
-
-#~ msgid "Unknown user"
-#~ msgstr "알 수 없는 사용자"
-
-#~ msgid "Unknown error"
-#~ msgstr "알 수 없는 오류"
-
-#~ msgid "%s: Bad number given to --reset=\n"
-#~ msgstr "%s: 잘못된 숫자가 --reset=에 설정됨\n"
-
-#~ msgid "%s: Unrecognised option %s\n"
-#~ msgstr "%s: 알려지지 않은 옵션 %s\n"
-
-#~ msgid ""
-#~ "%s: [--file rooted-filename] [--user username] [--reset[=n]] [--quiet]\n"
-#~ msgstr ""
-#~ "%s: [--file rooted-filename] [--user username] [--reset[=n]] [--quiet]\n"
-
-#~ msgid "%s: Can't reset all users to non-zero\n"
-#~ msgstr "%s: 모든 사용자를 영이 아닌 값으로 설정할 수 없음\n"
-
-#~ msgid "Login           Failures Latest failure     From\n"
-#~ msgstr "로그인           실패 마지막 실패     다음에서 발생\n"
-
-#~ msgid ""
-#~ "%s: [-f rooted-filename] [--file rooted-filename]\n"
-#~ "   [-u username] [--user username]\n"
-#~ "   [-r] [--reset[=n]] [--quiet]\n"
-#~ msgstr ""
-#~ "%s: [-f rooted-filename] [--file rooted-filename]\n"
-#~ "   [-u username] [--user username]\n"
-#~ "   [-r] [--reset[=n]] [--quiet]\n"
+msgstr "암호를 바꾸려면 조금 더 기다려야 합니다."

--- a/po/ko.po
+++ b/po/ko.po
@@ -84,7 +84,7 @@ msgstr "치명적인 오류 - 즉시 중지"
 
 #: libpam/pam_strerror.c:44
 msgid "Failed to load module"
-msgstr "모듈 적재 실패"
+msgstr "모듈 불러오기 실패"
 
 #: libpam/pam_strerror.c:46
 msgid "Symbol not found"


### PR DESCRIPTION
The original translation came from fedoraproject Weblate has totally broken, and it has no formal expression.

It would be helpful for keeping the consistency of the Korean translation in the Linux CLI environment.