### PR TITLE
Consistently reset the SIGCHLD handler before forking off helper processes

### DIFF
--- a/modules/pam_mkhomedir/pam_mkhomedir.c
+++ b/modules/pam_mkhomedir/pam_mkhomedir.c
@@ -125,15 +125,6 @@ create_homedir (pam_handle_t *pamh, options_t *opt,
 
    D(("called."));
 
-   /*
-    * This code arranges that the demise of the child does not cause
-    * the application to receive a signal it is not expecting - which
-    * may kill the application or worse.
-    */
-   memset(&newsa, '\0', sizeof(newsa));
-   newsa.sa_handler = SIG_DFL;
-   sigaction(SIGCHLD, &newsa, &oldsa);
-
    if (opt->ctrl & MKHOMEDIR_DEBUG) {
         pam_syslog(pamh, LOG_DEBUG, "Executing mkhomedir_helper.");
    }
@@ -152,6 +143,15 @@ create_homedir (pam_handle_t *pamh, options_t *opt,
    } else {
       login_homemode = _pam_conv_str_umask_to_homemode(opt->umask);
    }
+
+   /*
+    * This code arranges that the demise of the child does not cause
+    * the application to receive a signal it is not expecting - which
+    * may kill the application or worse.
+    */
+   memset(&newsa, '\0', sizeof(newsa));
+   newsa.sa_handler = SIG_DFL;
+   sigaction(SIGCHLD, &newsa, &oldsa);
 
    /* fork */
    child = fork();

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -52,6 +52,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#include <signal.h>
 
 #include <security/pam_modules.h>
 #include <security/_pam_macros.h>
@@ -99,6 +100,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	char *buffer = NULL;
 	size_t buffer_size = 0;
 	va_list ap;
+	struct sigaction newsa, oldsa;
 
 	*output = NULL;
 
@@ -111,6 +113,17 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 		pam_syslog(pamh, LOG_ERR, "Could not create pipe: %m");
 		close(ipipe[0]);
 		close(ipipe[1]);
+		return -1;
+	}
+
+	memset(&newsa, '\0', sizeof(newsa));
+	newsa.sa_handler = SIG_DFL;
+	if (sigaction(SIGCHLD, &newsa, &oldsa) == -1) {
+		pam_syslog(pamh, LOG_ERR, "failed to reset SIGCHLD handler: %m");
+		close(ipipe[0]);
+		close(ipipe[1]);
+		close(opipe[0]);
+		close(opipe[1]);
 		return -1;
 	}
 
@@ -209,6 +222,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 			}
 			close(opipe[0]);
 			waitpid(child, NULL, 0);
+			sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
 			return -1;
 		}
 		/* Save the new buffer location, copy the newly-read data into
@@ -225,6 +239,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	close(opipe[0]);
 	*output = buffer;
 	waitpid(child, NULL, 0);
+	sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
 	return 0;
 }
 


### PR DESCRIPTION
In pam_exec and pam_xauth, reset the SIGCHLD handler while a helper process is being handled.
In pam_mkhomedir and pam_namespace, move this SIGCHLD handler reset right before the fork call.

This addresses #405 and #469.