### PR TITLE
PAM: added configurable stylesheets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,29 @@ if test x"$enable_debug" = x"yes" ; then
 		[lots of stuff gets written to /var/run/pam-debug.log])
 fi
 
+AC_ARG_ENABLE(html_stylesheet,
+	AS_HELP_STRING([--enable-html-stylesheet=FILE],[html stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl@:>@]),
+	HTML_STYLESHEET=$enableval, HTML_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl)
+AC_SUBST(HTML_STYLESHEET)
+
+AC_ARG_ENABLE(txt_stylesheet,
+	AS_HELP_STRING([--enable-txt-stylesheet=FILE],[text stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl@:>@]),
+	TXT_STYLESHEET=$enableval, TXT_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl)
+AC_SUBST(TXT_STYLESHEET)
+# It has to be TXT_STYLESHEET otherwise a html tree will be generated while generating all README files.
+sed "s+HTML_STYLESHEET+$TXT_STYLESHEET+g" <doc/custom-html.xsl.in >doc/custom-html.xsl
+
+AC_ARG_ENABLE(pdf_stylesheet,
+	AS_HELP_STRING([--enable-pdf-stylesheet=FILE],[pdf stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl@:>@]),
+	PDF_STYLESHEET=$enableval, PDF_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl)
+AC_SUBST(PDF_STYLESHEET)
+
+AC_ARG_ENABLE(man_stylesheet,
+	AS_HELP_STRING([--enable-man-stylesheet=FILE],[man stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/manpages/profile-docbook.xsl@:>@]),
+	MAN_STYLESHEET=$enableval, MAN_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/profile-docbook.xsl)
+AC_SUBST(MAN_STYLESHEET)
+sed "s+MAN_STYLESHEET+$MAN_STYLESHEET+g" <doc/custom-man.xsl.in >doc/custom-man.xsl
+
 AC_ARG_ENABLE(securedir,
 	AS_HELP_STRING([--enable-securedir=DIR],[path to location of PAMs @<:@default=$libdir/security@:>@]),
 	SECUREDIR=$enableval, SECUREDIR=$libdir/security)

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -2,3 +2,5 @@ pam.sgml
 MODULES-SGML
 /*/*.txt
 /*/html/
+custom-man.xsl
+custom-html.xsl

--- a/doc/adg/Makefile.am
+++ b/doc/adg/Makefile.am
@@ -21,7 +21,7 @@ if ENABLE_GENERATE_PDF
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 3 --xinclude --nonet \
-	http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl $< > Linux-PAM_ADG.fo
+	$(PDF_STYLESHEET) $< > Linux-PAM_ADG.fo
 	$(FO2PDF) Linux-PAM_ADG.fo $@
 else
 	echo "No fo2pdf processor installed, skip PDF generation"
@@ -33,7 +33,7 @@ Linux-PAM_ADG.txt: $(XMLS) $(DEP_XMLS)
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 3 --xinclude --nonet \
-	  http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl $< | $(BROWSER) > $@
+	  $(TXT_STYLESHEET) $< | $(BROWSER) > $@
 
 html/Linux-PAM_ADG.html: $(XMLS) $(DEP_XMLS)
 	@test -d html || mkdir -p html
@@ -46,7 +46,7 @@ html/Linux-PAM_ADG.html: $(XMLS) $(DEP_XMLS)
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 3 --xinclude --nonet \
 	  --stringparam chunker.output.encoding UTF-8 \
-	  http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl $<
+	  $(HTML_STYLESHEET) $<
 
 distclean-local:
 	-rm -rf html Linux-PAM_ADG.txt Linux-PAM_ADG.pdf

--- a/doc/custom-html.xsl.in
+++ b/doc/custom-html.xsl.in
@@ -3,7 +3,7 @@
   xmlns:ss="http://docbook.sf.net/xmlns/string.subst/1.0"
   xmlns:exsl="http://exslt.org/common" version="1.0">
 
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
+  <xsl:import href="HTML_STYLESHEET"/>
   <xsl:param name="vendordir"/>
 
   <xsl:template match="filename">

