### PR TITLE
pam_faillock: Clarify missing user faillock files after reboot 

### DIFF
--- a/modules/pam_faillock/faillock.conf.5.xml
+++ b/modules/pam_faillock/faillock.conf.5.xml
@@ -44,6 +44,10 @@
                   The directory where the user files with the failure records are kept. The
                   default is <filename>/var/run/faillock</filename>.
                 </para>
+                <para>
+                  Note: These files will disappear after reboot on systems configured with
+                  directory <filename>/var/run/faillock</filename> mounted on virtual memory.
+                </para>
               </listitem>
             </varlistentry>
             <varlistentry>

--- a/modules/pam_faillock/pam_faillock.8.xml
+++ b/modules/pam_faillock/pam_faillock.8.xml
@@ -327,6 +327,12 @@ session  required       pam_selinux.so open
         <term><filename>/var/run/faillock/*</filename></term>
         <listitem>
           <para>the files logging the authentication failures for users</para>
+          <para>
+            Note: These files will disappear after reboot on systems configured with
+            directory <filename>/var/run/faillock</filename> mounted on virtual memory.
+            For persistent storage use the option <emphasis>dir=</emphasis> in
+            file <filename>/etc/security/faillock.conf</filename>.
+          </para>
         </listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
Adding note in man pages related to missing file post reboot

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2062512