### PR TITLE
security: Add landlock file restriction

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -528,6 +528,26 @@ fi
 
 ECONF_CFLAGS=
 ECONF_LIBS=
+AC_ARG_ENABLE([landlock],
+    AS_HELP_STRING([--enable-landlock],[Enable Landlock sandbox]),
+    [WITH_LANDLOCK=$enableval], WITH_LANDLOCK=no)
+if test "$WITH_LANDLOCK" = "yes" ; then
+  AC_CHECK_DECL([__NR_landlock_create_ruleset], [], [], [#include <sys/syscall.h>])
+  AC_CHECK_DECL([__NR_landlock_add_rule], [], [], [#include <sys/syscall.h>])
+  AC_CHECK_DECL([__NR_landlock_restrict_self], [], [], [#include <sys/syscall.h>])
+  AC_CHECK_HEADER(linux/landlock.h, [have_landlock_header=1], [have_landlock_header=0])
+  if test "x$ac_cv_have_decl___NR_landlock_create_ruleset" = xyes &&
+     test "x$ac_cv_have_decl___NR_landlock_add_rule" = xyes &&
+     test "x$ac_cv_have_decl___NR_landlock_restrict_self" = xyes &&
+     test "$have_landlock_header" = 1; then
+    AC_DEFINE([WITH_LANDLOCK], 1, [Defined if Landlock sandbox support is compiled in])
+  else
+    WITH_LANDLOCK=no
+  fi
+else
+  WITH_LANDLOCK=no
+fi
+
 AC_ARG_ENABLE([econf],
   AS_HELP_STRING([--disable-econf], [do not use libeconf]),
   [WITH_ECONF=$enableval], [WITH_ECONF=yes])
@@ -710,6 +730,7 @@ AM_CONDITIONAL([COND_BUILD_PAM_SETQUOTA], [test "$ac_cv_func_quotactl" = yes])
 AM_CONDITIONAL([COND_BUILD_PAM_TTY_AUDIT], [test "$HAVE_AUDIT_TTY_STATUS" = yes])
 AM_CONDITIONAL([COND_BUILD_PAM_UNIX], [test "$enable_unix" = yes])
 AM_CONDITIONAL([COND_BUILD_PAM_USERDB], [test -n "$LIBDB"])
+AM_CONDITIONAL([COND_BUILD_LANDLOCK], [test "$WITH_LANDLOCK" = yes])
 
 dnl Files to be created from when we run configure
 AC_CONFIG_FILES([Makefile libpam/Makefile libpamc/Makefile libpamc/test/Makefile \

--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -11,9 +11,14 @@ CLEANFILES = *~
 
 EXTRA_DIST = libpam.map
 
+if COND_BUILD_LANDLOCK
+ MAYBE_PAM_LANDLOCK = include/security/pam_landlock.h
+endif
+
 include_HEADERS = include/security/_pam_compat.h \
 	include/security/_pam_macros.h include/security/_pam_types.h \
 	include/security/pam_appl.h include/security/pam_modules.h \
+	${MAYBE_PAM_LANDLOCK} \
 	include/security/pam_ext.h include/security/pam_modutil.h
 
 noinst_HEADERS = pam_prelude.h pam_private.h pam_tokens.h \

--- a/libpam/include/security/pam_landlock.h
+++ b/libpam/include/security/pam_landlock.h
@@ -1,0 +1,104 @@
+#include "_pam_macros.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/landlock.h>
+#include <linux/prctl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef _SECURITY_PAM_LANDLOCK_H
+#define _SECURITY_PAM_LANDLOCK_H
+
+#ifndef landlock_create_ruleset
+static inline int
+landlock_create_ruleset(const struct landlock_ruleset_attr *const attr,
+		const size_t size, const __u32 flags)
+{
+	return syscall(__NR_landlock_create_ruleset, attr, size, flags);
+}
+#endif
+
+#ifndef landlock_add_rule
+static inline int landlock_add_rule(const int ruleset_fd,
+		const enum landlock_rule_type rule_type,
+		const void *const rule_attr,
+		const __u32 flags)
+{
+	return syscall(__NR_landlock_add_rule, ruleset_fd, rule_type, rule_attr,
+			flags);
+}
+#endif
+
+#ifndef landlock_restrict_self
+static inline int landlock_restrict_self(const int ruleset_fd,
+		const __u32 flags)
+{
+	return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
+}
+#endif
+
+#ifndef LANDLOCK_ACCESS_FS_REFER
+#define LANDLOCK_ACCESS_FS_REFER (1ULL << 13)
+#endif
+
+#define ACCESS_FS_ROUGHLY_WRITE ( \
+		LANDLOCK_ACCESS_FS_WRITE_FILE | \
+		LANDLOCK_ACCESS_FS_REMOVE_DIR | \
+		LANDLOCK_ACCESS_FS_REMOVE_FILE | \
+		LANDLOCK_ACCESS_FS_MAKE_CHAR | \
+		LANDLOCK_ACCESS_FS_MAKE_DIR | \
+		LANDLOCK_ACCESS_FS_MAKE_REG | \
+		LANDLOCK_ACCESS_FS_MAKE_SOCK | \
+		LANDLOCK_ACCESS_FS_MAKE_FIFO | \
+		LANDLOCK_ACCESS_FS_MAKE_BLOCK | \
+		LANDLOCK_ACCESS_FS_MAKE_SYM | \
+		LANDLOCK_ACCESS_FS_REFER)
+
+#define LANDLOCK_COMPAT_ERR -1
+#define LANDLOCK_FATAL_ERR 1
+
+static int _pam_landlock_create_ruleset(int * const ruleset_fd, const __u64 ruleset) {
+	int abi;
+
+	struct landlock_ruleset_attr ruleset_attr = {
+		.handled_access_fs = ruleset,
+	};
+
+	/* Checks for Landlock ABI compatibility. */
+	abi = landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
+	if (abi < 0)
+		return LANDLOCK_COMPAT_ERR;
+	if (abi < 2)
+		ruleset_attr.handled_access_fs &= ~LANDLOCK_ACCESS_FS_REFER;
+
+	*ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0);
+	if (*ruleset_fd < 0) {
+		D(("Failed to create a ruleset"));
+		return LANDLOCK_FATAL_ERR;
+	}
+	return 0;
+}
+
+static int _pam_landlock_apply_restrictions(const int ruleset_fd) {
+	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+		D(("Failed to restrict privileges"));
+		close(ruleset_fd);
+		return LANDLOCK_FATAL_ERR;
+	}
+	if (landlock_restrict_self(ruleset_fd, 0)) {
+		D(("Failed to enforce ruleset"));
+		close(ruleset_fd);
+		return LANDLOCK_FATAL_ERR;
+	}
+	close(ruleset_fd);
+	return 0;
+}
+
+#endif /* _SECURITY_PAM_LANDLOCK_H */

--- a/modules/pam_unix/unix_chkpwd.c
+++ b/modules/pam_unix/unix_chkpwd.c
@@ -32,6 +32,10 @@
 #include <security/_pam_types.h>
 #include <security/_pam_macros.h>
 
+#ifdef WITH_LANDLOCK
+#include <security/pam_landlock.h>
+#endif
+
 #include "passverify.h"
 #include "pam_inline.h"
 
@@ -102,6 +106,30 @@ int main(int argc, char *argv[])
 	 * Catch or ignore as many signal as possible.
 	 */
 	setup_signals();
+
+#ifdef WITH_LANDLOCK
+	/*
+	 * Use Landlock to restrict unix_chkpwd to a read-only access to the filesystem.
+	 */
+	int ruleset_fd, err;
+
+	err = _pam_landlock_create_ruleset(&ruleset_fd, ACCESS_FS_ROUGHLY_WRITE);
+	if (err) {
+		if (err == LANDLOCK_FATAL_ERR) {
+			helper_log_err(LOG_ERR, "Failed to create base ruleset");
+			return PAM_SYSTEM_ERR;
+		} else {
+			helper_log_err(LOG_NOTICE, "Failed to check Landlock compatibility,"
+						   "Landlock is either disabled or not supported by the current kernel");
+		}
+	} else {
+		err = _pam_landlock_apply_restrictions(ruleset_fd);
+		if (err) {
+			helper_log_err(LOG_ERR, "Failed to apply file restrictions");
+			return PAM_SYSTEM_ERR;
+		}
+	}
+#endif
 
 	/*
 	 * we establish that this program is running with non-tty stdin.


### PR DESCRIPTION
This patch adds a minimalist Landlock support to PAM which restricts the
SUID unix_chkpwd binary to a strict readonly access to /etc/shadow. The
goal here is to provide security in depth limiting access to the few
resources this program needs limiting uncontrolled privileged access to
the system.

The patch should evolve to support finer restrictions on other PAM
modules/binaries.