### PR TITLE
pam_pwhistory: load config from file

### DIFF
--- a/libpam/include/security/pam_modutil.h
+++ b/libpam/include/security/pam_modutil.h
@@ -147,7 +147,16 @@ pam_modutil_sanitize_helper_fds(pam_handle_t *pamh,
 				enum pam_modutil_redirect_fd redirect_stdout,
 				enum pam_modutil_redirect_fd redirect_stderr);
 
-/* lookup a value for key in login.defs file or similar key value format */
+/**************************************************
+ * @brief Lookup a value for the key in the file (i.e. login.defs or a similar
+ * key-value format file).
+ *
+ * @param[in] pamh The pam handle structure
+ * @param[in] file_name Configuration file name
+ * @param[in] key Lookup key
+ *
+ * @return value, or NULL if key was not found.
+ **************************************************/
 extern char * PAM_NONNULL((1,2,3))
 pam_modutil_search_key(pam_handle_t *pamh,
 		       const char *file_name,

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -26,12 +26,14 @@ if HAVE_VERSIONING
   pam_pwhistory_la_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
 
-noinst_HEADERS = opasswd.h
+noinst_HEADERS = opasswd.h pwhistory_config.h
+
+dist_secureconf_DATA = pwhistory.conf
 
 securelib_LTLIBRARIES = pam_pwhistory.la
 pam_pwhistory_la_CFLAGS = $(AM_CFLAGS)
 pam_pwhistory_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@ @LIBSELINUX@
-pam_pwhistory_la_SOURCES = pam_pwhistory.c opasswd.c
+pam_pwhistory_la_SOURCES = pam_pwhistory.c opasswd.c pwhistory_config.c
 
 sbin_PROGRAMS = pwhistory_helper
 pwhistory_helper_CFLAGS = $(AM_CFLAGS) -DHELPER_COMPILE=\"pwhistory_helper\" @EXE_CFLAGS@

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -9,9 +9,10 @@ MAINTAINERCLEANFILES = $(MANS) README
 EXTRA_DIST = $(XMLS)
 
 if HAVE_DOC
-dist_man_MANS = pam_pwhistory.8 pwhistory_helper.8
+dist_man_MANS = pam_pwhistory.8 pwhistory_helper.8 pwhistory.conf.5
 endif
-XMLS = README.xml pam_pwhistory.8.xml pwhistory_helper.8.xml
+XMLS = README.xml pam_pwhistory.8.xml pwhistory_helper.8.xml \
+  pwhistory.conf.5.xml
 dist_check_SCRIPTS = tst-pam_pwhistory
 TESTS = $(dist_check_SCRIPTS)
 

--- a/modules/pam_pwhistory/pam_pwhistory.8.xml
+++ b/modules/pam_pwhistory/pam_pwhistory.8.xml
@@ -39,6 +39,9 @@
       <arg choice="opt">
 	      file=<replaceable>/path/filename</replaceable>
       </arg>
+      <arg choice="opt">
+	      conf=<replaceable>/path/to/config-file</replaceable>
+      </arg>
 
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -107,7 +110,7 @@
         <listitem>
           <para>
             The last <replaceable>N</replaceable> passwords for each
-            user are saved in <filename>/etc/security/opasswd</filename>.
+            user are saved.
             The default is <emphasis>10</emphasis>. Value of
             <emphasis>0</emphasis> makes the module to keep the existing
             contents of the <filename>opasswd</filename> file unchanged.
@@ -153,7 +156,26 @@
           </listitem>
         </varlistentry>
 
+        <varlistentry>
+          <term>
+            <option>conf=<replaceable>/path/to/config-file</replaceable></option>
+          </term>
+          <listitem>
+            <para>
+              Use another configuration file instead of the default
+              <filename>/etc/security/pwhistory.conf</filename>.
+            </para>
+          </listitem>
+        </varlistentry>
+
     </variablelist>
+    <para>
+      The options for configuring the module behavior are described in the
+      <citerefentry><refentrytitle>pwhistory.conf</refentrytitle>
+      <manvolnum>5</manvolnum></citerefentry> manual page. The options
+      specified on the module command line override the values from the
+      configuration file.
+    </para>
   </refsect1>
 
   <refsect1 id="pam_pwhistory-types">
@@ -238,6 +260,9 @@ password     required       pam_unix.so        use_authtok
   <refsect1 id='pam_pwhistory-see_also'>
     <title>SEE ALSO</title>
     <para>
+      <citerefentry>
+	<refentrytitle>pwhistory.conf</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
       <citerefentry>
 	<refentrytitle>pam.conf</refentrytitle><manvolnum>5</manvolnum>
       </citerefentry>,

--- a/modules/pam_pwhistory/pam_pwhistory.c
+++ b/modules/pam_pwhistory/pam_pwhistory.c
@@ -63,15 +63,8 @@
 
 #include "opasswd.h"
 #include "pam_inline.h"
+#include "pwhistory_config.h"
 
-struct options_t {
-  int debug;
-  int enforce_for_root;
-  int remember;
-  int tries;
-  const char *filename;
-};
-typedef struct options_t options_t;
 
 
 static void
@@ -312,13 +305,14 @@ pam_sm_chauthtok (pam_handle_t *pamh, int flags, int argc, const char **argv)
   options.remember = 10;
   options.tries = 1;
 
+  parse_config_file(pamh, argc, argv, &options);
+
   /* Parse parameters for module */
   for ( ; argc-- > 0; argv++)
     parse_option (pamh, *argv, &options);
 
   if (options.debug)
     pam_syslog (pamh, LOG_DEBUG, "pam_sm_chauthtok entered");
-
 
   if (options.remember == 0)
     return PAM_IGNORE;

--- a/modules/pam_pwhistory/pwhistory.conf
+++ b/modules/pam_pwhistory/pwhistory.conf
@@ -1,0 +1,21 @@
+# Configuration for remembering the last passwords used by a user.
+#
+# Enable the debugging logs.
+# Enabled if option is present.
+# debug
+#
+# root account's passwords are also remembered.
+# Enabled if option is present.
+# enforce_for_root
+#
+# Number of passwords to remember.
+# The default is 10.
+# remember = 10
+#
+# Number of times to prompt for the password.
+# The default is 1.
+# retry = 1
+#
+# The directory where the last passwords are kept.
+# The default is /etc/security/opasswd.
+# file = /etc/security/opasswd

--- a/modules/pam_pwhistory/pwhistory.conf.5.xml
+++ b/modules/pam_pwhistory/pwhistory.conf.5.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+
+<refentry id="pwhistory.conf">
+
+  <refmeta>
+    <refentrytitle>pwhistory.conf</refentrytitle>
+    <manvolnum>5</manvolnum>
+    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+  </refmeta>
+
+  <refnamediv id="pwhistory.conf-name">
+    <refname>pwhistory.conf</refname>
+    <refpurpose>pam_pwhistory configuration file</refpurpose>
+  </refnamediv>
+
+  <refsect1 id="pwhistory.conf-description">
+
+    <title>DESCRIPTION</title>
+    <para>
+       <emphasis remap='B'>pwhistory.conf</emphasis> provides a way to configure the
+       default settings for saving the last passwords for each user.
+       This file is read by the <emphasis>pam_pwhistory</emphasis> module and is the
+       preferred method over configuring <emphasis>pam_pwhistory</emphasis> directly.
+    </para>
+    <para>
+       The file has a very simple <emphasis>name = value</emphasis> format with possible comments
+       starting with <emphasis>#</emphasis> character. The whitespace at the beginning of line, end
+       of line, and around the <emphasis>=</emphasis> sign is ignored.
+    </para>
+  </refsect1>
+
+  <refsect1 id="pwhistory.conf-options">
+
+    <title>OPTIONS</title>
+         <variablelist>
+            <varlistentry>
+              <term>
+                <option>debug</option>
+              </term>
+              <listitem>
+                <para>
+                  Turns on debugging via
+                  <citerefentry>
+                    <refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum>
+                  </citerefentry>.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <option>enforce_for_root</option>
+              </term>
+              <listitem>
+                <para>
+                  If this option is set, the check is enforced for root, too.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <option>remember=<replaceable>N</replaceable></option>
+              </term>
+              <listitem>
+                <para>
+                  The last <replaceable>N</replaceable> passwords for each
+                  user are saved.
+                  The default is <emphasis>10</emphasis>. Value of
+                  <emphasis>0</emphasis> makes the module to keep the existing
+                  contents of the <filename>opasswd</filename> file unchanged.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <option>retry=<replaceable>N</replaceable></option>
+              </term>
+              <listitem>
+                <para>
+                  Prompt user at most <replaceable>N</replaceable> times
+                  before returning with error. The default is 1.
+                </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <option>file=<replaceable>/path/filename</replaceable></option>
+              </term>
+              <listitem>
+                <para>
+                  Store password history in file
+                  <replaceable>/path/filename</replaceable> rather than the default
+                  location. The default location is
+	                <filename>/etc/security/opasswd</filename>.
+                </para>
+              </listitem>
+            </varlistentry>
+        </variablelist>
+  </refsect1>
+
+  <refsect1 id='pwhistory.conf-examples'>
+    <title>EXAMPLES</title>
+    <para>
+      /etc/security/pwhistory.conf file example:
+    </para>
+    <programlisting>
+debug
+remember=5
+file=/tmp/opasswd
+    </programlisting>
+  </refsect1>
+
+  <refsect1 id="pwhistory.conf-files">
+    <title>FILES</title>
+    <variablelist>
+      <varlistentry>
+        <term><filename>/etc/security/pwhistory.conf</filename></term>
+        <listitem>
+          <para>the config file for custom options</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1 id='pwhistory.conf-see_also'>
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+        <refentrytitle>pwhistory</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam_pwhistory</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam.conf</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam.d</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pwhistory.conf-author'>
+    <title>AUTHOR</title>
+      <para>
+        pam_pwhistory was written by Thorsten Kukuk. The support for
+        pwhistory.conf was written by Iker Pedrosa.
+      </para>
+  </refsect1>
+
+</refentry>

--- a/modules/pam_pwhistory/pwhistory_config.c
+++ b/modules/pam_pwhistory/pwhistory_config.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 Iker Pedrosa <ipedrosa@redhat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU Public License, in which case the provisions of the GPL are
+ * required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <security/pam_modutil.h>
+
+#include "pam_inline.h"
+#include "pwhistory_config.h"
+
+#define PWHISTORY_DEFAULT_CONF SCONFIGDIR "/pwhistory.conf"
+
+void
+parse_config_file(pam_handle_t *pamh, int argc, const char **argv,
+                  struct options_t *options)
+{
+    const char *fname = NULL;
+    int i;
+    char *val;
+
+    for (i = 0; i < argc; ++i) {
+        const char *str = pam_str_skip_prefix(argv[i], "conf=");
+
+        if (str != NULL) {
+            fname = str;
+        }
+    }
+
+    if (fname == NULL) {
+        fname = PWHISTORY_DEFAULT_CONF;
+    }
+
+    val = pam_modutil_search_key (pamh, fname, "debug");
+    if (val != NULL) {
+        options->debug = 1;
+        free(val);
+    }
+
+    val = pam_modutil_search_key (pamh, fname, "enforce_for_root");
+    if (val != NULL) {
+        options->enforce_for_root = 1;
+        free(val);
+    }
+
+    val = pam_modutil_search_key (pamh, fname, "remember");
+    if (val != NULL) {
+        unsigned int temp;
+        if (sscanf(val, "%u", &temp) != 1) {
+            pam_syslog(pamh, LOG_ERR,
+                "Bad number supplied for remember argument");
+        } else {
+            options->remember = temp;
+        }
+        free(val);
+    }
+
+    val = pam_modutil_search_key (pamh, fname, "retry");
+    if (val != NULL) {
+        unsigned int temp;
+        if (sscanf(val, "%u", &temp) != 1) {
+            pam_syslog(pamh, LOG_ERR,
+                "Bad number supplied for retry argument");
+        } else {
+            options->tries = temp;
+        }
+        free(val);
+    }
+
+    val = pam_modutil_search_key (pamh, fname, "file");
+    if (val != NULL) {
+        if (*val != '/') {
+            pam_syslog (pamh, LOG_ERR,
+                "File path should be absolute: %s", val);
+        } else {
+            options->filename = val;
+        }
+    }
+}

--- a/modules/pam_pwhistory/pwhistory_config.h
+++ b/modules/pam_pwhistory/pwhistory_config.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Iker Pedrosa <ipedrosa@redhat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU Public License, in which case the provisions of the GPL are
+ * required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PWHISTORY_CONFIG_H
+#define _PWHISTORY_CONFIG_H
+
+#include <security/pam_ext.h>
+
+struct options_t {
+    int debug;
+    int enforce_for_root;
+    int remember;
+    int tries;
+    const char *filename;
+};
+typedef struct options_t options_t;
+
+void
+parse_config_file(pam_handle_t *pamh, int argc, const char **argv,
+                  struct options_t *options);
+
+#endif /* _PWHISTORY_CONFIG_H */


### PR DESCRIPTION
I have added a new `conf` option in pam_pwhistory to select the configuration file to read. The default one being `/etc/security/pwhistory.conf`. On top of that I have used `pam_modutil_search_key()` function to read the pwhistory configuration file. This configuration is then loaded in the corresponding `options` structure.

Besides, I have documented the new `conf` option and the configuration file itself.

Finally, I have improved the `pam_modutil_search_key()` documentation.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2068461