### PR TITLE
pam_faillock: Disable consecutive login failure message for root user 

### DIFF
--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -374,9 +374,11 @@ write_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 		}
 		close(audit_fd);
 #endif
-		if (!(opts->flags & FAILLOCK_FLAG_NO_LOG_INFO)) {
-			pam_syslog(pamh, LOG_INFO, "Consecutive login failures for user %s account temporarily locked",
-				opts->user);
+		if (!(opts->flags & FAILLOCK_FLAG_NO_LOG_INFO) &&
+		    ((opts->flags & FAILLOCK_FLAG_DENY_ROOT) || (opts->uid != 0))) {
+			pam_syslog(pamh, LOG_INFO,
+				   "Consecutive login failures for user %s account temporarily locked",
+				   opts->user);
 		}
 	}
 


### PR DESCRIPTION
Resolve issue of consecutive failure msg for root if even_deny_root flag is not enabled.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2082442