### PR TITLE
pam_exec: add SIGCHLD protection handle

### DIFF
--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -48,6 +48,7 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <signal.h>
 
 #include <security/pam_modules.h>
 #include <security/pam_modutil.h>
@@ -105,6 +106,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
   FILE *stdout_file = NULL;
   int retval;
   const char *name;
+  struct sigaction newsa, oldsa;
 
   if (argc < 1) {
     pam_syslog (pamh, LOG_ERR,
@@ -226,6 +228,13 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
     return PAM_SERVICE_ERR;
   }
 
+  memset(&newsa, '\0', sizeof(newsa));
+  newsa.sa_handler = SIG_DFL;
+  if (sigaction(SIGCHLD, &newsa, &oldsa) == -1) {
+    pam_syslog(pamh, LOG_ERR, "Cannot set signal value");
+    return PAM_SYSTEM_ERR;
+  }
+
   pid = fork();
   if (pid == -1)
     return PAM_SYSTEM_ERR;
@@ -263,6 +272,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
       while ((rc = waitpid (pid, &status, 0)) == -1 &&
 	     errno == EINTR);
+      sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
       if (rc == (pid_t)-1)
 	{
 	  pam_syslog (pamh, LOG_ERR, "waitpid returns with -1: %m");

--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -231,7 +231,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
   memset(&newsa, '\0', sizeof(newsa));
   newsa.sa_handler = SIG_DFL;
   if (sigaction(SIGCHLD, &newsa, &oldsa) == -1) {
-    pam_syslog(pamh, LOG_ERR, "Cannot set signal value");
+    pam_syslog(pamh, LOG_ERR, "handle SIGCHLD signal failed");
     return PAM_SYSTEM_ERR;
   }
 

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -52,6 +52,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#include <signal.h>
 
 #include <security/pam_modules.h>
 #include <security/_pam_macros.h>
@@ -99,8 +100,16 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	char *buffer = NULL;
 	size_t buffer_size = 0;
 	va_list ap;
+    struct sigaction newsa, oldsa;
 
 	*output = NULL;
+
+    memset(&newsa, '\0', sizeof(newsa));
+    newsa.sa_handler = SIG_DFL;
+    if (sigaction(SIGCHLD, &newsa, &oldsa) == -1) {
+        pam_syslog(pamh, LOG_ERR, "Cannot set signal value");
+        return PAM_SYSTEM_ERR;
+	}
 
 	/* Create stdio pipery. */
 	if (pipe(ipipe) == -1) {
@@ -209,6 +218,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 			}
 			close(opipe[0]);
 			waitpid(child, NULL, 0);
+			sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
 			return -1;
 		}
 		/* Save the new buffer location, copy the newly-read data into
@@ -225,6 +235,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	close(opipe[0]);
 	*output = buffer;
 	waitpid(child, NULL, 0);
+	sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
 	return 0;
 }
 

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -52,6 +52,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#include <signal.h>
 
 #include <security/pam_modules.h>
 #include <security/_pam_macros.h>
@@ -99,8 +100,16 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	char *buffer = NULL;
 	size_t buffer_size = 0;
 	va_list ap;
+	struct sigaction newsa, oldsa;
 
 	*output = NULL;
+
+	memset(&newsa, '\0', sizeof(newsa));
+	newsa.sa_handler = SIG_DFL;
+	if (sigaction(SIGCHLD, &newsa, &oldsa) == -1) {
+		pam_syslog(pamh, LOG_ERR, "handle SIGCHLD signal failed");
+		return PAM_SYSTEM_ERR;
+	}
 
 	/* Create stdio pipery. */
 	if (pipe(ipipe) == -1) {
@@ -209,6 +218,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 			}
 			close(opipe[0]);
 			waitpid(child, NULL, 0);
+			sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
 			return -1;
 		}
 		/* Save the new buffer location, copy the newly-read data into
@@ -225,6 +235,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	close(opipe[0]);
 	*output = buffer;
 	waitpid(child, NULL, 0);
+	sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
 	return 0;
 }
 


### PR DESCRIPTION
save the SIGCHLD handler and return to the default before calling fork
restore the handler after waitpid returns

* modules/pam_exec/pam_exec.c (call_exec): add SIGCHLD protection handle.
* modules/pam_xauth/pam_xauth.c (run_coprocess): add SIGCHLD protection handle.

Resolves: https://github.com/linux-pam/linux-pam/issues/405