--- a/doc/custom-man.xsl.in
+++ b/doc/custom-man.xsl.in
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ss="http://docbook.sf.net/xmlns/string.subst/1.0" version="1.0">
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/manpages/profile-docbook.xsl"/>
+  <xsl:import href="MAN_STYLESHEET"/>
   <xsl:param name="vendordir"/>
 
   <xsl:param name="man.string.subst.map.local.pre">

--- a/doc/mwg/Makefile.am
+++ b/doc/mwg/Makefile.am
@@ -21,7 +21,7 @@ if ENABLE_GENERATE_PDF
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 3 --xinclude --nonet \
-	http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl $< > Linux-PAM_MWG.fo
+	$(PDF_STYLESHEET) $< > Linux-PAM_MWG.fo
 	$(FO2PDF) Linux-PAM_MWG.fo $@
 else
 	echo "No fo2pdf processor installed, skip PDF generation"
@@ -33,7 +33,7 @@ Linux-PAM_MWG.txt: $(XMLS) $(DEP_XMLS)
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 3 --xinclude --nonet \
-	  http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl $< | $(BROWSER) > $@
+	  $(TXT_STYLESHEET) $< | $(BROWSER) > $@
 
 html/Linux-PAM_MWG.html: $(XMLS) $(DEP_XMLS)
 	@test -d html || mkdir -p html
@@ -46,7 +46,7 @@ html/Linux-PAM_MWG.html: $(XMLS) $(DEP_XMLS)
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 3 --xinclude --nonet \
 	  --stringparam chunker.output.encoding UTF-8 \
-	  http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl $<
+	  $(HTML_STYLESHEET) $<
 
 distclean-local:
 	-rm -rf html Linux-PAM_MWG.txt Linux-PAM_MWG.pdf

--- a/doc/sag/Makefile.am
+++ b/doc/sag/Makefile.am
@@ -22,7 +22,7 @@ if ENABLE_GENERATE_PDF
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 2 --xinclude --nonet \
-	http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl $< > Linux-PAM_SAG.fo
+	$(PDF_STYLESHEET) $< > Linux-PAM_SAG.fo
 	$(FO2PDF) Linux-PAM_SAG.fo $@
 else
 	echo "No fo2pdf processor installed, skip PDF generation"
@@ -34,7 +34,7 @@ Linux-PAM_SAG.txt: $(XMLS) $(DEP_XMLS)
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 2 --xinclude --nonet \
-	  http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl $< | $(BROWSER) > $@
+	  $(TXT_STYLESHEET) $< | $(BROWSER) > $@
 
 html/Linux-PAM_SAG.html: $(XMLS) $(DEP_XMLS)
 	@test -d html || mkdir -p html
@@ -47,7 +47,7 @@ html/Linux-PAM_SAG.html: $(XMLS) $(DEP_XMLS)
 	  --stringparam section.label.includes.component.label 1 \
 	  --stringparam toc.max.depth 2 --xinclude --nonet \
 	  --stringparam chunker.output.encoding UTF-8 \
-	  http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl $<
+	  $(HTML_STYLESHEET) $<
 
 distclean-local:
 	-rm -rf html Linux-PAM_SAG.txt Linux-PAM_SAG.pdf


### PR DESCRIPTION
Stylesheets are currently hardcoded. With this PR stylesheets can be defined while the confiure call.
configure.ac: Define new options to set variable stylesheets:
              --enable-html-stylesheet=FILE
	      --enable-txt-stylesheet=FILE
	      --enable-pdf-stylesheet=FILE
	      --enable-man-stylesheet=FILE
doc/.gitignore: Ignoring files which will be build while running configure
doc/adg/Makefile.am: Using variable stylesheets
doc/mwg/Makefile.am: Using variable stylesheets
doc/sag/Makefile.am Using variable stylesheets
doc/custom-html.xsl → doc/custom-html.xsl.in: Template for configure able stylesheets. doc/custom-html.xsl will be genarted while the configure call.
doc/custom-man.xsl → doc/custom-man.xsl.in: Template for configure able stylesheets. doc/custom-man.xsl will be genarted while the configure call.
