### PR TITLE
pam_faillock: set config dir to the default value

### DIFF
--- a/modules/pam_faillock/main.c
+++ b/modules/pam_faillock/main.c
@@ -106,6 +106,8 @@ args_parse(int argc, char **argv, struct options *opts)
 		}
 	}
 
+	opts->dir = get_tally_dir(opts);
+
 	if ((rv = read_config_file(NULL, opts, conf)) != PAM_SUCCESS) {
 		fprintf(stderr, "Configuration file missing or broken");
 		return rv;


### PR DESCRIPTION
* modules/pam_faillock/main.c (args_parse): opts->dir need to be set the default value(FAILLOCK_DEFAULT_TALLYDIR) when invoking faillock command without arguments.

Resolves: https://github.com/linux-pam/linux-pam/issues/390