### PR TITLE
configure.ac: fix implicit function declaration in mail spool directo…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,6 +297,7 @@ if test x$with_mailspool != x ; then
 else
 	AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <paths.h>
+#include <stdlib.h>
 int main() {
 #ifdef _PATH_MAILDIR
 exit(0);


### PR DESCRIPTION
…ry check

Fixes the following error with Clang 15 (which makes implicit function declarations an error by default):
```
+error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 exit(0);
 ^
 note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
```

Signed-off-by: Sam James <sam@gentoo.org>