### PR TITLE
[RFC] pam_unix: use helper on skeleton root entry from libnss-systemd

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -242,7 +242,9 @@ PAMH_ARG_DECL(int get_account_info,
 			 * if shadowing is enabled
 			 */
 			*spwdent = pam_modutil_getspnam(pamh, name);
-			if (*spwdent == NULL) {
+			if (*spwdent == NULL ||
+			    /* synthesized entry from libnss-systemd */
+			    (strcmp(name, "root") == 0 && (*spwdent)->sp_pwdp && strcmp((*spwdent)->sp_pwdp, "!*") == 0)) {
 #ifndef HELPER_COMPILE
 				/* still a chance the user can authenticate */
 				return PAM_UNIX_RUN_HELPER;


### PR DESCRIPTION
libnss-systemd started[1] to synthesize a root entry with an invalid
password.  On Debian since version 251.3-2[2] systemd enables the
systemd module for shadow and gsshadow in nsswitch.conf.  This leads on
SELinux enabled systems, where the files module can not access the
shadow file, to the root account being locked.

Fall back to the unix_chkpwd helper in case the root user was queried
and the response was a locked password ("!*"[3]).

See also https://github.com/systemd/systemd/issues/20299 for previous issue leading to https://github.com/linux-pam/linux-pam/commit/470823c4aacef5cb3b1180be6ed70846b61a3752.

[1]: https://github.com/systemd/systemd/commit/f43a19ecd6e3415e
[2]: https://salsa.debian.org/systemd-team/systemd/-/commit/bf9a307cfcbe62ab4fbcf2198e6e628a1bca211b
[3]: https://github.com/systemd/systemd/blob/b622e95f2f59fcb58e23ddafed745eee26a0f52f/src/nss-systemd/nss-systemd.c#L34