### PR TITLE
Fixing issue#455

### DIFF
--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -231,8 +231,8 @@ static void try_to_display_directories_with_overrides(pam_handle_t *pamh,
     for (i = 0; i < num_motd_dirs; i++) {
 	int rv;
         motddir(motd_dir_path_split[i]);
-        rv = scandir(motd_dir_path_split[i], &(dirscans[i]),
-		     filter_dirents, alphasort);
+	rv = scandir(motd_dir_path_split[i], &(dirscans[i]),
+		filter_dirents, alphasort);
 	if (rv < 0) {
 	    if (errno != ENOENT || report_missing) {
 		pam_syslog(pamh, LOG_ERR, "error scanning directory %s: %m",

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -231,7 +231,7 @@ static void try_to_display_directories_with_overrides(pam_handle_t *pamh,
     for (i = 0; i < num_motd_dirs; i++) {
 	int rv;
         motddir(motd_dir_path_split[i]);
-	rv = scandir(motd_dir_path_split[i], &(dirscans[i]),
+        rv = scandir(motd_dir_path_split[i], &(dirscans[i]),
 		filter_dirents, alphasort);
 	if (rv < 0) {
 	    if (errno != ENOENT || report_missing) {

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -181,7 +181,7 @@ static int filter_dirents(const struct dirent *d)
     char *fullpath;
     int rc;
 
-    switch( d->d_type ) {
+    switch( d->d_type ) {  /* the filetype determines how to proceed      */
 	case DT_REG:
 	case DT_LNK:
             return 1;      /* regular files and symlinks are good         */

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -166,7 +166,7 @@ static int compare_strings(const void *a, const void *b)
     }
 }
 
-const char* motddir( char *d )
+const char* motddir( const char *d )
 {
     static const char* dir;
 


### PR DESCRIPTION
in module pam_motd, filter_dirents() relied on the filetype being available.