### PR TITLE
ci: add a few vendordir enabled jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,21 @@ jobs:
     - name: check
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
+  gcc11-x86_64-vendordir:
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-11
+      TARGET: x86_64
+      VENDORDIR: /usr/etc
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
   gcc11-x86_64:
     runs-on: ubuntu-20.04
     env:
@@ -60,6 +75,21 @@ jobs:
     env:
       CC: gcc-8
       TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang12-x86_64-vendordir:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang-12
+      TARGET: x86_64
+      VENDORDIR: /usr/etc
     steps:
     - uses: actions/checkout@v2
       with:
@@ -130,6 +160,21 @@ jobs:
     env:
       CC: clang-8
       TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  gcc11-x86-vendordir:
+    runs-on: ubuntu-18.04
+    env:
+      CC: gcc-11
+      TARGET: x86
+      VENDORDIR: /usr/etc
     steps:
     - uses: actions/checkout@v2
       with:

--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -32,6 +32,12 @@ case "${CHECK-}" in
 		;;
 esac
 
+case "${VENDORDIR-}" in
+	/*)
+		DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --enable-vendordir=$VENDORDIR"
+		;;
+esac
+
 echo 'BEGIN OF BUILD ENVIRONMENT INFORMATION'
 uname -a |head -1
 libc="$(ldd /bin/sh |sed -n 's|^[^/]*\(/[^ ]*/libc\.so[^ ]*\).*|\1|p' |head -1)"


### PR DESCRIPTION
Given that we are adding more code that depends on --enable-vendordir, it's time to add a few vendordir enabled jobs to the test matrix.