### PR TITLE
libpam*: For uncommon prefixes, provide substitution variables in pkgconfig files.

### DIFF
--- a/libpam/pam.pc.in
+++ b/libpam/pam.pc.in
@@ -1,3 +1,5 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 

--- a/libpam_misc/pam_misc.pc.in
+++ b/libpam_misc/pam_misc.pc.in
@@ -1,3 +1,5 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 

--- a/libpamc/pamc.pc.in
+++ b/libpamc/pamc.pc.in
@@ -1,3 +1,5 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 


### PR DESCRIPTION
Fix undefined references to ${exec_prefix} in pkgconfig files on Guix. The subsequent declarations of ${libdir} and ${includedir} in the same files require this commit when ${prefix} is set to something other than /usr.

When the pkgconfig files were initially provided, the two lines added here were dropped for what seemed like a good reason. [1] In the common case of a /usr prefix, 'configure.ac' sets ${libdir} and possibly ${includedir} explicitly [2] so the additional lines were then not needed.

Guix and probably Nix too, however, depart from the Filesystem Hierarchy Standard and require the missing lines. Without those lines, the pkgconfig files are defective on Guix. [3]

Since working systems are not affected, the lines are added for all. The fix was confirmed for Guix. One of the files looked like this:

prefix=/gnu/store/3mcmjilqrivrpb3hvps32lnbnyrxrzr8-linux-pam-1.5.2-1.dc2f566 exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=/gnu/store/3mcmjilqrivrpb3hvps32lnbnyrxrzr8-linux-pam-1.5.2-1.dc2f566/include/security

Name: PAM
Description: The primary Linux-PAM library. It is used by PAM modules and PAM-aware applications. URL: http://www.linux-pam.org/
Version: 1.5.2
Cflags: -I${includedir}
Libs: -L${libdir} -lpam

* libpam/pam.pc.in, libpamc/pamc.pc.in, libpam_misc/pam_misc.pc.in: Add @prefix@ and @exec_prefix@.

Resolves: https://github.com/linux-pam/linux-pam/issues/466

[1] https://github.com/linux-pam/linux-pam/pull/369#discussion_r650557756
[2] https://github.com/linux-pam/linux-pam/blob/40c271164dbcebfc5304d0537a42fb42e6b6803c/configure.ac#L28-L36
[3] https://github.com/linux-pam/linux-pam/issues/466