### PR TITLE
doc: Update PAM documentation from DockBook 4 to DocBook 5

### DIFF
--- a/Make.xml.rules.in
+++ b/Make.xml.rules.in
@@ -5,22 +5,22 @@
 README: $(XMLS)
 
 README: README.xml
-	$(XSLTPROC) --path $(srcdir) --xinclude --stringparam generate.toc "none" @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-html.xsl $< | $(BROWSER) > $(srcdir)/$@
+	$(XSLTPROC) --path $(srcdir) --xinclude --stringparam generate.toc "none" @STRINGPARAM_VENDORDIR@ --nonet $(TXT_STYLESHEET) $< | $(BROWSER) > $(srcdir)/$@
 
 %.1: %.1.xml
-	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.3: %.3.xml
-	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.5: %.5.xml
-	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.8: %.8.xml
-	$(XMLLINT) --nonet --xinclude --postvalid --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_HMAC@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 #CLEANFILES += $(man_MANS) README

--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -13,8 +13,8 @@ automake
 autopoint
 bison
 bzip2
-docbook-xml
-docbook-xsl
+docbook5-xml
+docbook-xsl-ns
 flex
 gettext
 libaudit-dev

--- a/configure.ac
+++ b/configure.ac
@@ -243,26 +243,35 @@ if test x"$enable_debug" = x"yes" ; then
 		[lots of stuff gets written to /var/run/pam-debug.log])
 fi
 
+AC_ARG_ENABLE(docbook_rng,
+	AS_HELP_STRING([--enable-docbook-rng=FILE],[RNG file for checking XML files @<:@default=http://docbook.org/xml/5.0/rng/docbookxi.rng@:>@]),
+	DOCBOOK_RNG=$enableval, DOCBOOK_RNG=http://docbook.org/xml/5.0/rng/docbookxi.rng)
+AC_SUBST(DOCBOOK_RNG)
+
 AC_ARG_ENABLE(html_stylesheet,
-	AS_HELP_STRING([--enable-html-stylesheet=FILE],[html stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl@:>@]),
-	HTML_STYLESHEET=$enableval, HTML_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl)
+	AS_HELP_STRING([--enable-html-stylesheet=FILE],[html stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl-ns/current/html/chunk.xsl@:>@]),
+	HTML_STYLESHEET=$enableval, HTML_STYLESHEET=http://docbook.sourceforge.net/release/xsl-ns/current/html/chunk.xsl)
 AC_SUBST(HTML_STYLESHEET)
 
 AC_ARG_ENABLE(txt_stylesheet,
-	AS_HELP_STRING([--enable-txt-stylesheet=FILE],[text stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl@:>@]),
-	TXT_STYLESHEET=$enableval, TXT_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl)
+	AS_HELP_STRING([--enable-txt-stylesheet=FILE],[text stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl-ns/current/html/docbook.xsl@:>@]),
+	TXT_STYLESHEET=$enableval, TXT_STYLESHEET=http://docbook.sourceforge.net/release/xsl-ns/current/html/docbook.xsl)
+
+
 AC_SUBST(TXT_STYLESHEET)
 # It has to be TXT_STYLESHEET otherwise a html tree will be generated while generating all README files.
 sed "s+HTML_STYLESHEET+$TXT_STYLESHEET+g" <doc/custom-html.xsl.in >doc/custom-html.xsl
 
 AC_ARG_ENABLE(pdf_stylesheet,
-	AS_HELP_STRING([--enable-pdf-stylesheet=FILE],[pdf stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl@:>@]),
-	PDF_STYLESHEET=$enableval, PDF_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl)
+	AS_HELP_STRING([--enable-pdf-stylesheet=FILE],[pdf stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl-ns/current/fo/docbook.xsl@:>@]),
+	PDF_STYLESHEET=$enableval, PDF_STYLESHEET=http://docbook.sourceforge.net/release/xsl-ns/current/fo/docbook.xsl)
 AC_SUBST(PDF_STYLESHEET)
 
 AC_ARG_ENABLE(man_stylesheet,
-	AS_HELP_STRING([--enable-man-stylesheet=FILE],[man stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl/current/manpages/profile-docbook.xsl@:>@]),
-	MAN_STYLESHEET=$enableval, MAN_STYLESHEET=http://docbook.sourceforge.net/release/xsl/current/manpages/profile-docbook.xsl)
+	AS_HELP_STRING([--enable-man-stylesheet=FILE],[man stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl-ns/current/manpages/profile-docbook.xsl@:>@]),
+	MAN_STYLESHEET=$enableval, MAN_STYLESHEET=http://docbook.sourceforge.net/release/xsl-ns/current/manpages/profile-docbook.xsl)
+
+
 AC_SUBST(MAN_STYLESHEET)
 sed "s+MAN_STYLESHEET+$MAN_STYLESHEET+g" <doc/custom-man.xsl.in >doc/custom-man.xsl
 
@@ -608,10 +617,10 @@ if test -z "$XSLTPROC"; then
      enable_docu=no
 fi
 AC_PATH_PROG([XMLLINT], [xmllint],[/bin/true])
-dnl check for DocBook DTD and stylesheets in the local catalog.
-JH_CHECK_XML_CATALOG([-//OASIS//DTD DocBook XML V4.4//EN],
-                [DocBook XML DTD V4.4], [], enable_docu=no)
-JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl],
+dnl check for DocBook RNG and stylesheets in the local catalog.
+JH_CHECK_XML_CATALOG([http://docbook.org/xml/5.0/rng/docbookxi.rng],
+                [DocBook XML RNG V5.0], [], enable_docu=no)
+JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl],
                 [DocBook XSL Stylesheets], [], enable_docu=no)
 
 AC_PATH_PROG([BROWSER], [w3m])

--- a/doc/adg/Linux-PAM_ADG.xml
+++ b/doc/adg/Linux-PAM_ADG.xml
@@ -1,50 +1,39 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-	"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<book id="adg">
-  <bookinfo>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg">
+  <info>
     <title>The Linux-PAM Application Developers' Guide</title>
     <authorgroup>
-      <author>
-        <firstname>Andrew G.</firstname>
-        <surname>Morgan</surname>
-        <email>morgan@kernel.org</email>
-      </author>
-      <author>
-        <firstname>Thorsten</firstname>
-        <surname>Kukuk</surname>
-        <email>kukuk@thkukuk.de</email>
-      </author>
+      <author><personname><firstname>Andrew G.</firstname><surname>Morgan</surname></personname><email>morgan@kernel.org</email></author>
+      <author><personname><firstname>Thorsten</firstname><surname>Kukuk</surname></personname><email>kukuk@thkukuk.de</email></author>
     </authorgroup>
     <releaseinfo>Version 1.1.2, 31. August 2010</releaseinfo>
     <abstract>
       <para>
         This manual documents what an application developer needs to know
-        about the <emphasis remap='B'>Linux-PAM</emphasis> library. It
+        about the <emphasis remap="B">Linux-PAM</emphasis> library. It
         describes how an application might use the
-        <emphasis remap='B'>Linux-PAM</emphasis> library to authenticate
+        <emphasis remap="B">Linux-PAM</emphasis> library to authenticate
         users. In addition it contains a description of the functions
         to be found in <filename>libpam_misc</filename> library, that can
         be used in general applications. Finally, it contains some comments
         on PAM related security issues for the application developer.
       </para>
     </abstract>
-  </bookinfo>
+  </info>
 
-  <chapter id="adg-introduction">
+  <chapter xml:id="adg-introduction">
     <title>Introduction</title>
-    <section id="adg-introduction-description">
+    <section xml:id="adg-introduction-description">
       <title>Description</title>
       <para>
-        <emphasis remap='B'>Linux-PAM</emphasis>
+        <emphasis remap="B">Linux-PAM</emphasis>
         (Pluggable Authentication Modules for Linux) is a library that enables
         the local system administrator to choose how individual applications
         authenticate users. For an overview of the
-        <emphasis remap='B'>Linux-PAM</emphasis> library see the
+        <emphasis remap="B">Linux-PAM</emphasis> library see the
         <emphasis>Linux-PAM System Administrators' Guide</emphasis>.
       </para>
       <para>
-        It is the purpose of the <emphasis remap='B'>Linux-PAM</emphasis>
+        It is the purpose of the <emphasis remap="B">Linux-PAM</emphasis>
         project to liberate the development of privilege granting software
         from the development of secure and appropriate authentication schemes.
         This is accomplished by providing a documented library of functions
@@ -64,11 +53,11 @@
       </para>
     </section>
 
-    <section id="adg-introduction-synopsis">
+    <section xml:id="adg-introduction-synopsis">
       <title>Synopsis</title>
       <para>
         For general applications that wish to use the services provided by
-        <emphasis remap='B'>Linux-PAM</emphasis> the following is a summary
+        <emphasis remap="B">Linux-PAM</emphasis> the following is a summary
         of the relevant linking information:
         <programlisting>
 #include &lt;security/pam_appl.h&gt;
@@ -92,7 +81,7 @@ cc -o application .... -lpam -lpam_misc
     </section>
   </chapter>
 
-  <chapter id="adg-overview">
+  <chapter xml:id="adg-overview">
     <title>Overview</title>
     <para>
       Most service-giving applications are restricted. In other words,
@@ -108,7 +97,7 @@ cc -o application .... -lpam -lpam_misc
       authentication-token (password changing) management services.  It is
       important to realize when writing a PAM based application that these
       services are provided in a manner that is
-      <emphasis remap='B'>transparent</emphasis> to the application. That is
+      <emphasis remap="B">transparent</emphasis> to the application. That is
       to say, when the application is written, no assumptions can be made
       about <emphasis>how</emphasis> the client will be authenticated.
     </para>
@@ -206,74 +195,58 @@ cc -o application .... -lpam -lpam_misc
     </para>
   </chapter>
 
-  <chapter id="adg-interface">
+  <chapter xml:id="adg-interface">
     <title>
-      The public interface to <emphasis remap='B'>Linux-PAM</emphasis>
+      The public interface to <emphasis remap="B">Linux-PAM</emphasis>
     </title>
     <para>
       Firstly, the relevant include file for the
-      <emphasis remap='B'>Linux-PAM</emphasis> library is
+      <emphasis remap="B">Linux-PAM</emphasis> library is
       <function>&lt;security/pam_appl.h&gt;</function>.
       It contains the definitions for a number of functions. After
       listing these functions, we collect some guiding remarks for
       programmers.
     </para>
-    <section id="adg-interface-by-app-expected">
+    <section xml:id="adg-interface-by-app-expected">
       <title>What can be expected by the application</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_start.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_end.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_set_item.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_get_item.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_strerror.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_fail_delay.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_authenticate.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_setcred.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_acct_mgmt.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_chauthtok.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_open_session.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_close_session.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_putenv.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_getenv.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_getenvlist.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_start.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_end.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_set_item.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_get_item.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_strerror.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_fail_delay.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_authenticate.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setcred.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_acct_mgmt.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_chauthtok.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_open_session.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_close_session.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_putenv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_getenv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_getenvlist.xml"/>
     </section>
-    <section id="adg-interface-of-app-expected">
+    <section xml:id="adg-interface-of-app-expected">
       <title>What is expected of an application</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_conv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_conv.xml"/>
     </section>
-    <section id="adg-interface-programming-notes">
+    <section xml:id="adg-interface-programming-notes">
       <title>Programming notes</title>
       <para>
         Note, all of the authentication service function calls accept the
-        token <emphasis remap='B'>PAM_SILENT</emphasis>, which instructs
+        token <emphasis remap="B">PAM_SILENT</emphasis>, which instructs
         the modules to not send messages to the application. This token
         can be logically OR'd with any one of the permitted tokens specific
         to the individual function calls.
-        <emphasis remap='B'>PAM_SILENT</emphasis> does not override the
+        <emphasis remap="B">PAM_SILENT</emphasis> does not override the
         prompting of the user for passwords etc., it only stops informative
         messages from being generated.
       </para>
     </section>
   </chapter>
 
-  <chapter id="adg-security">
+  <chapter xml:id="adg-security">
     <title>
-      Security issues of <emphasis remap='B'>Linux-PAM</emphasis>
+      Security issues of <emphasis remap="B">Linux-PAM</emphasis>
     </title>
     <para>
       PAM, from the perspective of an application, is a convenient API for
@@ -284,19 +257,19 @@ cc -o application .... -lpam -lpam_misc
     </para>
     <para>
       A poorly (or maliciously) written application can defeat any
-      <emphasis remap='B'>Linux-PAM</emphasis> module's authentication
+      <emphasis remap="B">Linux-PAM</emphasis> module's authentication
       mechanisms by simply ignoring it's return values. It is the
       applications task and responsibility to grant privileges and access
-      to services.  The <emphasis remap='B'>Linux-PAM</emphasis> library
+      to services.  The <emphasis remap="B">Linux-PAM</emphasis> library
       simply assumes the responsibility of <emphasis>authenticating</emphasis>
       the user; ascertaining that the user <emphasis>is</emphasis> who they
       say they are. Care should be taken to anticipate all of the documented
-      behavior of the <emphasis remap='B'>Linux-PAM</emphasis> library
+      behavior of the <emphasis remap="B">Linux-PAM</emphasis> library
       functions. A failure to do this will most certainly lead to a future
       security breach.
     </para>
 
-    <section id="adg-security-library-calls">
+    <section xml:id="adg-security-library-calls">
       <title>Care about standard library calls</title>
       <para>
         In general, writers of authorization-granting applications should
@@ -308,9 +281,9 @@ cc -o application .... -lpam -lpam_misc
         function is likely to corrupt a pointer previously
         obtained by the application. The application programmer should
         either re-call such a 'libc' function after a call to the
-        <emphasis remap='B'>Linux-PAM</emphasis> library, or copy the
+        <emphasis remap="B">Linux-PAM</emphasis> library, or copy the
         structure contents to some safe area of memory before passing
-        control to the <emphasis remap='B'>Linux-PAM</emphasis> library.
+        control to the <emphasis remap="B">Linux-PAM</emphasis> library.
       </para>
       <para>
         Two important function classes that fall into this category are
@@ -322,12 +295,12 @@ cc -o application .... -lpam -lpam_misc
       </para>
     </section>
 
-    <section id="adg-security-service-name">
+    <section xml:id="adg-security-service-name">
       <title>Choice of a service name</title>
       <para>
         When picking the <emphasis>service-name</emphasis> that
         corresponds to the first entry in the
-        <emphasis remap='B'>Linux-PAM</emphasis> configuration file,
+        <emphasis remap="B">Linux-PAM</emphasis> configuration file,
         the application programmer should <emphasis>avoid</emphasis>
         the temptation of choosing something related to
         <varname>argv[0]</varname>. It is a trivial matter for any user
@@ -352,11 +325,11 @@ cc -o application .... -lpam -lpam_misc
         and then run <command>./preferred_name</command>.
       </para>
       <para>
-        By studying the <emphasis remap='B'>Linux-PAM</emphasis>
+        By studying the <emphasis remap="B">Linux-PAM</emphasis>
         configuration file(s), an attacker can choose the
         <command>preferred_name</command> to be that of a service enjoying
         minimal protection; for example a game which uses
-        <emphasis remap='B'>Linux-PAM</emphasis> to restrict access to
+        <emphasis remap="B">Linux-PAM</emphasis> to restrict access to
         certain hours of the day.  If the service-name were to be linked
         to the filename under which the service was invoked, it
         is clear that the user is effectively in the position of
@@ -370,7 +343,7 @@ cc -o application .... -lpam -lpam_misc
       </para>
     </section>
 
-    <section id="adg-security-conv-function">
+    <section xml:id="adg-security-conv-function">
       <title>The conversation function</title>
       <para>
         Care should be taken to ensure that the <function>conv()</function>
@@ -380,10 +353,10 @@ cc -o application .... -lpam -lpam_misc
       </para>
     </section>
 
-    <section id="adg-security-user-identity">
+    <section xml:id="adg-security-user-identity">
       <title>The identity of the user</title>
       <para>
-        The <emphasis remap='B'>Linux-PAM</emphasis> modules will need
+        The <emphasis remap="B">Linux-PAM</emphasis> modules will need
         to determine the identity of the user who requests a service,
         and the identity of the user who grants the service. These two
         users will seldom be the same. Indeed there is generally a third
@@ -444,7 +417,7 @@ cc -o application .... -lpam -lpam_misc
       </para>
     </section>
 
-    <section id="adg-security-resources">
+    <section xml:id="adg-security-resources">
       <title>Sufficient resources</title>
       <para>
         Care should be taken to ensure that the proper execution of an
@@ -465,7 +438,7 @@ cc -o application .... -lpam -lpam_misc
     </section>
   </chapter>
 
-  <chapter id='adg-libpam_misc'>
+  <chapter xml:id="adg-libpam_misc">
     <title>A library of miscellaneous helper functions</title>
     <para>
       To aid the work of the application developer a library of
@@ -479,24 +452,20 @@ cc -o application .... -lpam -lpam_misc
       library can be defined by including
       <function>&lt;security/pam_misc.h&gt;</function>. It should be
       noted that this library is specific to
-      <emphasis remap='B'>Linux-PAM</emphasis> and is not referred to in
+      <emphasis remap="B">Linux-PAM</emphasis> and is not referred to in
       the defining DCE-RFC (see <link linkend="adg-see-also">See also</link>)
       below.
     </para>
-    <section id='adg-libpam-functions'>
+    <section xml:id="adg-libpam-functions">
       <title>Functions supplied</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_misc_conv.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_misc_paste_env.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_misc_drop_env.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_misc_setenv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_misc_conv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_misc_paste_env.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_misc_drop_env.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_misc_setenv.xml"/>
     </section>
   </chapter>
 
-  <chapter id='adg-porting'>
+  <chapter xml:id="adg-porting">
     <title>Porting legacy applications</title>
     <para>
       The point of PAM is that the application is not supposed to
@@ -545,7 +514,7 @@ cc -o application .... -lpam -lpam_misc
     </para>
   </chapter>
 
-  <chapter id='adg-glossary'>
+  <chapter xml:id="adg-glossary">
     <title>Glossary of PAM related terms</title>
     <para>
       The following are a list of terms used within this document.
@@ -585,17 +554,17 @@ cc -o application .... -lpam -lpam_misc
     </variablelist>
   </chapter>
 
-  <chapter id='adg-example'>
+  <chapter xml:id="adg-example">
     <title>An example application</title>
     <para>
-      To get a flavor of the way a <emphasis remap='B'>Linux-PAM</emphasis>
+      To get a flavor of the way a <emphasis remap="B">Linux-PAM</emphasis>
       application is written we include the following example. It prompts
       the user for their password and indicates whether their account
       is valid on the standard output, its return code also indicates
       the success (<returnvalue>0</returnvalue> for success;
       <returnvalue>1</returnvalue> for failure).
     </para>
-    <programlisting><![CDATA[
+    <programlisting>
 /*
   This program was contributed by Shane Watts
   [modifications by AGM and kukuk]
@@ -607,9 +576,9 @@ cc -o application .... -lpam -lpam_misc
   account    required     pam_unix.so
  */
 
-#include <security/pam_appl.h>
-#include <security/pam_misc.h>
-#include <stdio.h>
+#include &lt;security/pam_appl.h&gt;
+#include &lt;security/pam_misc.h&gt;
+#include &lt;stdio.h&gt;
 
 static struct pam_conv conv = {
     misc_conv,
@@ -626,12 +595,12 @@ int main(int argc, char *argv[])
         user = argv[1];
     }
 
-    if(argc > 2) {
+    if(argc &gt; 2) {
         fprintf(stderr, "Usage: check_user [username]\n");
         exit(1);
     }
 
-    retval = pam_start("check_user", user, &conv, &pamh);
+    retval = pam_start("check_user", user, &amp;conv, &amp;pamh);
 
     if (retval == PAM_SUCCESS)
         retval = pam_authenticate(pamh, 0);    /* is user really user? */
@@ -655,24 +624,24 @@ int main(int argc, char *argv[])
 
     return ( retval == PAM_SUCCESS ? 0:1 );       /* indicate success */
 }
-]]>
+
     </programlisting>
   </chapter>
 
-  <chapter id='adg-files'>
+  <chapter xml:id="adg-files">
     <title>Files</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/usr/include/security/pam_appl.h</filename></term>
+        <term>/usr/include/security/pam_appl.h</term>
         <listitem>
           <para>
             Header file with interfaces for
-            <emphasis remap='B'>Linux-PAM</emphasis> applications.
+            <emphasis remap="B">Linux-PAM</emphasis> applications.
            </para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><filename>/usr/include/security/pam_misc.h</filename></term>
+        <term>/usr/include/security/pam_misc.h</term>
         <listitem>
           <para>
             Header file for useful library functions for making
@@ -683,7 +652,7 @@ int main(int argc, char *argv[])
     </variablelist>
   </chapter>
 
-  <chapter id="adg-see-also">
+  <chapter xml:id="adg-see-also">
     <title>See also</title>
     <itemizedlist>
       <listitem>
@@ -706,7 +675,7 @@ int main(int argc, char *argv[])
     </itemizedlist>
   </chapter>
 
-  <chapter id='adg-author'>
+  <chapter xml:id="adg-author">
     <title>Author/acknowledgments</title>
     <para>
       This document was written by Andrew G. Morgan (morgan@kernel.org)
@@ -726,14 +695,14 @@ int main(int argc, char *argv[])
     <para>
       Thanks are also due to Sun Microsystems, especially to Vipin Samar and
       Charlie Lai for their advice. At an early stage in the development of
-      <emphasis remap='B'>Linux-PAM</emphasis>, Sun graciously made the
+      <emphasis remap="B">Linux-PAM</emphasis>, Sun graciously made the
       documentation for their implementation of PAM available. This act
       greatly accelerated the development of
-      <emphasis remap='B'>Linux-PAM</emphasis>.
+      <emphasis remap="B">Linux-PAM</emphasis>.
     </para>
   </chapter>
 
-  <chapter id='adg-copyright'>
+  <chapter xml:id="adg-copyright">
     <title>Copyright information for this document</title>
     <programlisting>
 Copyright (c) 2006 Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;

--- a/doc/adg/Makefile.am
+++ b/doc/adg/Makefile.am
@@ -16,7 +16,7 @@ all: Linux-PAM_ADG.txt html/Linux-PAM_ADG.html Linux-PAM_ADG.pdf
 
 Linux-PAM_ADG.pdf: $(XMLS) $(DEP_XMLS)
 if ENABLE_GENERATE_PDF
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam generate.toc "book toc" \
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
@@ -28,7 +28,7 @@ else
 endif
 
 Linux-PAM_ADG.txt: $(XMLS) $(DEP_XMLS)
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam generate.toc "book toc" \
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
@@ -37,7 +37,7 @@ Linux-PAM_ADG.txt: $(XMLS) $(DEP_XMLS)
 
 html/Linux-PAM_ADG.html: $(XMLS) $(DEP_XMLS)
 	@test -d html || mkdir -p html
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam base.dir html/ \
 	  --stringparam root.filename Linux-PAM_ADG \
 	  --stringparam use.id.as.filename 1 \

--- a/doc/adg/pam_acct_mgmt.xml
+++ b/doc/adg/pam_acct_mgmt.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_acct_mgmt'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_acct_mgmt">
   <title>Account validation management</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_acct_mgmt.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_acct_mgmt-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_acct_mgmt.3.xml" xpointer='xpointer(id("pam_acct_mgmt-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_acct_mgmt-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_acct_mgmt.3.xml" xpointer='xpointer(//refsect1[@id = "pam_acct_mgmt-description"]/*)'/>
+  <section xml:id="adg-pam_acct_mgmt-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_acct_mgmt.3.xml" xpointer='xpointer(id("pam_acct_mgmt-description")/*)'/>
   </section>
-  <section id='adg-pam_acct_mgmt-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_acct_mgmt.3.xml" xpointer='xpointer(//refsect1[@id = "pam_acct_mgmt-return_values"]/*)'/>
+  <section xml:id="adg-pam_acct_mgmt-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_acct_mgmt.3.xml" xpointer='xpointer(id("pam_acct_mgmt-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_authenticate.xml
+++ b/doc/adg/pam_authenticate.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_authenticate'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_authenticate">
   <title>Authenticating the user</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_authenticate.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_authenticate-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_authenticate.3.xml" xpointer='xpointer(id("pam_authenticate-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_authenticate-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_authenticate.3.xml" xpointer='xpointer(//refsect1[@id = "pam_authenticate-description"]/*)'/>
+  <section xml:id="adg-pam_authenticate-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_authenticate.3.xml" xpointer='xpointer(id("pam_authenticate-description")/*)'/>
   </section>
-  <section id='adg-pam_authenticate-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_authenticate.3.xml" xpointer='xpointer(//refsect1[@id = "pam_authenticate-return_values"]/*)'/>
+  <section xml:id="adg-pam_authenticate-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_authenticate.3.xml" xpointer='xpointer(id("pam_authenticate-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_chauthtok.xml
+++ b/doc/adg/pam_chauthtok.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_chauthtok'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_chauthtok">
   <title>Updating authentication tokens</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_chauthtok.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_chauthtok-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_chauthtok.3.xml" xpointer='xpointer(id("pam_chauthtok-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_chauthtok-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_chauthtok.3.xml" xpointer='xpointer(//refsect1[@id = "pam_chauthtok-description"]/*)'/>
+  <section xml:id="adg-pam_chauthtok-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_chauthtok.3.xml" xpointer='xpointer(id("pam_chauthtok-description")/*)'/>
   </section>
-  <section id='adg-pam_chauthtok-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_chauthtok.3.xml" xpointer='xpointer(//refsect1[@id = "pam_chauthtok-return_values"]/*)'/>
+  <section xml:id="adg-pam_chauthtok-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_chauthtok.3.xml" xpointer='xpointer(id("pam_chauthtok-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_close_session.xml
+++ b/doc/adg/pam_close_session.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_close_session'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_close_session">
   <title>terminating PAM session management</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_close_session.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_close_session-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_close_session.3.xml" xpointer='xpointer(id("pam_close_session-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_close_session-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_close_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_close_session-description"]/*)'/>
+  <section xml:id="adg-pam_close_session-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_close_session.3.xml" xpointer='xpointer(id("pam_close_session-description")/*)'/>
   </section>
-  <section id='adg-pam_close_session-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_close_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_close_session-return_values"]/*)'/>
+  <section xml:id="adg-pam_close_session-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_close_session.3.xml" xpointer='xpointer(id("pam_close_session-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_conv.xml
+++ b/doc/adg/pam_conv.xml
@@ -1,11 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_conv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_conv">
   <title>The conversation function</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_conv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_conv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_conv.3.xml" xpointer='xpointer(id("pam_conv-synopsis")/*)'/>
   </funcsynopsis>
   <programlisting>
 struct pam_message {
@@ -24,12 +20,10 @@ struct pam_conv {
     void *appdata_ptr;
 };
   </programlisting>
-  <section id='adg-pam_conv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_conv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_conv-description"]/*)'/>
+  <section xml:id="adg-pam_conv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_conv.3.xml" xpointer='xpointer(id("pam_conv-description")/*)'/>
   </section>
-  <section id='adg-pam_conv-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_conv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_conv-return_values"]/*)'/>
+  <section xml:id="adg-pam_conv-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_conv.3.xml" xpointer='xpointer(id("pam_conv-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_end.xml
+++ b/doc/adg/pam_end.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_end'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_end">
   <title>Termination of PAM transaction</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_end.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_end-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_end.3.xml" xpointer='xpointer(id("pam_end-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_end-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_end.3.xml" xpointer='xpointer(//refsect1[@id = "pam_end-description"]/*)'/>
+  <section xml:id="adg-pam_end-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_end.3.xml" xpointer='xpointer(id("pam_end-description")/*)'/>
   </section>
-  <section id='adg-pam_end-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_end.3.xml" xpointer='xpointer(//refsect1[@id = "pam_end-return_values"]/*)'/>
+  <section xml:id="adg-pam_end-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_end.3.xml" xpointer='xpointer(id("pam_end-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_fail_delay.xml
+++ b/doc/adg/pam_fail_delay.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_fail_delay'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_fail_delay">
   <title>Request a delay on failure</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_fail_delay.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_fail_delay-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_fail_delay.3.xml" xpointer='xpointer(id("pam_fail_delay-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_fail_delay-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_fail_delay.3.xml" xpointer='xpointer(//refsect1[@id = "pam_fail_delay-description"]/*)'/>
+  <section xml:id="adg-pam_fail_delay-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_fail_delay.3.xml" xpointer='xpointer(id("pam_fail_delay-description")/*)'/>
   </section>
-  <section id='adg-pam_fail_delay-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_fail_delay.3.xml" xpointer='xpointer(//refsect1[@id = "pam_fail_delay-return_values"]/*)'/>
+  <section xml:id="adg-pam_fail_delay-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_fail_delay.3.xml" xpointer='xpointer(id("pam_fail_delay-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_get_item.xml
+++ b/doc/adg/pam_get_item.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_get_item'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_get_item">
   <title>Getting PAM items</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_item.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_get_item-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_item.3.xml" xpointer='xpointer(id("pam_get_item-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_get_item-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_item-description"]/*)'/>
+  <section xml:id="adg-pam_get_item-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_item.3.xml" xpointer='xpointer(id("pam_get_item-description")/*)'/>
   </section>
-  <section id='adg-pam_get_item-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_item-return_values"]/*)'/>
+  <section xml:id="adg-pam_get_item-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_item.3.xml" xpointer='xpointer(id("pam_get_item-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_getenv.xml
+++ b/doc/adg/pam_getenv.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_getenv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_getenv">
   <title>Get a PAM environment variable</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_getenv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenv.3.xml" xpointer='xpointer(id("pam_getenv-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_getenv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenv-description"]/*)'/>
+  <section xml:id="adg-pam_getenv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenv.3.xml" xpointer='xpointer(id("pam_getenv-description")/*)'/>
   </section>
-  <section id='adg-pam_getenv-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenv-return_values"]/*)'/>
+  <section xml:id="adg-pam_getenv-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenv.3.xml" xpointer='xpointer(id("pam_getenv-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_getenvlist.xml
+++ b/doc/adg/pam_getenvlist.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_getenvlist'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_getenvlist">
   <title>Getting the PAM environment</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenvlist.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_getenvlist-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenvlist.3.xml" xpointer='xpointer(id("pam_getenvlist-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_getenvlist-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenvlist.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenvlist-description"]/*)'/>
+  <section xml:id="adg-pam_getenvlist-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenvlist.3.xml" xpointer='xpointer(id("pam_getenvlist-description")/*)'/>
   </section>
-  <section id='adg-pam_getenvlist-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenvlist.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenvlist-return_values"]/*)'/>
+  <section xml:id="adg-pam_getenvlist-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenvlist.3.xml" xpointer='xpointer(id("pam_getenvlist-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_misc_conv.xml
+++ b/doc/adg/pam_misc_conv.xml
@@ -1,14 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-misc_conv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-misc_conv">
   <title>Text based conversation function</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/misc_conv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "misc_conv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/misc_conv.3.xml" xpointer='xpointer(id("misc_conv-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-misc_conv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/misc_conv.3.xml" xpointer='xpointer(//refsect1[@id = "misc_conv-description"]/*)'/>
+  <section xml:id="adg-misc_conv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/misc_conv.3.xml" xpointer='xpointer(id("misc_conv-description")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_misc_drop_env.xml
+++ b/doc/adg/pam_misc_drop_env.xml
@@ -1,14 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_misc_drop_env'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_misc_drop_env">
   <title>Liberating a locally saved environment</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_misc_drop_env.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_misc_drop_env-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_misc_drop_env.3.xml" xpointer='xpointer(id("pam_misc_drop_env-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_misc_drop_env-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_misc_drop_env.3.xml" xpointer='xpointer(//refsect1[@id = "pam_misc_drop_env-description"]/*)'/>
+  <section xml:id="adg-pam_misc_drop_env-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_misc_drop_env.3.xml" xpointer='xpointer(id("pam_misc_drop_env-description")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_misc_paste_env.xml
+++ b/doc/adg/pam_misc_paste_env.xml
@@ -1,14 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_misc_paste_env'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_misc_paste_env">
   <title>Transcribing an environment to that of PAM</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_misc_paste_env.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_misc_paste_env-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_misc_paste_env.3.xml" xpointer='xpointer(id("pam_misc_paste_env-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_misc_paste_env-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_misc_paste_env.3.xml" xpointer='xpointer(//refsect1[@id = "pam_misc_paste_env-description"]/*)'/>
+  <section xml:id="adg-pam_misc_paste_env-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_misc_paste_env.3.xml" xpointer='xpointer(id("pam_misc_paste_env-description")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_misc_setenv.xml
+++ b/doc/adg/pam_misc_setenv.xml
@@ -1,14 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_misc_setenv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_misc_setenv">
   <title>BSD like PAM environment variable setting</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_misc_setenv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_misc_setenv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_misc_setenv.3.xml" xpointer='xpointer(id("pam_misc_setenv-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_misc_setenv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_misc_setenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_misc_setenv-description"]/*)'/>
+  <section xml:id="adg-pam_misc_setenv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_misc_setenv.3.xml" xpointer='xpointer(id("pam_misc_setenv-description")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_open_session.xml
+++ b/doc/adg/pam_open_session.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_open_session'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_open_session">
   <title>Start PAM session management</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_open_session.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_open_session-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_open_session.3.xml" xpointer='xpointer(id("pam_open_session-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_open_session-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_open_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_open_session-description"]/*)'/>
+  <section xml:id="adg-pam_open_session-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_open_session.3.xml" xpointer='xpointer(id("pam_open_session-description")/*)'/>
   </section>
-  <section id='adg-pam_open_session-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_open_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_open_session-return_values"]/*)'/>
+  <section xml:id="adg-pam_open_session-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_open_session.3.xml" xpointer='xpointer(id("pam_open_session-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_putenv.xml
+++ b/doc/adg/pam_putenv.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_putenv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_putenv">
   <title>Set or change PAM environment variable</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_putenv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_putenv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_putenv.3.xml" xpointer='xpointer(id("pam_putenv-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_putenv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_putenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_putenv-description"]/*)'/>
+  <section xml:id="adg-pam_putenv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_putenv.3.xml" xpointer='xpointer(id("pam_putenv-description")/*)'/>
   </section>
-  <section id='adg-pam_putenv-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_putenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_putenv-return_values"]/*)'/>
+  <section xml:id="adg-pam_putenv-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_putenv.3.xml" xpointer='xpointer(id("pam_putenv-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_set_item.xml
+++ b/doc/adg/pam_set_item.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_set_item'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_set_item">
   <title>Setting PAM items</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_item.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_set_item-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_item.3.xml" xpointer='xpointer(id("pam_set_item-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_set_item-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_set_item-description"]/*)'/>
+  <section xml:id="adg-pam_set_item-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_item.3.xml" xpointer='xpointer(id("pam_set_item-description")/*)'/>
   </section>
-  <section id='adg-pam_set_item-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_set_item-return_values"]/*)'/>
+  <section xml:id="adg-pam_set_item-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_item.3.xml" xpointer='xpointer(id("pam_set_item-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_setcred.xml
+++ b/doc/adg/pam_setcred.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_setcred'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_setcred">
   <title>Setting user credentials</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_setcred.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_setcred-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_setcred.3.xml" xpointer='xpointer(id("pam_setcred-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_setcred-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_setcred.3.xml" xpointer='xpointer(//refsect1[@id = "pam_setcred-description"]/*)'/>
+  <section xml:id="adg-pam_setcred-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_setcred.3.xml" xpointer='xpointer(id("pam_setcred-description")/*)'/>
   </section>
-  <section id='adg-pam_setcred-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_setcred.3.xml" xpointer='xpointer(//refsect1[@id = "pam_setcred-return_values"]/*)'/>
+  <section xml:id="adg-pam_setcred-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_setcred.3.xml" xpointer='xpointer(id("pam_setcred-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_start.xml
+++ b/doc/adg/pam_start.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_start'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_start">
   <title>Initialization of PAM transaction</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_start.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_start-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_start.3.xml" xpointer='xpointer(id("pam_start-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_start-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_start.3.xml" xpointer='xpointer(//refsect1[@id = "pam_start-description"]/*)'/>
+  <section xml:id="adg-pam_start-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_start.3.xml" xpointer='xpointer(id("pam_start-description")/*)'/>
   </section>
-  <section id='adg-pam_start-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_start.3.xml" xpointer='xpointer(//refsect1[@id = "pam_start-return_values"]/*)'/>
+  <section xml:id="adg-pam_start-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_start.3.xml" xpointer='xpointer(id("pam_start-return_values")/*)'/>
   </section>
 </section>

--- a/doc/adg/pam_strerror.xml
+++ b/doc/adg/pam_strerror.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_strerror'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_strerror">
   <title>Strings describing PAM error codes</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_strerror.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_strerror-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_strerror.3.xml" xpointer='xpointer(id("pam_strerror-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_strerror-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_strerror.3.xml" xpointer='xpointer(//refsect1[@id = "pam_strerror-description"]/*)'/>
+  <section xml:id="adg-pam_strerror-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_strerror.3.xml" xpointer='xpointer(id("pam_strerror-description")/*)'/>
   </section>
-  <section id='adg-pam_strerror-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_strerror.3.xml" xpointer='xpointer(//refsect1[@id = "pam_strerror-return_values"]/*)'/>
+  <section xml:id="adg-pam_strerror-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_strerror.3.xml" xpointer='xpointer(id("pam_strerror-return_values")/*)'/>
   </section>
 </section>

--- a/doc/man/misc_conv.3.xml
+++ b/doc/man/misc_conv.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="misc_conv">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="misc_conv">
 
   <refmeta>
     <refentrytitle>misc_conv</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="misc_conv-name">
+  <refnamediv xml:id="misc_conv-name">
     <refname>misc_conv</refname>
     <refpurpose>text based conversation function</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="misc_conv-synopsis">
+    <funcsynopsis xml:id="misc_conv-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_misc.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>misc_conv</function></funcdef>
@@ -30,7 +27,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='misc_conv-description'>
+  <refsect1 xml:id="misc_conv-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>misc_conv</function> function is part of
@@ -50,7 +47,7 @@
     </para>
     <variablelist>
       <varlistentry>
-        <term><type>time_t</type> <varname>pam_misc_conv_warn_time</varname>;</term>
+        <term>time_t pam_misc_conv_warn_time;</term>
         <listitem>
           <para>
             This variable contains the <emphasis>time</emphasis> (as
@@ -67,7 +64,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><type>const char *</type><varname>pam_misc_conv_warn_line</varname>;</term>
+        <term>const char *pam_misc_conv_warn_line;</term>
         <listitem>
           <para>
             Used in conjunction with
@@ -83,7 +80,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><type>time_t</type> <varname>pam_misc_conv_die_time</varname>;</term>
+        <term>time_t pam_misc_conv_die_time;</term>
         <listitem>
           <para>
             This variable contains the <emphasis>time</emphasis> (as
@@ -100,7 +97,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><type>const char *</type><varname>pam_misc_conv_die_line</varname>;</term>
+        <term>const char *pam_misc_conv_die_line;</term>
         <listitem>
           <para>
             Used in conjunction with
@@ -116,7 +113,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><type>int</type> <varname>pam_misc_conv_died</varname>;</term>
+        <term>int pam_misc_conv_died;</term>
         <listitem>
           <para>
             Following a return from the <emphasis>Linux-PAM</emphasis>
@@ -136,7 +133,7 @@
     <variablelist>
       <varlistentry>
         <term>
-          <type>int</type> <varname>(*pam_binary_handler_fn)</varname>(<type>void *</type><varname>appdata</varname>, <type>pamc_bp_t *</type><varname>prompt_p</varname>);
+          int (*pam_binary_handler_fn)(void *appdata, pamc_bp_t *prompt_p);
         </term>
         <listitem>
           <para>
@@ -151,7 +148,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <type>int</type> <varname>(*pam_binary_handler_free)</varname>(<type>void *</type><varname>appdata</varname>, <type>pamc_bp_t *</type><varname>delete_me</varname>);
+          int (*pam_binary_handler_free)(void *appdata, pamc_bp_t *delete_me);
         </term>
         <listitem>
           <para>
@@ -164,7 +161,7 @@
      </variablelist>
   </refsect1>
 
-  <refsect1 id='misc_conv-see_also'>
+  <refsect1 xml:id="misc_conv-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -176,7 +173,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='misc_conv-standards'>
+  <refsect1 xml:id="misc_conv-standards">
     <title>STANDARDS</title>
     <para>
       The <function>misc_conv</function> function is part of the

--- a/doc/man/pam.3.xml
+++ b/doc/man/pam.3.xml
@@ -1,20 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam3'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam3">
 
   <refmeta>
     <refentrytitle>pam</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam3-name'>
+  <refnamediv xml:id="pam3-name">
     <refname>pam</refname>
     <refpurpose>Pluggable Authentication Modules Library</refpurpose>
   </refnamediv>
 
-  <refsynopsisdiv id='pam3-synopsis'>
+  <refsynopsisdiv xml:id="pam3-synopsis">
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
@@ -22,10 +20,10 @@
    </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam3-description'>
+  <refsect1 xml:id="pam3-description">
     <title>DESCRIPTION</title>
     <para>
-      <emphasis remap='B'>PAM</emphasis> is a system of libraries
+      <emphasis remap="B">PAM</emphasis> is a system of libraries
       that handle the authentication tasks of applications (services)
       on the system. The library provides a stable general interface
       (Application Programming Interface - API) that privilege granting
@@ -38,7 +36,7 @@
       defer to to perform standard authentication tasks.
     </para>
 
-    <refsect2 id='pam3-initialization_and_cleanup'>
+    <refsect2 xml:id="pam3-initialization_and_cleanup">
       <title>Initialization and Cleanup</title>
       <para>
         The
@@ -64,7 +62,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-authentication'>
+    <refsect2 xml:id="pam3-authentication">
       <title>Authentication</title>
       <para>
         The
@@ -85,7 +83,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-account_management'>
+    <refsect2 xml:id="pam3-account_management">
       <title>Account Management</title>
       <para>
         The
@@ -98,7 +96,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-password_management'>
+    <refsect2 xml:id="pam3-password_management">
       <title>Password Management</title>
       <para>
         The
@@ -109,7 +107,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-session_management'>
+    <refsect2 xml:id="pam3-session_management">
       <title>Session Management</title>
       <para>
         The
@@ -124,7 +122,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-conversation'>
+    <refsect2 xml:id="pam3-conversation">
       <title>Conversation</title>
       <para>
         The PAM library uses an application-defined callback to allow
@@ -141,7 +139,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-data'>
+    <refsect2 xml:id="pam3-data">
       <title>Data Objects</title>
       <para>
         The
@@ -176,7 +174,7 @@
       </para>
     </refsect2>
 
-    <refsect2 id='pam3-miscellaneous'>
+    <refsect2 xml:id="pam3-miscellaneous">
     <title>Environment and Error Management</title>
       <para>
         The
@@ -202,7 +200,7 @@
     </refsect2>
   </refsect1>
 
-  <refsect1 id='pam3-return_values'>
+  <refsect1 xml:id="pam3-return_values">
     <title>RETURN VALUES</title>
     <para>
       The following return codes are known by PAM:
@@ -389,7 +387,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='see_also'><title>SEE ALSO</title>
+  <refsect1 xml:id="see_also"><title>SEE ALSO</title>
     <para>
       <citerefentry>
         <refentrytitle>pam_acct_mgmt</refentrytitle><manvolnum>3</manvolnum>
@@ -430,7 +428,7 @@
       </citerefentry>
     </para>
   </refsect1>
-  <refsect1 id='pam3-notes'><title>NOTES</title>
+  <refsect1 xml:id="pam3-notes"><title>NOTES</title>
     <para>
       The <emphasis>libpam</emphasis> interfaces are only thread-safe if each
       thread within the multithreaded application uses its own PAM handle.

--- a/doc/man/pam.8.xml
+++ b/doc/man/pam.8.xml
@@ -1,32 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam8'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam8">
 
   <refmeta>
     <refentrytitle>pam</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam8-name'>
+  <refnamediv xml:id="pam8-name">
     <refname>PAM</refname>
     <refname>pam</refname>
     <refpurpose>Pluggable Authentication Modules for Linux</refpurpose>
   </refnamediv>
 
-  <refsect1 id='pam8-description'>
+  <refsect1 xml:id="pam8-description">
     <title>DESCRIPTION</title>
     <para>
       This manual is intended to offer a quick introduction to
-      <emphasis remap='B'>Linux-PAM</emphasis>. For more information
+      <emphasis remap="B">Linux-PAM</emphasis>. For more information
       the reader is directed to the
-      <emphasis remap='B'>Linux-PAM system administrators' guide</emphasis>.
+      <emphasis remap="B">Linux-PAM system administrators' guide</emphasis>.
     </para>
 
     <para>
-      <emphasis remap='B'>Linux-PAM</emphasis> is a system of libraries
+      <emphasis remap="B">Linux-PAM</emphasis> is a system of libraries
       that handle the authentication tasks of applications (services) on
       the system. The library provides a stable general interface
       (Application Programming Interface - API) that privilege granting
@@ -43,12 +40,12 @@
       system administrator is free to choose how individual
       service-providing applications will authenticate users. This dynamic
       configuration is set by the contents of the single
-      <emphasis remap='B'>Linux-PAM</emphasis> configuration file
+      <emphasis remap="B">Linux-PAM</emphasis> configuration file
       <filename>/etc/pam.conf</filename>. Alternatively, the configuration
       can be set by individual configuration files located in the
       <filename>/etc/pam.d/</filename> directory. The presence of this
-      directory will cause <emphasis remap='B'>Linux-PAM</emphasis> to
-      <emphasis remap='I'>ignore</emphasis> <filename>/etc/pam.conf</filename>.
+      directory will cause <emphasis remap="B">Linux-PAM</emphasis> to
+      <emphasis remap="I">ignore</emphasis> <filename>/etc/pam.conf</filename>.
     </para>
 
     <para>
@@ -64,26 +61,26 @@
 <para>From the point of view of the system administrator, for whom this
 manual is provided, it is not of primary importance to understand the
 internal behavior of the
-<emphasis remap='B'>Linux-PAM</emphasis>
+<emphasis remap="B">Linux-PAM</emphasis>
 library.  The important point to recognize is that the configuration
 file(s)
-<emphasis remap='I'>define</emphasis>
+<emphasis remap="I">define</emphasis>
 the connection between applications
-<emphasis remap='B'></emphasis>(<emphasis remap='B'>services</emphasis>)
+<emphasis remap="B"/>(<emphasis remap="B">services</emphasis>)
 and the pluggable authentication modules
-<emphasis remap='B'></emphasis>(<emphasis remap='B'>PAM</emphasis>s)
+<emphasis remap="B"/>(<emphasis remap="B">PAM</emphasis>s)
 that perform the actual authentication tasks.</para>
 
 
-<para><emphasis remap='B'>Linux-PAM</emphasis>
+<para><emphasis remap="B">Linux-PAM</emphasis>
 separates the tasks of
-<emphasis remap='I'>authentication</emphasis>
+<emphasis remap="I">authentication</emphasis>
 into four independent management groups:
-<emphasis remap='B'>account</emphasis> management;
-<emphasis remap='B'>auth</emphasis>entication management;
-<emphasis remap='B'>password</emphasis> management;
+<emphasis remap="B">account</emphasis> management;
+<emphasis remap="B">auth</emphasis>entication management;
+<emphasis remap="B">password</emphasis> management;
 and
-<emphasis remap='B'>session</emphasis> management.
+<emphasis remap="B">session</emphasis> management.
 (We highlight the abbreviations used for these groups in the
 configuration file.)</para>
 
@@ -92,12 +89,12 @@ configuration file.)</para>
 user's request for a restricted service:</para>
 
 
-<para><emphasis remap='B'>account</emphasis> -
+<para><emphasis remap="B">account</emphasis> -
 provide account verification types of service: has the user's password
 expired?; is this user permitted access to the requested service?</para>
 
 <!-- .br -->
-<para><emphasis remap='B'>auth</emphasis>entication -
+<para><emphasis remap="B">auth</emphasis>entication -
 authenticate a user and set up user credentials. Typically this is via
 some challenge-response request that the user must satisfy: if you are
 who you claim to be please enter your password. Not all authentications
@@ -105,64 +102,64 @@ are of this type, there exist hardware based authentication schemes
 (such as the use of smart-cards and biometric devices), with suitable
 modules, these may be substituted seamlessly for more standard
 approaches to authentication - such is the flexibility of
-<emphasis remap='B'>Linux-PAM</emphasis>.</para>
+<emphasis remap="B">Linux-PAM</emphasis>.</para>
 
 <!-- .br -->
-<para><emphasis remap='B'>password</emphasis> -
+<para><emphasis remap="B">password</emphasis> -
 this group's responsibility is the task of updating authentication
 mechanisms. Typically, such services are strongly coupled to those of
 the
-<emphasis remap='B'>auth</emphasis>
+<emphasis remap="B">auth</emphasis>
 group. Some authentication mechanisms lend themselves well to being
 updated with such a function. Standard UN*X password-based access is
 the obvious example: please enter a replacement password.</para>
 
 <!-- .br -->
-<para><emphasis remap='B'>session</emphasis> -
+<para><emphasis remap="B">session</emphasis> -
 this group of tasks cover things that should be done prior to a
 service being given and after it is withdrawn. Such tasks include the
 maintenance of audit trails and the mounting of the user's home
 directory. The
-<emphasis remap='B'>session</emphasis>
+<emphasis remap="B">session</emphasis>
 management group is important as it provides both an opening and
 closing hook for modules to affect the services available to a user.</para>
 
 </refsect1>
 
-  <refsect1 id='pam8-files'>
+  <refsect1 xml:id="pam8-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/pam.conf</filename></term>
+        <term>/etc/pam.conf</term>
         <listitem>
           <para>the configuration file</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><filename>/etc/pam.d</filename></term>
+        <term>/etc/pam.d</term>
         <listitem>
           <para>
-            the <emphasis remap='B'>Linux-PAM</emphasis> configuration
+            the <emphasis remap="B">Linux-PAM</emphasis> configuration
             directory. Generally, if this directory is present, the
             <filename>/etc/pam.conf</filename> file is ignored.
           </para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><filename>/usr/lib/pam.d</filename></term>
+        <term>/usr/lib/pam.d</term>
         <listitem>
           <para>
-            the <emphasis remap='B'>Linux-PAM</emphasis> vendor configuration
+            the <emphasis remap="B">Linux-PAM</emphasis> vendor configuration
             directory. Files in <filename>/etc/pam.d</filename> override
             files with the same name in this directory.
           </para>
         </listitem>
       </varlistentry>
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/pam.d</filename></term>
+        <term>%vendordir%/pam.d</term>
         <listitem>
           <para>
-            the <emphasis remap='B'>Linux-PAM</emphasis> vendor configuration
+            the <emphasis remap="B">Linux-PAM</emphasis> vendor configuration
 	    directory. Files in <filename>/etc/pam.d</filename> and
 	    <filename>/usr/lib/pam.d</filename> override files with the same
 	    name in this directory.
@@ -172,18 +169,18 @@ closing hook for modules to affect the services available to a user.</para>
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam8-errors'>
+  <refsect1 xml:id="pam8-errors">
     <title>ERRORS</title>
     <para>
       Typically errors generated by the
-      <emphasis remap='B'>Linux-PAM</emphasis> system of libraries, will
+      <emphasis remap="B">Linux-PAM</emphasis> system of libraries, will
       be written to <citerefentry>
       <refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum>
       </citerefentry>.
     </para>
   </refsect1>
 
-  <refsect1 id='pam8-conforming_to'>
+  <refsect1 xml:id="pam8-conforming_to">
     <title>CONFORMING TO</title>
     <para>
       DCE-RFC 86.0, October 1995.
@@ -192,7 +189,7 @@ closing hook for modules to affect the services available to a user.</para>
     </para>
   </refsect1>
 
-  <refsect1 id='pam8-see_also'>
+  <refsect1 xml:id="pam8-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam.conf-desc.xml
+++ b/doc/man/pam.conf-desc.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<section id='pam.conf-desc'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam.conf-desc">
   <para>
     When a <emphasis>PAM</emphasis> aware privilege granting application
     is started, it activates its attachment to the PAM-API. This

--- a/doc/man/pam.conf-dir.xml
+++ b/doc/man/pam.conf-dir.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<section id='pam.conf-dir'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam.conf-dir">
     <para>
       More flexible than the single configuration file is it to
       configure libpam via the contents of the
@@ -25,6 +22,6 @@ type  control  module-path  module-arguments
       The only difference being that the service-name is not present. The
       service-name is of course the name of the given configuration file.
       For example, <filename>/etc/pam.d/login</filename> contains the
-      configuration for the <emphasis remap='B'>login</emphasis> service.
+      configuration for the <emphasis remap="B">login</emphasis> service.
     </para>
 </section>

--- a/doc/man/pam.conf-syntax.xml
+++ b/doc/man/pam.conf-syntax.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<section id='pam.conf-syntax'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam.conf-syntax">
   <para>
     The syntax of the <filename>/etc/pam.conf</filename>
     configuration file is as follows. The file is made up of a list
@@ -18,7 +14,7 @@
     </para>
 
     <para>
-      <emphasis remap='B'> service  type  control  module-path  module-arguments</emphasis>
+      <emphasis remap="B"> service  type  control  module-path  module-arguments</emphasis>
     </para>
 
     <para>
@@ -411,7 +407,7 @@
       should use `\]'. In other words:
     </para>
     <programlisting>
-    [..[..\]..]    -->   ..[..]..
+    [..[..\]..]    --&gt;   ..[..]..
     </programlisting>
 
     <para>

--- a/doc/man/pam.conf.5.xml
+++ b/doc/man/pam.conf.5.xml
@@ -1,15 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam.conf'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam.conf">
 
   <refmeta>
     <refentrytitle>pam.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam.conf-name'>
+  <refnamediv xml:id="pam.conf-name">
     <refname>pam.conf</refname>
     <refname>pam.d</refname>
     <refpurpose>PAM configuration files</refpurpose>
@@ -17,22 +15,16 @@
 
 <!-- body begins here -->
 
-  <refsect1 id='pam.conf-description'>
+  <refsect1 xml:id="pam.conf-description">
     <title>DESCRIPTION</title>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam.conf-desc.xml"
-     xpointer='xpointer(//section[@id = "pam.conf-desc"]/*)' />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam.conf-desc.xml" xpointer='xpointer(id("pam.conf-desc")/*)' />
 
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam.conf-syntax.xml"
-     xpointer='xpointer(//section[@id = "pam.conf-syntax"]/*)' />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam.conf-syntax.xml" xpointer='xpointer(id("pam.conf-syntax")/*)' />
 
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam.conf-dir.xml"
-     xpointer='xpointer(//section[@id = "pam.conf-dir"]/*)' />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam.conf-dir.xml" xpointer='xpointer(id("pam.conf-dir")/*)' />
   </refsect1>
 
-  <refsect1 id='pam.conf-see_also'>
+  <refsect1 xml:id="pam.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_acct_mgmt.3.xml
+++ b/doc/man/pam_acct_mgmt.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_acct_mgmt'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_acct_mgmt">
   <refmeta>
     <refentrytitle>pam_acct_mgmt</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_acct_mgmt-name">
+  <refnamediv xml:id="pam_acct_mgmt-name">
     <refname>pam_acct_mgmt</refname>
     <refpurpose>PAM account validation management</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_acct_mgmt-synopsis'>
+    <funcsynopsis xml:id="pam_acct_mgmt-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_acct_mgmt</function></funcdef>
@@ -27,7 +25,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_acct_mgmt-description'>
+  <refsect1 xml:id="pam_acct_mgmt-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_acct_mgmt</function> function is used to determine
@@ -62,7 +60,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_acct_mgmt-return_values">
+  <refsect1 xml:id="pam_acct_mgmt-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -122,7 +120,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_acct_mgmt-see_also'>
+  <refsect1 xml:id="pam_acct_mgmt-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_authenticate.3.xml
+++ b/doc/man/pam_authenticate.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_authenticate'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_authenticate">
   <refmeta>
     <refentrytitle>pam_authenticate</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_authenticate-name">
+  <refnamediv xml:id="pam_authenticate-name">
     <refname>pam_authenticate</refname>
     <refpurpose>account authentication</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_authenticate-synopsis'>
+    <funcsynopsis xml:id="pam_authenticate-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_authenticate</function></funcdef>
@@ -27,7 +25,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_authenticate-description'>
+  <refsect1 xml:id="pam_authenticate-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_authenticate</function> function is used to
@@ -77,7 +75,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_authenticate-return_values">
+  <refsect1 xml:id="pam_authenticate-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -146,7 +144,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_authenticate-see_also'>
+  <refsect1 xml:id="pam_authenticate-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_chauthtok.3.xml
+++ b/doc/man/pam_chauthtok.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_chauthtok'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_chauthtok">
   <refmeta>
     <refentrytitle>pam_chauthtok</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_chauthtok-name">
+  <refnamediv xml:id="pam_chauthtok-name">
     <refname>pam_chauthtok</refname>
     <refpurpose>updating authentication tokens</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_chauthtok-synopsis'>
+    <funcsynopsis xml:id="pam_chauthtok-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_chauthtok</function></funcdef>
@@ -27,7 +25,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_chauthtok-description'>
+  <refsect1 xml:id="pam_chauthtok-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_chauthtok</function> function is used to change the
@@ -64,7 +62,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_chauthtok-return_values">
+  <refsect1 xml:id="pam_chauthtok-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -138,7 +136,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_chauthtok-see_also'>
+  <refsect1 xml:id="pam_chauthtok-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_close_session.3.xml
+++ b/doc/man/pam_close_session.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_send'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_send">
 
   <refmeta>
     <refentrytitle>pam_close_session</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_close_session-name">
+  <refnamediv xml:id="pam_close_session-name">
     <refname>pam_close_session</refname>
     <refpurpose>terminate PAM session management</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_close_session-synopsis">
+    <funcsynopsis xml:id="pam_close_session-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_close_session</function></funcdef>
@@ -29,7 +26,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_close_session-description">
+  <refsect1 xml:id="pam_close_session-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_close_session</function> function is used
@@ -63,7 +60,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_close_session-return_values">
+  <refsect1 xml:id="pam_close_session-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -101,7 +98,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_close_session-see_also">
+  <refsect1 xml:id="pam_close_session-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_conv.3.xml
+++ b/doc/man/pam_conv.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_conv'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_conv">
   <refmeta>
     <refentrytitle>pam_conv</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_conv-name">
+  <refnamediv xml:id="pam_conv-name">
     <refname>pam_conv</refname>
     <refpurpose>PAM conversation function</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_conv-synopsis">
+    <funcsynopsis xml:id="pam_conv-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
     </funcsynopsis>
     <programlisting>
@@ -38,7 +36,7 @@ struct pam_conv {
     </programlisting>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_conv-description'>
+  <refsect1 xml:id="pam_conv-description">
     <title>DESCRIPTION</title>
     <para>
       The PAM library uses an application-defined callback to allow
@@ -174,7 +172,7 @@ struct pam_conv {
     </itemizedlist>
   </refsect1>
 
-  <refsect1 id="pam_conv-return_values">
+  <refsect1 xml:id="pam_conv-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -205,7 +203,7 @@ struct pam_conv {
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_conv-see_also'>
+  <refsect1 xml:id="pam_conv-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_end.3.xml
+++ b/doc/man/pam_end.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_end'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_end">
 
   <refmeta>
     <refentrytitle>pam_end</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_end-name">
+  <refnamediv xml:id="pam_end-name">
     <refname>pam_end</refname>
     <refpurpose>termination of PAM transaction</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_end-synopsis">
+    <funcsynopsis xml:id="pam_end-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_end</function></funcdef>
@@ -29,7 +26,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_end-description">
+  <refsect1 xml:id="pam_end-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_end</function> function terminates the PAM
@@ -79,7 +76,7 @@
     </para>
 
   </refsect1>
-  <refsect1 id="pam_end-return_values">
+  <refsect1 xml:id="pam_end-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -102,7 +99,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_end-see_also">
+  <refsect1 xml:id="pam_end-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_error.3.xml
+++ b/doc/man/pam_error.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_error">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_error">
 
   <refmeta>
     <refentrytitle>pam_error</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_error-name">
+  <refnamediv xml:id="pam_error-name">
     <refname>pam_error</refname>
     <refname>pam_verror</refname>
     <refpurpose>display error messages to the user</refpurpose>
@@ -18,7 +15,7 @@
 
 <!-- body begins here -->
 
-  <refsynopsisdiv id="pam_error-synopsis">
+  <refsynopsisdiv xml:id="pam_error-synopsis">
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;security/pam_ext.h&gt;</funcsynopsisinfo>
       <funcprototype>
@@ -36,7 +33,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_error-description'>
+  <refsect1 xml:id="pam_error-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_error</function> function prints error messages
@@ -51,7 +48,7 @@
       </citerefentry> variable argument list macros.
     </para>
   </refsect1>
-  <refsect1 id="pam_error-return_values">
+  <refsect1 xml:id="pam_error-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -89,7 +86,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_error-see_also'>
+  <refsect1 xml:id="pam_error-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -110,7 +107,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_error-standards'>
+  <refsect1 xml:id="pam_error-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_error</function> and <function>pam_verror</function>

--- a/doc/man/pam_fail_delay.3.xml
+++ b/doc/man/pam_fail_delay.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_fail_delay">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_fail_delay">
 
   <refmeta>
     <refentrytitle>pam_fail_delay</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_fail_delay-name">
+  <refnamediv xml:id="pam_fail_delay-name">
     <refname>pam_fail_delay</refname>
     <refpurpose>request a delay on failure</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_fail_delay-synopsis">
+    <funcsynopsis xml:id="pam_fail_delay-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_fail_delay</function></funcdef>
@@ -28,7 +25,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_fail_delay-description'>
+  <refsect1 xml:id="pam_fail_delay-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_fail_delay</function> function provides a
@@ -105,7 +102,7 @@ void (*delay_fn)(int retval, unsigned usec_delay, void *appdata_ptr);
     </para>
   </refsect1>
 
-  <refsect1 id='pam_fail_delay-rationale'>
+  <refsect1 xml:id="pam_fail_delay-rationale">
     <title>RATIONALE</title>
     <para>
       It is often possible to attack an authentication scheme by exploiting
@@ -129,7 +126,7 @@ void (*delay_fn)(int retval, unsigned usec_delay, void *appdata_ptr);
     </para>
   </refsect1>
 
-  <refsect1 id='pam_fail_delay-example'>
+  <refsect1 xml:id="pam_fail_delay-example">
     <title>EXAMPLE</title>
     <para>
       For example, a login application may require a failure delay of
@@ -161,7 +158,7 @@ module #2:    pam_fail_delay (pamh, 4000000);
     </para>
   </refsect1>
 
-  <refsect1 id='pam_fail_delay-return_values'>
+  <refsect1 xml:id="pam_fail_delay-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -183,7 +180,7 @@ module #2:    pam_fail_delay (pamh, 4000000);
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_fail_delay-see_also'>
+  <refsect1 xml:id="pam_fail_delay-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -198,7 +195,7 @@ module #2:    pam_fail_delay (pamh, 4000000);
     </para>
   </refsect1>
 
-  <refsect1 id='pam_fail_delay-standards'>
+  <refsect1 xml:id="pam_fail_delay-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_fail_delay</function> function is an

--- a/doc/man/pam_get_authtok.3.xml
+++ b/doc/man/pam_get_authtok.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_get_authtok">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_get_authtok">
 
   <refmeta>
     <refentrytitle>pam_get_authtok</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_get_authtok-name">
+  <refnamediv xml:id="pam_get_authtok-name">
     <refname>pam_get_authtok</refname>
     <refname>pam_get_authtok_verify</refname>
     <refname>pam_get_authtok_noverify</refname>
@@ -19,7 +16,7 @@
 
 <!-- body begins here -->
 
-  <refsynopsisdiv id="pam_get_authtok-synopsis">
+  <refsynopsisdiv xml:id="pam_get_authtok-synopsis">
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;security/pam_ext.h&gt;</funcsynopsisinfo>
       <funcprototype>
@@ -44,7 +41,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_get_authtok-description'>
+  <refsect1 xml:id="pam_get_authtok-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_get_authtok</function> function returns the
@@ -119,7 +116,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_get_authtok-options">
+  <refsect1 xml:id="pam_get_authtok-options">
     <title>OPTIONS</title>
     <para>
       <function>pam_get_authtok</function> honours the following module
@@ -128,7 +125,7 @@
     <variablelist>
       <varlistentry>
         <term>
-          <option>try_first_pass</option>
+          try_first_pass
         </term>
         <listitem>
           <para>
@@ -140,7 +137,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_first_pass</option>
+          use_first_pass
         </term>
         <listitem>
           <para>
@@ -153,7 +150,7 @@
       </varlistentry>
        <varlistentry>
         <term>
-          <option>use_authtok</option>
+          use_authtok
         </term>
         <listitem>
           <para>
@@ -166,7 +163,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>authtok_type=<replaceable>XXX</replaceable></option>
+          authtok_type=XXX
         </term>
         <listitem>
           <para>
@@ -182,7 +179,7 @@
   </refsect1>
 
 
-  <refsect1 id="pam_get_authtok-return_values">
+  <refsect1 xml:id="pam_get_authtok-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -228,7 +225,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_get_authtok-see_also'>
+  <refsect1 xml:id="pam_get_authtok-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -237,7 +234,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_get_authtok-standards'>
+  <refsect1 xml:id="pam_get_authtok-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_get_authtok</function> function is a Linux-PAM

--- a/doc/man/pam_get_data.3.xml
+++ b/doc/man/pam_get_data.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_get_data'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_get_data">
 
   <refmeta>
     <refentrytitle>pam_get_data</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_get_data-name'>
+  <refnamediv xml:id="pam_get_data-name">
     <refname>pam_get_data</refname>
     <refpurpose>
        get module internal data
@@ -22,7 +19,7 @@
 
   <refsynopsisdiv>
 
-   <funcsynopsis id="pam_get_data-synopsis">
+   <funcsynopsis xml:id="pam_get_data-synopsis">
      <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
      <funcprototype>
        <funcdef>int <function>pam_get_data</function></funcdef>
@@ -35,7 +32,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_get_data-description">
+  <refsect1 xml:id="pam_get_data-description">
     <title>DESCRIPTION</title>
     <para>
       This function together with the
@@ -58,7 +55,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_get_data-return_values">
+  <refsect1 xml:id="pam_get_data-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -90,7 +87,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_get_data-see_also">
+  <refsect1 xml:id="pam_get_data-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_get_item.3.xml
+++ b/doc/man/pam_get_item.3.xml
@@ -1,22 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
-[
-<!--
-<!ENTITY accessconf SYSTEM "pam_item_types_std.inc.xml">
-<!ENTITY accessconf SYSTEM "pam_item_types_ext.inc.xml">
--->
-]>
-
-<refentry id='pam_get_item'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_get_item">
 
   <refmeta>
     <refentrytitle>pam_get_item</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_get_item-name'>
+  <refnamediv xml:id="pam_get_item-name">
     <refname>pam_get_item</refname>
     <refpurpose>
        getting PAM information
@@ -28,7 +19,7 @@
 
   <refsynopsisdiv>
 
-   <funcsynopsis id="pam_get_item-synopsis">
+   <funcsynopsis xml:id="pam_get_item-synopsis">
      <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
      <funcprototype>
        <funcdef>int <function>pam_get_item</function></funcdef>
@@ -41,7 +32,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_get_item-description">
+  <refsect1 xml:id="pam_get_item-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_get_item</function> function allows applications
@@ -55,16 +46,14 @@
       <emphasis>item_type</emphasis>:
    </para>
 
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_item_types_std.inc.xml"/>
+   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_item_types_std.inc.xml"/>
 
    <para>
      The following additional items are specific to Linux-PAM and should not be used in
      portable applications:
    </para>
 
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_item_types_ext.inc.xml"/>
+   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_item_types_ext.inc.xml"/>
 
     <para>
       If a service module wishes to obtain the name of the user,
@@ -80,7 +69,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_get_item-return_values">
+  <refsect1 xml:id="pam_get_item-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -128,7 +117,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_get_item-see_also">
+  <refsect1 xml:id="pam_get_item-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_get_user.3.xml
+++ b/doc/man/pam_get_user.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_get_user'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_get_user">
 
   <refmeta>
     <refentrytitle>pam_get_user</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_get_user-name'>
+  <refnamediv xml:id="pam_get_user-name">
     <refname>pam_get_user</refname>
     <refpurpose>
        get user name
@@ -22,7 +19,7 @@
 
   <refsynopsisdiv>
 
-   <funcsynopsis id="pam_get_user-synopsis">
+   <funcsynopsis xml:id="pam_get_user-synopsis">
      <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
      <funcprototype>
        <funcdef>int <function>pam_get_user</function></funcdef>
@@ -35,7 +32,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_get_user-description">
+  <refsect1 xml:id="pam_get_user-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_get_user</function> function returns the
@@ -87,7 +84,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_get_user-return_values">
+  <refsect1 xml:id="pam_get_user-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -143,7 +140,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_get_user-see_also">
+  <refsect1 xml:id="pam_get_user-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_getenv.3.xml
+++ b/doc/man/pam_getenv.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_getenv'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_getenv">
   <refmeta>
     <refentrytitle>pam_getenv</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_getenv-name">
+  <refnamediv xml:id="pam_getenv-name">
     <refname>pam_getenv</refname>
     <refpurpose>get a PAM environment variable</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_getenv-synopsis'>
+    <funcsynopsis xml:id="pam_getenv-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>const char *<function>pam_getenv</function></funcdef>
@@ -27,7 +25,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_getenv-description'>
+  <refsect1 xml:id="pam_getenv-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_getenv</function> function searches the
@@ -39,7 +37,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_getenv-return_values">
+  <refsect1 xml:id="pam_getenv-return_values">
     <title>RETURN VALUES</title>
     <para>
       The <function>pam_getenv</function> function returns NULL
@@ -47,7 +45,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_getenv-see_also'>
+  <refsect1 xml:id="pam_getenv-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_getenvlist.3.xml
+++ b/doc/man/pam_getenvlist.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_getenvlist'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_getenvlist">
   <refmeta>
     <refentrytitle>pam_getenvlist</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_getenvlist-name">
+  <refnamediv xml:id="pam_getenvlist-name">
     <refname>pam_getenvlist</refname>
     <refpurpose>getting the PAM environment</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_getenvlist-synopsis'>
+    <funcsynopsis xml:id="pam_getenvlist-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>char **<function>pam_getenvlist</function></funcdef>
@@ -26,7 +24,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_getenvlist-description'>
+  <refsect1 xml:id="pam_getenvlist-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_getenvlist</function> function returns a complete
@@ -57,7 +55,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_getenvlist-return_values">
+  <refsect1 xml:id="pam_getenvlist-return_values">
     <title>RETURN VALUES</title>
     <para>
       The <function>pam_getenvlist</function> function returns NULL
@@ -65,7 +63,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_getenvlist-see_also'>
+  <refsect1 xml:id="pam_getenvlist-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_info.3.xml
+++ b/doc/man/pam_info.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_info">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_info">
 
   <refmeta>
     <refentrytitle>pam_info</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_info-name">
+  <refnamediv xml:id="pam_info-name">
     <refname>pam_info</refname>
     <refname>pam_vinfo</refname>
     <refpurpose>display messages to the user</refpurpose>
@@ -18,7 +15,7 @@
 
 <!-- body begins here -->
 
-  <refsynopsisdiv id="pam_info-synopsis">
+  <refsynopsisdiv xml:id="pam_info-synopsis">
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;security/pam_ext.h&gt;</funcsynopsisinfo>
       <funcprototype>
@@ -36,7 +33,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_info-description'>
+  <refsect1 xml:id="pam_info-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_info</function> function prints messages
@@ -51,7 +48,7 @@
       </citerefentry> variable argument list macros.
     </para>
   </refsect1>
-  <refsect1 id="pam_info-return_values">
+  <refsect1 xml:id="pam_info-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -89,7 +86,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_info-see_also'>
+  <refsect1 xml:id="pam_info-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -98,7 +95,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_info-standards'>
+  <refsect1 xml:id="pam_info-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_info</function> and <function>pam_vinfo</function>

--- a/doc/man/pam_item_types_ext.inc.xml
+++ b/doc/man/pam_item_types_ext.inc.xml
@@ -1,6 +1,5 @@
 <!-- this file is included by pam_set_item and pam_get_item -->
-
-    <variablelist>
+<variablelist xmlns="http://docbook.org/ns/docbook" version="5.0">
       <varlistentry>
         <term>PAM_FAIL_DELAY</term>
         <listitem>

--- a/doc/man/pam_item_types_std.inc.xml
+++ b/doc/man/pam_item_types_std.inc.xml
@@ -1,6 +1,5 @@
 <!-- this file is included by pam_set_item and pam_get_item -->
-
-    <variablelist>
+<variablelist xmlns="http://docbook.org/ns/docbook" version="5.0">
       <varlistentry>
         <term>PAM_SERVICE</term>
         <listitem>

--- a/doc/man/pam_misc_drop_env.3.xml
+++ b/doc/man/pam_misc_drop_env.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_misc_drop_env">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_misc_drop_env">
 
   <refmeta>
     <refentrytitle>pam_misc_drop_env</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_misc_drop_env-name">
+  <refnamediv xml:id="pam_misc_drop_env-name">
     <refname>pam_misc_drop_env</refname>
     <refpurpose>liberating a locally saved environment</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_misc_drop_env-synopsis">
+    <funcsynopsis xml:id="pam_misc_drop_env-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_misc.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_misc_drop_env</function></funcdef>
@@ -27,7 +24,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_misc_drop_env-description'>
+  <refsect1 xml:id="pam_misc_drop_env-description">
     <title>DESCRIPTION</title>
     <para>
       This function is defined to complement the <citerefentry>
@@ -39,7 +36,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_misc_drop_env-see_also'>
+  <refsect1 xml:id="pam_misc_drop_env-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -51,7 +48,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_misc_drop_env-standards'>
+  <refsect1 xml:id="pam_misc_drop_env-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_misc_drop_env</function> function is part of the

--- a/doc/man/pam_misc_paste_env.3.xml
+++ b/doc/man/pam_misc_paste_env.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_misc_paste_env">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_misc_paste_env">
 
   <refmeta>
     <refentrytitle>pam_misc_paste_env</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_misc_paste_env-name">
+  <refnamediv xml:id="pam_misc_paste_env-name">
     <refname>pam_misc_paste_env</refname>
     <refpurpose>transcribing an environment to that of PAM</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_misc_paste_env-synopsis">
+    <funcsynopsis xml:id="pam_misc_paste_env-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_misc.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_misc_paste_env</function></funcdef>
@@ -28,7 +25,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_misc_paste_env-description'>
+  <refsect1 xml:id="pam_misc_paste_env-description">
     <title>DESCRIPTION</title>
     <para>
       This function takes the supplied list of environment pointers and
@@ -37,7 +34,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_misc_paste_env-see_also'>
+  <refsect1 xml:id="pam_misc_paste_env-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -49,7 +46,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_misc_paste_env-standards'>
+  <refsect1 xml:id="pam_misc_paste_env-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_misc_paste_env</function> function is part of the

--- a/doc/man/pam_misc_setenv.3.xml
+++ b/doc/man/pam_misc_setenv.3.xml
@@ -1,15 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_misc_setenv">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_misc_setenv">
 
   <refmeta>
     <refentrytitle>pam_misc_setenv</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
-  <refnamediv id="pam_misc_setenv-name">
+  <refnamediv xml:id="pam_misc_setenv-name">
     <refname>pam_misc_setenv</refname>
     <refpurpose>BSD like PAM environment variable setting</refpurpose>
   </refnamediv>
@@ -17,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_misc_setenv-synopsis">
+    <funcsynopsis xml:id="pam_misc_setenv-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_misc.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_misc_setenv</function></funcdef>
@@ -29,7 +26,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_misc_setenv-description'>
+  <refsect1 xml:id="pam_misc_setenv-description">
     <title>DESCRIPTION</title>
     <para>
       This function performs a task equivalent to <citerefentry>
@@ -44,7 +41,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_misc_setenv-see_also'>
+  <refsect1 xml:id="pam_misc_setenv-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -56,7 +53,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_misc_setenv-standards'>
+  <refsect1 xml:id="pam_misc_setenv-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_misc_setenv</function> function is part of the

--- a/doc/man/pam_open_session.3.xml
+++ b/doc/man/pam_open_session.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_send'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_send">
 
   <refmeta>
     <refentrytitle>pam_open_session</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_open_session-name">
+  <refnamediv xml:id="pam_open_session-name">
     <refname>pam_open_session</refname>
     <refpurpose>start PAM session management</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_open_session-synopsis">
+    <funcsynopsis xml:id="pam_open_session-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_open_session</function></funcdef>
@@ -29,7 +26,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_open_session-description">
+  <refsect1 xml:id="pam_open_session-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_open_session</function> function sets up a
@@ -63,7 +60,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_open_session-return_values">
+  <refsect1 xml:id="pam_open_session-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -101,7 +98,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_open_session-see_also">
+  <refsect1 xml:id="pam_open_session-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_prompt.3.xml
+++ b/doc/man/pam_prompt.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_prompt">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_prompt">
 
   <refmeta>
     <refentrytitle>pam_prompt</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_prompt-name">
+  <refnamediv xml:id="pam_prompt-name">
     <refname>pam_prompt</refname>
     <refname>pam_vprompt</refname>
     <refpurpose>interface to conversation function</refpurpose>
@@ -18,7 +15,7 @@
 
 <!-- body begins here -->
 
-  <refsynopsisdiv id="pam_prompt-synopsis">
+  <refsynopsisdiv xml:id="pam_prompt-synopsis">
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;security/pam_ext.h&gt;</funcsynopsisinfo>
       <funcprototype>
@@ -40,7 +37,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_prompt-description'>
+  <refsect1 xml:id="pam_prompt-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_prompt</function> function constructs a message
@@ -52,7 +49,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_prompt-return_values">
+  <refsect1 xml:id="pam_prompt-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -91,7 +88,7 @@
   </refsect1>
 
 
-  <refsect1 id='pam_prompt-see_also'>
+  <refsect1 xml:id="pam_prompt-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -103,7 +100,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_prompt-standards'>
+  <refsect1 xml:id="pam_prompt-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_prompt</function> and <function>pam_vprompt</function>

--- a/doc/man/pam_putenv.3.xml
+++ b/doc/man/pam_putenv.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_putenv'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_putenv">
   <refmeta>
     <refentrytitle>pam_putenv</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_putenv-name">
+  <refnamediv xml:id="pam_putenv-name">
     <refname>pam_putenv</refname>
     <refpurpose>set or change PAM environment variable</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_putenv-synopsis'>
+    <funcsynopsis xml:id="pam_putenv-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_putenv</function></funcdef>
@@ -27,7 +25,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_putenv-description'>
+  <refsect1 xml:id="pam_putenv-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_putenv</function> function is used to
@@ -83,7 +81,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_putenv-return_values">
+  <refsect1 xml:id="pam_putenv-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -129,7 +127,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_putenv-see_also'>
+  <refsect1 xml:id="pam_putenv-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_set_data.3.xml
+++ b/doc/man/pam_set_data.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_set_data'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_set_data">
 
   <refmeta>
     <refentrytitle>pam_set_data</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_set_data-name'>
+  <refnamediv xml:id="pam_set_data-name">
     <refname>pam_set_data</refname>
     <refpurpose>
        set module internal data
@@ -22,7 +19,7 @@
 
   <refsynopsisdiv>
 
-   <funcsynopsis id="pam_set_data-synopsis">
+   <funcsynopsis xml:id="pam_set_data-synopsis">
      <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
      <funcprototype>
        <funcdef>int <function>pam_set_data</function></funcdef>
@@ -36,7 +33,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_set_data-description">
+  <refsect1 xml:id="pam_set_data-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_set_data</function> function associates a pointer
@@ -123,7 +120,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_set_data-return_values">
+  <refsect1 xml:id="pam_set_data-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -154,7 +151,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_set_data-see_also">
+  <refsect1 xml:id="pam_set_data-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_set_item.3.xml
+++ b/doc/man/pam_set_item.3.xml
@@ -1,22 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
-[
-<!--
-<!ENTITY accessconf SYSTEM "pam_item_types_std.inc.xml">
-<!ENTITY accessconf SYSTEM "pam_item_types_ext.inc.xml">
--->
-]>
-
-<refentry id='pam_set_item'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_set_item">
 
   <refmeta>
     <refentrytitle>pam_set_item</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_set_item-name'>
+  <refnamediv xml:id="pam_set_item-name">
     <refname>pam_set_item</refname>
     <refpurpose>
        set and update PAM information
@@ -28,7 +19,7 @@
 
   <refsynopsisdiv>
 
-   <funcsynopsis id="pam_set_item-synopsis">
+   <funcsynopsis xml:id="pam_set_item-synopsis">
      <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
      <funcprototype>
        <funcdef>int <function>pam_set_item</function></funcdef>
@@ -41,7 +32,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_set_item-description">
+  <refsect1 xml:id="pam_set_item-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_set_item</function> function allows applications
@@ -52,16 +43,14 @@
       supported:
    </para>
 
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_item_types_std.inc.xml"/>
+   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_item_types_std.inc.xml"/>
 
    <para>
      The following additional items are specific to Linux-PAM and should not be used in
      portable applications:
    </para>
 
-   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_item_types_ext.inc.xml"/>
+   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_item_types_ext.inc.xml"/>
 
     <para>
       For all <emphasis>item_type</emphasis>s, other than PAM_CONV and
@@ -81,7 +70,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_set_item-return_values">
+  <refsect1 xml:id="pam_set_item-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -121,7 +110,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_set_item-see_also">
+  <refsect1 xml:id="pam_set_item-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_setcred.3.xml
+++ b/doc/man/pam_setcred.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_setcred">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_setcred">
 
   <refmeta>
     <refentrytitle>pam_setcred</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_setcred-name">
+  <refnamediv xml:id="pam_setcred-name">
     <refname>pam_setcred</refname>
     <refpurpose>
        establish / delete user credentials
@@ -19,7 +16,7 @@
 
   <!-- body begins here -->
   <refsynopsisdiv>
-    <funcsynopsis id='pam_setcred-synopsis'>
+    <funcsynopsis xml:id="pam_setcred-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_setcred</function></funcdef>
@@ -30,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_setcred-description'>
+  <refsect1 xml:id="pam_setcred-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_setcred</function> function is used to establish,
@@ -95,7 +92,7 @@
       </variablelist>
    </refsect1>
 
-   <refsect1 id='pam_setcred-return_values'>
+   <refsect1 xml:id="pam_setcred-return_values">
      <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -160,7 +157,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_set_data-see_also">
+  <refsect1 xml:id="pam_set_data-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_sm_acct_mgmt.3.xml
+++ b/doc/man/pam_sm_acct_mgmt.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_sm_acct_mgmt'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sm_acct_mgmt">
   <refmeta>
     <refentrytitle>pam_sm_acct_mgmt</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sm_acct_mgmt-name">
+  <refnamediv xml:id="pam_sm_acct_mgmt-name">
     <refname>pam_sm_acct_mgmt</refname>
     <refpurpose>PAM service function for account management</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_sm_acct_mgmt-synopsis'>
+    <funcsynopsis xml:id="pam_sm_acct_mgmt-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_sm_acct_mgmt</function></funcdef>
@@ -29,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_sm_acct_mgmt-description'>
+  <refsect1 xml:id="pam_sm_acct_mgmt-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_sm_acct_mgmt</function> function is the service
@@ -64,7 +62,7 @@
         <term>PAM_DISALLOW_NULL_AUTHTOK</term>
         <listitem>
           <para>
-            Return <emphasis remap='B'>PAM_AUTH_ERR</emphasis> if the
+            Return <emphasis remap="B">PAM_AUTH_ERR</emphasis> if the
             database of authentication tokens for this authentication
             mechanism has a <emphasis>NULL</emphasis> entry for the user.
           </para>
@@ -73,7 +71,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_sm_acct_mgmt-return_values">
+  <refsect1 xml:id="pam_sm_acct_mgmt-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -131,7 +129,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_sm_acct_mgmt-see_also'>
+  <refsect1 xml:id="pam_sm_acct_mgmt-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_sm_authenticate.3.xml
+++ b/doc/man/pam_sm_authenticate.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_sm_authenticate'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sm_authenticate">
   <refmeta>
     <refentrytitle>pam_sm_authenticate</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sm_authenticate-name">
+  <refnamediv xml:id="pam_sm_authenticate-name">
     <refname>pam_sm_authenticate</refname>
     <refpurpose>PAM service function for user authentication</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_sm_authenticate-synopsis'>
+    <funcsynopsis xml:id="pam_sm_authenticate-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_sm_authenticate</function></funcdef>
@@ -29,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_sm_authenticate-description'>
+  <refsect1 xml:id="pam_sm_authenticate-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_sm_authenticate</function> function is the service
@@ -58,7 +56,7 @@
         <term>PAM_DISALLOW_NULL_AUTHTOK</term>
         <listitem>
           <para>
-            Return <emphasis remap='B'>PAM_AUTH_ERR</emphasis> if the
+            Return <emphasis remap="B">PAM_AUTH_ERR</emphasis> if the
             database of authentication tokens for this authentication
             mechanism has a <emphasis>NULL</emphasis> entry for the user.
             Without this flag, such a <emphasis>NULL</emphasis> token
@@ -69,7 +67,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_sm_authenticate-return_values">
+  <refsect1 xml:id="pam_sm_authenticate-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -128,7 +126,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_sm_authenticate-see_also'>
+  <refsect1 xml:id="pam_sm_authenticate-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_sm_chauthtok.3.xml
+++ b/doc/man/pam_sm_chauthtok.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_sm_chauthtok'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sm_chauthtok">
   <refmeta>
     <refentrytitle>pam_sm_chauthtok</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sm_chauthtok-name">
+  <refnamediv xml:id="pam_sm_chauthtok-name">
     <refname>pam_sm_chauthtok</refname>
     <refpurpose>PAM service function for authentication token management</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_sm_chauthtok-synopsis'>
+    <funcsynopsis xml:id="pam_sm_chauthtok-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_sm_chauthtok</function></funcdef>
@@ -29,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_sm_chauthtok-description'>
+  <refsect1 xml:id="pam_sm_chauthtok-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_sm_chauthtok</function> function is the service
@@ -77,7 +75,7 @@
             some network it should attempt to verify it can connect to
             this system on receiving this flag. If a module cannot establish
             it is ready to update the user's authentication token it should
-            return <emphasis remap='B'>PAM_TRY_AGAIN</emphasis>, this
+            return <emphasis remap="B">PAM_TRY_AGAIN</emphasis>, this
             information will be passed back to the application.
           </para>
           <para>
@@ -93,7 +91,7 @@
           <para>
             This informs the module that this is the call it should change
             the authorization tokens. If the flag is logically OR'd with
-            <emphasis remap='B'>PAM_CHANGE_EXPIRED_AUTHTOK</emphasis>, the
+            <emphasis remap="B">PAM_CHANGE_EXPIRED_AUTHTOK</emphasis>, the
             token is only changed if it has actually expired.
           </para>
         </listitem>
@@ -101,15 +99,15 @@
     </variablelist>
     <para>
       The PAM library calls this function twice in succession. The first
-      time with <emphasis remap='B'>PAM_PRELIM_CHECK</emphasis> and then,
+      time with <emphasis remap="B">PAM_PRELIM_CHECK</emphasis> and then,
       if the module does not return
-      <emphasis remap='B'>PAM_TRY_AGAIN</emphasis>, subsequently with
-      <emphasis remap='B'>PAM_UPDATE_AUTHTOK</emphasis>. It is only on
+      <emphasis remap="B">PAM_TRY_AGAIN</emphasis>, subsequently with
+      <emphasis remap="B">PAM_UPDATE_AUTHTOK</emphasis>. It is only on
       the second call that the authorization token is (possibly) changed.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_sm_chauthtok-return_values">
+  <refsect1 xml:id="pam_sm_chauthtok-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -181,7 +179,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_sm_chauthtok-see_also'>
+  <refsect1 xml:id="pam_sm_chauthtok-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_sm_close_session.3.xml
+++ b/doc/man/pam_sm_close_session.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-close.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_sm_close_session'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sm_close_session">
   <refmeta>
     <refentrytitle>pam_sm_close_session</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sm_close_session-name">
+  <refnamediv xml:id="pam_sm_close_session-name">
     <refname>pam_sm_close_session</refname>
     <refpurpose>PAM service function to terminate session management</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_sm_close_session-synopsis'>
+    <funcsynopsis xml:id="pam_sm_close_session-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_sm_close_session</function></funcdef>
@@ -29,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_sm_close_session-description'>
+  <refsect1 xml:id="pam_sm_close_session-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_sm_close_session</function> function is the service
@@ -40,7 +38,7 @@
     </para>
     <para>
       This function is called to terminate a session. The only valid
-      value for <varname role='parameter'>flags</varname> is zero or:
+      value for <varname role="parameter">flags</varname> is zero or:
     </para>
     <variablelist>
       <varlistentry>
@@ -54,7 +52,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_sm_close_session-return_values">
+  <refsect1 xml:id="pam_sm_close_session-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -76,7 +74,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_sm_close_session-see_also'>
+  <refsect1 xml:id="pam_sm_close_session-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_sm_open_session.3.xml
+++ b/doc/man/pam_sm_open_session.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_sm_open_session'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sm_open_session">
   <refmeta>
     <refentrytitle>pam_sm_open_session</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sm_open_session-name">
+  <refnamediv xml:id="pam_sm_open_session-name">
     <refname>pam_sm_open_session</refname>
     <refpurpose>PAM service function to start session management</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_sm_open_session-synopsis'>
+    <funcsynopsis xml:id="pam_sm_open_session-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_sm_open_session</function></funcdef>
@@ -29,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_sm_open_session-description'>
+  <refsect1 xml:id="pam_sm_open_session-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_sm_open_session</function> function is the service
@@ -40,7 +38,7 @@
     </para>
     <para>
       This function is called to commence a session. The only valid
-      value for <varname role='parameter'>flags</varname> is zero or:
+      value for <varname role="parameter">flags</varname> is zero or:
     </para>
     <variablelist>
       <varlistentry>
@@ -54,7 +52,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_sm_open_session-return_values">
+  <refsect1 xml:id="pam_sm_open_session-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -76,7 +74,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_sm_open_session-see_also'>
+  <refsect1 xml:id="pam_sm_open_session-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_sm_setcred.3.xml
+++ b/doc/man/pam_sm_setcred.3.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-<refentry id='pam_sm_setcred'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sm_setcred">
   <refmeta>
     <refentrytitle>pam_sm_setcred</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sm_setcred-name">
+  <refnamediv xml:id="pam_sm_setcred-name">
     <refname>pam_sm_setcred</refname>
     <refpurpose>PAM service function to alter credentials</refpurpose>
   </refnamediv>
@@ -16,7 +14,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id='pam_sm_setcred-synopsis'>
+    <funcsynopsis xml:id="pam_sm_setcred-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_modules.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_sm_setcred</function></funcdef>
@@ -29,7 +27,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_sm_setcred-description'>
+  <refsect1 xml:id="pam_sm_setcred-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_sm_setcred</function> function is the service
@@ -92,7 +90,7 @@
       </varlistentry>
     </variablelist>
     <para>
-      The way the <emphasis remap='B'>auth</emphasis> stack is
+      The way the <emphasis remap="B">auth</emphasis> stack is
       navigated in order to evaluate the <function>pam_setcred</function>()
       function call, independent of the <function>pam_sm_setcred</function>()
       return codes, is exactly the same way that it was navigated when
@@ -102,11 +100,11 @@
       libpam evaluates the <function>pam_setcred</function>() function
       call. Otherwise, the return codes from each module specific
       <function>pam_sm_setcred</function>() call are treated as
-      <emphasis remap='B'>required</emphasis>.
+      <emphasis remap="B">required</emphasis>.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_sm_setcred-return_values">
+  <refsect1 xml:id="pam_sm_setcred-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -158,7 +156,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_sm_setcred-see_also'>
+  <refsect1 xml:id="pam_sm_setcred-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_start.3.xml
+++ b/doc/man/pam_start.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_start'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_start">
 
   <refmeta>
     <refentrytitle>pam_start</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_start-name">
+  <refnamediv xml:id="pam_start-name">
     <refname>pam_start</refname>
     <refname>pam_start_confdir</refname>
     <refpurpose>initialization of PAM transaction</refpurpose>
@@ -19,7 +16,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_start-synopsis">
+    <funcsynopsis xml:id="pam_start-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>int <function>pam_start</function></funcdef>
@@ -40,7 +37,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_start-description">
+  <refsect1 xml:id="pam_start-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_start</function> function creates the PAM context
@@ -108,7 +105,7 @@
     </para>
 
   </refsect1>
-  <refsect1 id="pam_start-return_values">
+  <refsect1 xml:id="pam_start-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -147,7 +144,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_start-see_also">
+  <refsect1 xml:id="pam_start-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_strerror.3.xml
+++ b/doc/man/pam_strerror.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_strerror'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_strerror">
 
   <refmeta>
     <refentrytitle>pam_strerror</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_strerror-name">
+  <refnamediv xml:id="pam_strerror-name">
     <refname>pam_strerror</refname>
     <refpurpose>return string describing PAM error code</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_strerror-synopsis">
+    <funcsynopsis xml:id="pam_strerror-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
       <funcprototype>
         <funcdef>const char *<function>pam_strerror</function></funcdef>
@@ -29,7 +26,7 @@
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_strerror-description">
+  <refsect1 xml:id="pam_strerror-description">
     <title>DESCRIPTION</title>
     <para>
        The <function>pam_strerror</function> function returns a pointer to
@@ -40,14 +37,14 @@
        modify this string.
     </para>
   </refsect1>
-  <refsect1 id="pam_strerror-return_values">
+  <refsect1 xml:id="pam_strerror-return_values">
     <title>RETURN VALUES</title>
     <para>
        This function returns always a pointer to a string.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_strerror-see_also">
+  <refsect1 xml:id="pam_strerror-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>

--- a/doc/man/pam_syslog.3.xml
+++ b/doc/man/pam_syslog.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_syslog">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_syslog">
 
   <refmeta>
     <refentrytitle>pam_syslog</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_syslog-name">
+  <refnamediv xml:id="pam_syslog-name">
     <refname>pam_syslog</refname>
     <refname>pam_vsyslog</refname>
     <refpurpose>send messages to the system logger</refpurpose>
@@ -18,7 +15,7 @@
 
 <!-- body begins here -->
 
-  <refsynopsisdiv id="pam_syslog-synopsis">
+  <refsynopsisdiv xml:id="pam_syslog-synopsis">
     <funcsynopsis>
       <funcsynopsisinfo>#include &lt;syslog.h&gt;</funcsynopsisinfo>
       <funcsynopsisinfo>#include &lt;security/pam_ext.h&gt;</funcsynopsisinfo>
@@ -39,7 +36,7 @@
     </funcsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_syslog-description'>
+  <refsect1 xml:id="pam_syslog-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_syslog</function> function logs messages using
@@ -62,7 +59,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_syslog-see_also'>
+  <refsect1 xml:id="pam_syslog-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -71,7 +68,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_syslog-standards'>
+  <refsect1 xml:id="pam_syslog-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_syslog</function> and <function>pam_vsyslog</function>

--- a/doc/man/pam_xauth_data.3.xml
+++ b/doc/man/pam_xauth_data.3.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id="pam_xauth_data">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_xauth_data">
 
   <refmeta>
     <refentrytitle>pam_xauth_data</refentrytitle>
     <manvolnum>3</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_xauth_data-name">
+  <refnamediv xml:id="pam_xauth_data-name">
     <refname>pam_xauth_data</refname>
     <refpurpose>structure containing X authentication data</refpurpose>
   </refnamediv>
@@ -18,7 +15,7 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <funcsynopsis id="pam_xauth_data-synopsis">
+    <funcsynopsis xml:id="pam_xauth_data-synopsis">
       <funcsynopsisinfo>#include &lt;security/pam_appl.h&gt;</funcsynopsisinfo>
     </funcsynopsis>
     <programlisting>
@@ -31,7 +28,7 @@ struct pam_xauth_data {
     </programlisting>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_xauth_data-description'>
+  <refsect1 xml:id="pam_xauth_data-description">
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_xauth_data</function> structure contains X
@@ -70,7 +67,7 @@ struct pam_xauth_data {
     </para>
   </refsect1>
 
-  <refsect1 id='pam_xauth_data-see_also'>
+  <refsect1 xml:id="pam_xauth_data-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -82,7 +79,7 @@ struct pam_xauth_data {
     </para>
   </refsect1>
 
-  <refsect1 id='pam_xauth_data-standards'>
+  <refsect1 xml:id="pam_xauth_data-standards">
     <title>STANDARDS</title>
     <para>
       The <function>pam_xauth_data</function> structure and

--- a/doc/mwg/Linux-PAM_MWG.xml
+++ b/doc/mwg/Linux-PAM_MWG.xml
@@ -1,49 +1,38 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-	"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<book id="mwg">
-  <bookinfo>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg">
+  <info>
     <title>The Linux-PAM Module Writers' Guide</title>
     <authorgroup>
-      <author>
-        <firstname>Andrew G.</firstname>
-        <surname>Morgan</surname>
-        <email>morgan@kernel.org</email>
-      </author>
-      <author>
-        <firstname>Thorsten</firstname>
-        <surname>Kukuk</surname>
-        <email>kukuk@thkukuk.de</email>
-      </author>
+      <author><personname><firstname>Andrew G.</firstname><surname>Morgan</surname></personname><email>morgan@kernel.org</email></author>
+      <author><personname><firstname>Thorsten</firstname><surname>Kukuk</surname></personname><email>kukuk@thkukuk.de</email></author>
     </authorgroup>
     <releaseinfo>Version 1.1.2, 31. August 2010</releaseinfo>
     <abstract>
       <para>
         This manual documents what a programmer needs to know in order
         to write a module that conforms to the
-        <emphasis remap='B'>Linux-PAM</emphasis> standard.It also
+        <emphasis remap="B">Linux-PAM</emphasis> standard.It also
         discusses some security issues from the point of view of the
         module programmer.
       </para>
     </abstract>
-  </bookinfo>
+  </info>
 
-  <chapter id="mwg-introduction">
+  <chapter xml:id="mwg-introduction">
     <title>Introduction</title>
-    <section id="mwg-introduction-description">
+    <section xml:id="mwg-introduction-description">
       <title>Description</title>
       <para>
-        <emphasis remap='B'>Linux-PAM</emphasis> (Pluggable Authentication
+        <emphasis remap="B">Linux-PAM</emphasis> (Pluggable Authentication
         Modules for Linux) is a library that enables the local system
         administrator to choose how individual applications authenticate
         users. For an overview of the
-        <emphasis remap='B'>Linux-PAM</emphasis> library see the
+        <emphasis remap="B">Linux-PAM</emphasis> library see the
         <emphasis>Linux-PAM System Administrators' Guide</emphasis>.
       </para>
       <para>
-        A <emphasis remap='B'>Linux-PAM</emphasis> module is a single
+        A <emphasis remap="B">Linux-PAM</emphasis> module is a single
         executable binary file that can be loaded by the
-        <emphasis remap='B'>Linux-PAM</emphasis> interface library.
+        <emphasis remap="B">Linux-PAM</emphasis> interface library.
         This PAM library is configured locally with a system file,
         <filename>/etc/pam.conf</filename>, to authenticate a user
         request via the locally available authentication modules. The
@@ -54,14 +43,14 @@
         <citerefentry>
           <refentrytitle>dlopen</refentrytitle><manvolnum>3</manvolnum>
         </citerefentry>. Alternatively, the modules can be statically
-        linked into the <emphasis remap='B'>Linux-PAM</emphasis> library;
-        this is mostly to allow <emphasis remap='B'>Linux-PAM</emphasis> to
+        linked into the <emphasis remap="B">Linux-PAM</emphasis> library;
+        this is mostly to allow <emphasis remap="B">Linux-PAM</emphasis> to
         be used on platforms without dynamic linking available, but this is
         a <emphasis>deprecated</emphasis> functionality. It is the
-        <emphasis remap='B'>Linux-PAM</emphasis> interface that is called
+        <emphasis remap="B">Linux-PAM</emphasis> interface that is called
         by an application and it is the responsibility of the library to
         locate, load and call the appropriate functions in a
-        <emphasis remap='B'>Linux-PAM</emphasis>-module.
+        <emphasis remap="B">Linux-PAM</emphasis>-module.
       </para>
       <para>
         Except for the immediate purpose of interacting with the user
@@ -71,7 +60,7 @@
       </para>
     </section>
 
-    <section id="mwg-introduction-synopsis">
+    <section xml:id="mwg-introduction-synopsis">
       <title>Synopsis</title>
       <programlisting>
 #include &lt;security/pam_modules.h&gt;
@@ -82,63 +71,52 @@ gcc -shared -o pam_module.so pam_module.o -lpam
     </section>
   </chapter>
 
-  <chapter id="mwg-expected-by-module">
+  <chapter xml:id="mwg-expected-by-module">
     <title>What can be expected by the module</title>
     <para>
       Here we list the interface that the conventions that all
-      <emphasis remap='B'>Linux-PAM</emphasis> modules must adhere to.
+      <emphasis remap="B">Linux-PAM</emphasis> modules must adhere to.
     </para>
-    <section id="mwg-expected-by-module-item">
+    <section xml:id="mwg-expected-by-module-item">
       <title>
         Getting and setting <emphasis>PAM_ITEM</emphasis>s and
         <emphasis>data</emphasis>
       </title>
       <para>
         First, we cover what the module should expect from the
-        <emphasis remap='B'>Linux-PAM</emphasis> library and a
-        <emphasis remap='B'>Linux-PAM</emphasis> aware application.
+        <emphasis remap="B">Linux-PAM</emphasis> library and a
+        <emphasis remap="B">Linux-PAM</emphasis> aware application.
         Essentially this is the <filename>libpam.*</filename> library.
       </para>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_set_data.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_get_data.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_set_item.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_get_item.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_get_user.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_conv.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_putenv.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_getenv.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_getenvlist.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_set_data.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_get_data.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_set_item.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_get_item.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_get_user.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_conv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_putenv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_getenv.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_getenvlist.xml"/>
     </section>
-    <section id="mwg-expected-by-module-other">
+    <section xml:id="mwg-expected-by-module-other">
       <title>
         Other functions provided by <filename>libpam</filename>
       </title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_strerror.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_fail_delay.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_strerror.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_fail_delay.xml"/>
     </section>
   </chapter>
 
-  <chapter id="mwg-expected-of-module">
+  <chapter xml:id="mwg-expected-of-module">
     <title>What is expected of a module</title>
     <para>
       The module must supply a sub-set of the six functions listed
       below. Together they define the function of a
-      <emphasis remap='B'>Linux-PAM module</emphasis>. Module developers
+      <emphasis remap="B">Linux-PAM module</emphasis>. Module developers
       are strongly urged to read the comments on security that follow
       this list.
     </para>
-    <section id="mwg-expected-of-module-overview">
+    <section xml:id="mwg-expected-of-module-overview">
       <title>Overview</title>
       <para>
         The six module functions are grouped into four independent
@@ -149,7 +127,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
         at least one of these groups. A single module may contain the
         necessary functions for <emphasis>all</emphasis> four groups.
       </para>
-      <section id="mwg-expected-of-module-overview-1">
+      <section xml:id="mwg-expected-of-module-overview-1">
         <title>Functional independence</title>
         <para>
           The independence of the four groups of service a module can
@@ -163,7 +141,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           As an informative example, consider the possibility that an
           application applies to change a user's authentication token,
           without having first requested that
-          <emphasis remap='B'>Linux-PAM</emphasis> authenticate the
+          <emphasis remap="B">Linux-PAM</emphasis> authenticate the
           user. In some cases this may be deemed appropriate: when
           <command>root</command> wants to change the authentication
           token of some lesser user. In other cases it may not be
@@ -176,7 +154,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           this when implementing a given module.
         </para>
       </section>
-      <section id="mwg-expected-of-module-overview-2">
+      <section xml:id="mwg-expected-of-module-overview-2">
         <title>Minimizing administration problems</title>
         <para>
           To avoid system administration problems and the poor
@@ -189,7 +167,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           simply return <errorname>PAM_IGNORE</errorname>.
         </para>
       </section>
-      <section id="mwg-expected-of-module-overview-3">
+      <section xml:id="mwg-expected-of-module-overview-3">
         <title>Arguments supplied to the module</title>
         <para>
           The <parameter>flags</parameter> argument of each of
@@ -203,7 +181,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           arguments are taken from the line appropriate to this
           module---that is, with the <emphasis>service_name</emphasis>
           matching that of the application---in the configuration file
-          (see the <emphasis remap='B'>Linux-PAM</emphasis>
+          (see the <emphasis remap="B">Linux-PAM</emphasis>
           System Administrators' Guide). Together these two parameters
           provide the number of arguments and an array of pointers to
           the individual argument tokens. This will be familiar to C
@@ -214,33 +192,27 @@ gcc -shared -o pam_module.so pam_module.o -lpam
         </para>
       </section>
     </section>
-    <section id="mwg-expected-of-module-auth">
+    <section xml:id="mwg-expected-of-module-auth">
       <title>Authentication management</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_sm_authenticate.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_sm_setcred.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sm_authenticate.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sm_setcred.xml"/>
     </section>
-    <section id="mwg-expected-of-module-acct">
+    <section xml:id="mwg-expected-of-module-acct">
       <title>Account management</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_sm_acct_mgmt.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sm_acct_mgmt.xml"/>
     </section>
-    <section id="mwg-expected-of-module-session">
+    <section xml:id="mwg-expected-of-module-session">
       <title>Session management</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_sm_open_session.xml"/>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_sm_close_session.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sm_open_session.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sm_close_session.xml"/>
     </section>
-    <section id="mwg-expected-of-module-chauthtok">
+    <section xml:id="mwg-expected-of-module-chauthtok">
       <title>Authentication token management</title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-       href="pam_sm_chauthtok.xml"/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sm_chauthtok.xml"/>
     </section>
   </chapter>
 
-  <chapter id="mwg-see-options">
+  <chapter xml:id="mwg-see-options">
     <title>Generic optional arguments</title>
     <para>
       Here we list the generic arguments that all modules can expect to
@@ -276,17 +248,17 @@ gcc -shared -o pam_module.so pam_module.o -lpam
     </variablelist>
   </chapter>
 
-  <chapter id="mwg-see-programming">
+  <chapter xml:id="mwg-see-programming">
     <title>Programming notes</title>
     <para>
       Here we collect some pointers for the module writer to bear in mind
-      when writing/developing a <emphasis remap='B'>Linux-PAM</emphasis>
+      when writing/developing a <emphasis remap="B">Linux-PAM</emphasis>
       compatible module.
     </para>
 
-    <section id="mwg-see-programming-sec">
+    <section xml:id="mwg-see-programming-sec">
       <title>Security issues for module creation</title>
-      <section id="mwg-see-programming-sec-res">
+      <section xml:id="mwg-see-programming-sec-res">
         <title>Sufficient resources</title>
         <para>
           Care should be taken to ensure that the proper execution
@@ -299,7 +271,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           consideration.
         </para>
       </section>
-      <section id="mwg-see-programming-sec-who">
+      <section xml:id="mwg-see-programming-sec-who">
         <title>Who´s who?</title>
         <para>
           Generally, the module may wish to establish the identity of
@@ -349,13 +321,13 @@ gcc -shared -o pam_module.so pam_module.o -lpam
               Z, the user under whose identity the service will be granted.
               This is the username returned by
               <function>pam_get_user()</function> and also stored in the
-              <emphasis remap='B'>Linux-PAM</emphasis> item,
+              <emphasis remap="B">Linux-PAM</emphasis> item,
               <emphasis>PAM_USER</emphasis>.
             </para>
           </listitem>
           <listitem>
             <para>
-              <emphasis remap='B'>Linux-PAM</emphasis> has a place for
+              <emphasis remap="B">Linux-PAM</emphasis> has a place for
               an additional user identity that a module may care to make
               use of. This is the <emphasis>PAM_RUSER</emphasis> item.
               Generally, network sensitive modules/applications may wish
@@ -369,10 +341,10 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           <emphasis>uid</emphasis> or <emphasis>euid</emphasis> of the
           running process, it should take care to restore the original
           values prior to returning control to the
-          <emphasis remap='B'>Linux-PAM</emphasis> library.
+          <emphasis remap="B">Linux-PAM</emphasis> library.
         </para>
       </section>
-      <section id="mwg-see-programming-sec-conv">
+      <section xml:id="mwg-see-programming-sec-conv">
         <title>Using the conversation function</title>
         <para>
           Prior to calling the conversation function, the module should
@@ -389,7 +361,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           indicating failure.
         </para>
       </section>
-      <section id="mwg-see-programming-sec-token">
+      <section xml:id="mwg-see-programming-sec-token">
         <title>Authentication tokens</title>
         <para>
           To ensure that the authentication tokens are not left lying
@@ -403,7 +375,7 @@ gcc -shared -o pam_module.so pam_module.o -lpam
           general rule the module should overwrite authentication tokens
           as soon as they are no longer needed. Especially before
           <function>free()</function>'ing them. The
-          <emphasis remap='B'>Linux-PAM</emphasis> library is
+          <emphasis remap="B">Linux-PAM</emphasis> library is
           required to do this when either of these authentication
           token items are (re)set.
         </para>
@@ -437,7 +409,7 @@ int cleanup(pam_handle_t *pamh, void *data, int error_status)
         </para>
       </section>
     </section>
-    <section id="mwg-see-programming-syslog">
+    <section xml:id="mwg-see-programming-syslog">
       <title>Use of <citerefentry>
         <refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum>
       </citerefentry></title>
@@ -451,7 +423,7 @@ int cleanup(pam_handle_t *pamh, void *data, int error_status)
         <citerefentry>
         <refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum>
         </citerefentry> with <emphasis>facility-type</emphasis>
-        <emphasis remap='B'>LOG_AUTHPRIV</emphasis>.
+        <emphasis remap="B">LOG_AUTHPRIV</emphasis>.
       </para>
       <para>
         With a few exceptions, the level of logging is, at the discretion
@@ -501,7 +473,7 @@ int cleanup(pam_handle_t *pamh, void *data, int error_status)
         </listitem>
       </itemizedlist>
     </section>
-    <section id="mwg-see-programming-libs">
+    <section xml:id="mwg-see-programming-libs">
       <title>Modules that require system libraries</title>
       <para>
         Writing a module is much like writing an application. You
@@ -526,16 +498,16 @@ int cleanup(pam_handle_t *pamh, void *data, int error_status)
     </section>
   </chapter>
 
-  <chapter id="mwg-example">
+  <chapter xml:id="mwg-example">
     <title>An example module</title>
     <para>
       At some point, we may include a fully commented example of a module in
       this document. For now, please look at the modules directory of the
-      <emphasis remap='B'>Linux-PAM</emphasis> sources.
+      <emphasis remap="B">Linux-PAM</emphasis> sources.
     </para>
   </chapter>
 
-  <chapter id="mwg-see-also">
+  <chapter xml:id="mwg-see-also">
     <title>See also</title>
     <itemizedlist>
       <listitem>
@@ -558,7 +530,7 @@ int cleanup(pam_handle_t *pamh, void *data, int error_status)
     </itemizedlist>
   </chapter>
 
-  <chapter id='mwg-author'>
+  <chapter xml:id="mwg-author">
     <title>Author/acknowledgments</title>
     <para>
       This document was written by Andrew G. Morgan (morgan@kernel.org)
@@ -578,14 +550,14 @@ int cleanup(pam_handle_t *pamh, void *data, int error_status)
     <para>
       Thanks are also due to Sun Microsystems, especially to Vipin Samar and
       Charlie Lai for their advice. At an early stage in the development of
-      <emphasis remap='B'>Linux-PAM</emphasis>, Sun graciously made the
+      <emphasis remap="B">Linux-PAM</emphasis>, Sun graciously made the
       documentation for their implementation of PAM available. This act
       greatly accelerated the development of
-      <emphasis remap='B'>Linux-PAM</emphasis>.
+      <emphasis remap="B">Linux-PAM</emphasis>.
     </para>
   </chapter>
 
-  <chapter id='mwg-copyright'>
+  <chapter xml:id="mwg-copyright">
     <title>Copyright information for this document</title>
     <programlisting>
 Copyright (c) 2006 Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;

--- a/doc/mwg/Makefile.am
+++ b/doc/mwg/Makefile.am
@@ -16,7 +16,7 @@ all: Linux-PAM_MWG.txt html/Linux-PAM_MWG.html Linux-PAM_MWG.pdf
 
 Linux-PAM_MWG.pdf: $(XMLS) $(DEP_XMLS)
 if ENABLE_GENERATE_PDF
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam generate.toc "book toc" \
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
@@ -28,7 +28,7 @@ else
 endif
 
 Linux-PAM_MWG.txt: $(XMLS) $(DEP_XMLS)
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam generate.toc "book toc" \
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
@@ -37,7 +37,7 @@ Linux-PAM_MWG.txt: $(XMLS) $(DEP_XMLS)
 
 html/Linux-PAM_MWG.html: $(XMLS) $(DEP_XMLS)
 	@test -d html || mkdir -p html
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam base.dir html/ \
 	  --stringparam root.filename Linux-PAM_MWG \
 	  --stringparam use.id.as.filename 1 \

--- a/doc/mwg/pam_conv.xml
+++ b/doc/mwg/pam_conv.xml
@@ -1,11 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_conv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_conv">
   <title>The conversation function</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_conv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_conv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_conv.3.xml" xpointer='xpointer(id("pam_conv-synopsis")/*)'/>
   </funcsynopsis>
   <programlisting>
 struct pam_message {
@@ -24,12 +20,10 @@ struct pam_conv {
     void *appdata_ptr;
 };
   </programlisting>
-  <section id='mwg-pam_conv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_conv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_conv-description"]/*)'/>
+  <section xml:id="mwg-pam_conv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_conv.3.xml" xpointer='xpointer(id("pam_conv-description")/*)'/>
   </section>
-  <section id='mwg-pam_conv-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_conv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_conv-return_values"]/*)'/>
+  <section xml:id="mwg-pam_conv-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_conv.3.xml" xpointer='xpointer(id("pam_conv-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_fail_delay.xml
+++ b/doc/mwg/pam_fail_delay.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_fail_delay'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_fail_delay">
   <title>Request a delay on failure</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_fail_delay.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_fail_delay-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_fail_delay.3.xml" xpointer='xpointer(id("pam_fail_delay-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_fail_delay-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_fail_delay.3.xml" xpointer='xpointer(//refsect1[@id = "pam_fail_delay-description"]/*)'/>
+  <section xml:id="adg-pam_fail_delay-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_fail_delay.3.xml" xpointer='xpointer(id("pam_fail_delay-description")/*)'/>
   </section>
-  <section id='adg-pam_fail_delay-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_fail_delay.3.xml" xpointer='xpointer(//refsect1[@id = "pam_fail_delay-return_values"]/*)'/>
+  <section xml:id="adg-pam_fail_delay-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_fail_delay.3.xml" xpointer='xpointer(id("pam_fail_delay-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_get_data.xml
+++ b/doc/mwg/pam_get_data.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_get_data'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_get_data">
   <title>Get module internal data</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_data.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_get_data-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_data.3.xml" xpointer='xpointer(id("pam_get_data-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_get_data-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_data.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_data-description"]/*)'/>
+  <section xml:id="mwg-pam_get_data-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_data.3.xml" xpointer='xpointer(id("pam_get_data-description")/*)'/>
   </section>
-  <section id='mwg-pam_get_data-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_data.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_data-return_values"]/*)'/>
+  <section xml:id="mwg-pam_get_data-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_data.3.xml" xpointer='xpointer(id("pam_get_data-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_get_item.xml
+++ b/doc/mwg/pam_get_item.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_get_item'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_get_item">
   <title>Getting PAM items</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_item.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_get_item-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_item.3.xml" xpointer='xpointer(id("pam_get_item-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_get_item-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_item-description"]/*)'/>
+  <section xml:id="mwg-pam_get_item-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_item.3.xml" xpointer='xpointer(id("pam_get_item-description")/*)'/>
   </section>
-  <section id='mwg-pam_get_item-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_item-return_values"]/*)'/>
+  <section xml:id="mwg-pam_get_item-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_item.3.xml" xpointer='xpointer(id("pam_get_item-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_get_user.xml
+++ b/doc/mwg/pam_get_user.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_get_user'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_get_user">
   <title>Get user name</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_user.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_get_user-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_user.3.xml" xpointer='xpointer(id("pam_get_user-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_get_user-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_user.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_user-description"]/*)'/>
+  <section xml:id="mwg-pam_get_user-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_user.3.xml" xpointer='xpointer(id("pam_get_user-description")/*)'/>
   </section>
-  <section id='mwg-pam_get_user-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_get_user.3.xml" xpointer='xpointer(//refsect1[@id = "pam_get_user-return_values"]/*)'/>
+  <section xml:id="mwg-pam_get_user-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_get_user.3.xml" xpointer='xpointer(id("pam_get_user-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_getenv.xml
+++ b/doc/mwg/pam_getenv.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_getenv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_getenv">
   <title>Get a PAM environment variable</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_getenv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenv.3.xml" xpointer='xpointer(id("pam_getenv-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_getenv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenv-description"]/*)'/>
+  <section xml:id="adg-pam_getenv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenv.3.xml" xpointer='xpointer(id("pam_getenv-description")/*)'/>
   </section>
-  <section id='adg-pam_getenv-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenv-return_values"]/*)'/>
+  <section xml:id="adg-pam_getenv-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenv.3.xml" xpointer='xpointer(id("pam_getenv-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_getenvlist.xml
+++ b/doc/mwg/pam_getenvlist.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_getenvlist'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_getenvlist">
   <title>Getting the PAM environment</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenvlist.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_getenvlist-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenvlist.3.xml" xpointer='xpointer(id("pam_getenvlist-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_getenvlist-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenvlist.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenvlist-description"]/*)'/>
+  <section xml:id="adg-pam_getenvlist-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenvlist.3.xml" xpointer='xpointer(id("pam_getenvlist-description")/*)'/>
   </section>
-  <section id='adg-pam_getenvlist-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_getenvlist.3.xml" xpointer='xpointer(//refsect1[@id = "pam_getenvlist-return_values"]/*)'/>
+  <section xml:id="adg-pam_getenvlist-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_getenvlist.3.xml" xpointer='xpointer(id("pam_getenvlist-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_putenv.xml
+++ b/doc/mwg/pam_putenv.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_putenv'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_putenv">
   <title>Set or change PAM environment variable</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_putenv.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_putenv-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_putenv.3.xml" xpointer='xpointer(id("pam_putenv-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_putenv-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_putenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_putenv-description"]/*)'/>
+  <section xml:id="adg-pam_putenv-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_putenv.3.xml" xpointer='xpointer(id("pam_putenv-description")/*)'/>
   </section>
-  <section id='adg-pam_putenv-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_putenv.3.xml" xpointer='xpointer(//refsect1[@id = "pam_putenv-return_values"]/*)'/>
+  <section xml:id="adg-pam_putenv-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_putenv.3.xml" xpointer='xpointer(id("pam_putenv-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_set_data.xml
+++ b/doc/mwg/pam_set_data.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_set_data'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_set_data">
   <title>Set module internal data</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_data.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_set_data-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_data.3.xml" xpointer='xpointer(id("pam_set_data-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_set_data-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_data.3.xml" xpointer='xpointer(//refsect1[@id = "pam_set_data-description"]/*)'/>
+  <section xml:id="mwg-pam_set_data-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_data.3.xml" xpointer='xpointer(id("pam_set_data-description")/*)'/>
   </section>
-  <section id='mwg-pam_set_data-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_data.3.xml" xpointer='xpointer(//refsect1[@id = "pam_set_data-return_values"]/*)'/>
+  <section xml:id="mwg-pam_set_data-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_data.3.xml" xpointer='xpointer(id("pam_set_data-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_set_item.xml
+++ b/doc/mwg/pam_set_item.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_set_item'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_set_item">
   <title>Setting PAM items</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_item.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_set_item-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_item.3.xml" xpointer='xpointer(id("pam_set_item-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_set_item-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_set_item-description"]/*)'/>
+  <section xml:id="mwg-pam_set_item-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_item.3.xml" xpointer='xpointer(id("pam_set_item-description")/*)'/>
   </section>
-  <section id='mwg-pam_set_item-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_set_item.3.xml" xpointer='xpointer(//refsect1[@id = "pam_set_item-return_values"]/*)'/>
+  <section xml:id="mwg-pam_set_item-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_set_item.3.xml" xpointer='xpointer(id("pam_set_item-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_sm_acct_mgmt.xml
+++ b/doc/mwg/pam_sm_acct_mgmt.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_sm_acct_mgmt'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_sm_acct_mgmt">
   <title>Service function for account management</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_acct_mgmt.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_sm_acct_mgmt-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_acct_mgmt.3.xml" xpointer='xpointer(id("pam_sm_acct_mgmt-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_sm_acct_mgmt-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_acct_mgmt.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_acct_mgmt-description"]/*)'/>
+  <section xml:id="mwg-pam_sm_acct_mgmt-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_acct_mgmt.3.xml" xpointer='xpointer(id("pam_sm_acct_mgmt-description")/*)'/>
   </section>
-  <section id='mwg-pam_sm_acct_mgmt-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_acct_mgmt.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_acct_mgmt-return_values"]/*)'/>
+  <section xml:id="mwg-pam_sm_acct_mgmt-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_acct_mgmt.3.xml" xpointer='xpointer(id("pam_sm_acct_mgmt-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_sm_authenticate.xml
+++ b/doc/mwg/pam_sm_authenticate.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_sm_authenticate'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_sm_authenticate">
   <title>Service function for user authentication</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_authenticate.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_sm_authenticate-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_authenticate.3.xml" xpointer='xpointer(id("pam_sm_authenticate-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_sm_authenticate-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_authenticate.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_authenticate-description"]/*)'/>
+  <section xml:id="mwg-pam_sm_authenticate-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_authenticate.3.xml" xpointer='xpointer(id("pam_sm_authenticate-description")/*)'/>
   </section>
-  <section id='mwg-pam_sm_authenticate-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_authenticate.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_authenticate-return_values"]/*)'/>
+  <section xml:id="mwg-pam_sm_authenticate-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_authenticate.3.xml" xpointer='xpointer(id("pam_sm_authenticate-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_sm_chauthtok.xml
+++ b/doc/mwg/pam_sm_chauthtok.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_sm_chauthtok'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_sm_chauthtok">
   <title>Service function to alter authentication token</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_chauthtok.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_sm_chauthtok-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_chauthtok.3.xml" xpointer='xpointer(id("pam_sm_chauthtok-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_sm_chauthtok-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_chauthtok.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_chauthtok-description"]/*)'/>
+  <section xml:id="mwg-pam_sm_chauthtok-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_chauthtok.3.xml" xpointer='xpointer(id("pam_sm_chauthtok-description")/*)'/>
   </section>
-  <section id='mwg-pam_sm_chauthtok-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_chauthtok.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_chauthtok-return_values"]/*)'/>
+  <section xml:id="mwg-pam_sm_chauthtok-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_chauthtok.3.xml" xpointer='xpointer(id("pam_sm_chauthtok-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_sm_close_session.xml
+++ b/doc/mwg/pam_sm_close_session.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-close.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_sm_close_session'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_sm_close_session">
   <title>Service function to terminate session management</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_close_session.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_sm_close_session-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_close_session.3.xml" xpointer='xpointer(id("pam_sm_close_session-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_sm_close_session-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_close_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_close_session-description"]/*)'/>
+  <section xml:id="mwg-pam_sm_close_session-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_close_session.3.xml" xpointer='xpointer(id("pam_sm_close_session-description")/*)'/>
   </section>
-  <section id='mwg-pam_sm_close_session-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_close_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_close_session-return_values"]/*)'/>
+  <section xml:id="mwg-pam_sm_close_session-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_close_session.3.xml" xpointer='xpointer(id("pam_sm_close_session-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_sm_open_session.xml
+++ b/doc/mwg/pam_sm_open_session.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_sm_open_session'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_sm_open_session">
   <title>Service function to start session management</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_open_session.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_sm_open_session-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_open_session.3.xml" xpointer='xpointer(id("pam_sm_open_session-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_sm_open_session-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_open_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_open_session-description"]/*)'/>
+  <section xml:id="mwg-pam_sm_open_session-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_open_session.3.xml" xpointer='xpointer(id("pam_sm_open_session-description")/*)'/>
   </section>
-  <section id='mwg-pam_sm_open_session-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_open_session.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_open_session-return_values"]/*)'/>
+  <section xml:id="mwg-pam_sm_open_session-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_open_session.3.xml" xpointer='xpointer(id("pam_sm_open_session-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_sm_setcred.xml
+++ b/doc/mwg/pam_sm_setcred.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='mwg-pam_sm_setcred'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mwg-pam_sm_setcred">
   <title>Service function to alter credentials</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_setcred.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_sm_setcred-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_setcred.3.xml" xpointer='xpointer(id("pam_sm_setcred-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='mwg-pam_sm_setcred-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_setcred.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_setcred-description"]/*)'/>
+  <section xml:id="mwg-pam_sm_setcred-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_setcred.3.xml" xpointer='xpointer(id("pam_sm_setcred-description")/*)'/>
   </section>
-  <section id='mwg-pam_sm_setcred-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_sm_setcred.3.xml" xpointer='xpointer(//refsect1[@id = "pam_sm_setcred-return_values"]/*)'/>
+  <section xml:id="mwg-pam_sm_setcred-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_sm_setcred.3.xml" xpointer='xpointer(id("pam_sm_setcred-return_values")/*)'/>
   </section>
 </section>

--- a/doc/mwg/pam_strerror.xml
+++ b/doc/mwg/pam_strerror.xml
@@ -1,18 +1,12 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='adg-pam_strerror'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="adg-pam_strerror">
   <title>Strings describing PAM error codes</title>
   <funcsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_strerror.3.xml" xpointer='xpointer(//funcsynopsis[@id = "pam_strerror-synopsis"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_strerror.3.xml" xpointer='xpointer(id("pam_strerror-synopsis")/*)'/>
   </funcsynopsis>
-  <section id='adg-pam_strerror-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_strerror.3.xml" xpointer='xpointer(//refsect1[@id = "pam_strerror-description"]/*)'/>
+  <section xml:id="adg-pam_strerror-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_strerror.3.xml" xpointer='xpointer(id("pam_strerror-description")/*)'/>
   </section>
-  <section id='adg-pam_strerror-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam_strerror.3.xml" xpointer='xpointer(//refsect1[@id = "pam_strerror-return_values"]/*)'/>
+  <section xml:id="adg-pam_strerror-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam_strerror.3.xml" xpointer='xpointer(id("pam_strerror-return_values")/*)'/>
   </section>
 </section>

--- a/doc/sag/Linux-PAM_SAG.xml
+++ b/doc/sag/Linux-PAM_SAG.xml
@@ -1,36 +1,25 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-	"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<book id="sag">
-  <bookinfo>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag">
+  <info>
     <title>The Linux-PAM System Administrators' Guide</title>
     <authorgroup>
-      <author>
-        <firstname>Andrew G.</firstname>
-        <surname>Morgan</surname>
-        <email>morgan@kernel.org</email>
-      </author>
-      <author>
-        <firstname>Thorsten</firstname>
-        <surname>Kukuk</surname>
-        <email>kukuk@thkukuk.de</email>
-      </author>
+      <author><personname><firstname>Andrew G.</firstname><surname>Morgan</surname></personname><email>morgan@kernel.org</email></author>
+      <author><personname><firstname>Thorsten</firstname><surname>Kukuk</surname></personname><email>kukuk@thkukuk.de</email></author>
     </authorgroup>
     <releaseinfo>Version 1.1.2, 31. August 2010</releaseinfo>
     <abstract>
       <para>
         This manual documents what a system-administrator needs to know about
-        the <emphasis remap='B'>Linux-PAM</emphasis> library. It covers the
+        the <emphasis remap="B">Linux-PAM</emphasis> library. It covers the
         correct syntax of the PAM configuration file and discusses strategies
         for maintaining a secure system.
       </para>
     </abstract>
-  </bookinfo>
+  </info>
 
-  <chapter id='sag-introduction'>
+  <chapter xml:id="sag-introduction">
     <title>Introduction</title>
     <para>
-      <emphasis remap='B'>Linux-PAM</emphasis> (Pluggable Authentication
+      <emphasis remap="B">Linux-PAM</emphasis> (Pluggable Authentication
       Modules for Linux) is a suite of shared libraries that enable the
       local system administrator to choose how applications authenticate users.
     </para>
@@ -58,7 +47,7 @@
       on entries in the <filename>/etc/group</filename> file.
     </para>
     <para>
-      It is the purpose of the <emphasis remap='B'>Linux-PAM</emphasis>
+      It is the purpose of the <emphasis remap="B">Linux-PAM</emphasis>
       project to separate the development of privilege granting software
       from the development of secure and appropriate authentication schemes.
       This is accomplished by providing a library of functions that an
@@ -76,7 +65,7 @@
     </para>
   </chapter>
 
-  <chapter id="sag-text-conventions">
+  <chapter xml:id="sag-text-conventions">
     <title>Some comments on the text</title>
     <para>
       Before proceeding to read the rest of this document, it should be
@@ -91,7 +80,7 @@
     <para>
       As an example of the above, where it is explicit, the text assumes
       that PAM loadable object files (the
-      <emphasis remap='B'>modules</emphasis>) are to be located in
+      <emphasis remap="B">modules</emphasis>) are to be located in
       the following directory: <filename>/lib/security/</filename> or
       <filename>/lib64/security</filename> depending on the architecture.
       This is generally the location that seems to be compatible with the
@@ -103,7 +92,7 @@
     </para>
   </chapter>
 
-  <chapter id="sag-overview">
+  <chapter xml:id="sag-overview">
     <title>Overview</title>
     <para>
       For the uninitiated, we begin by considering an example.  We take an
@@ -121,16 +110,16 @@
       password and then verifying that it agrees with that located on
       the system; hence verifying that as far as the system is concerned
       the user is who they claim to be. This is the task that is delegated
-      to <emphasis remap='B'>Linux-PAM</emphasis>.
+      to <emphasis remap="B">Linux-PAM</emphasis>.
     </para>
     <para>
       From the perspective of the application programmer (in this case
       the person that wrote the <command>login</command> application),
-      <emphasis remap='B'>Linux-PAM</emphasis> takes care of this
+      <emphasis remap="B">Linux-PAM</emphasis> takes care of this
       authentication task -- verifying the identity of the user.
     </para>
     <para>
-      The flexibility of <emphasis remap='B'>Linux-PAM</emphasis> is
+      The flexibility of <emphasis remap="B">Linux-PAM</emphasis> is
       that <emphasis>you</emphasis>, the system administrator, have
       the freedom to stipulate which authentication scheme is to be
       used. You have the freedom to set the scheme for any/all
@@ -152,7 +141,7 @@
       authentication can be upgraded to include (long) division!
     </para>
     <para>
-      <emphasis remap='B'>Linux-PAM</emphasis> deals with four
+      <emphasis remap="B">Linux-PAM</emphasis> deals with four
       separate types of (management) task. These are:
       <emphasis>authentication management</emphasis>;
       <emphasis>account management</emphasis>;
@@ -160,15 +149,15 @@
       <emphasis>password management</emphasis>.
       The association of the preferred management scheme with the behavior
       of an application is made with entries in the relevant
-      <emphasis remap='B'>Linux-PAM</emphasis> configuration file.
+      <emphasis remap="B">Linux-PAM</emphasis> configuration file.
       The management functions are performed by <emphasis>modules</emphasis>
       specified in the configuration file. The syntax for this
       file is discussed in the section
-      <link  linkend="sag-configuration">below</link>.
+      <link linkend="sag-configuration">below</link>.
     </para>
     <para>
       Here is a figure that describes the overall organization of
-      <emphasis remap='B'>Linux-PAM</emphasis>:
+      <emphasis remap="B">Linux-PAM</emphasis>:
       <programlisting>
   +----------------+
   | application: X |
@@ -193,14 +182,14 @@
       </programlisting>
       By way of explanation, the left of the figure represents the
       application; application X.  Such an application interfaces with the
-      <emphasis remap='B'>Linux-PAM</emphasis> library and knows none of
+      <emphasis remap="B">Linux-PAM</emphasis> library and knows none of
       the specifics of its configured authentication method. The
-      <emphasis remap='B'>Linux-PAM</emphasis> library (in the center)
+      <emphasis remap="B">Linux-PAM</emphasis> library (in the center)
       consults the contents of the PAM configuration file and loads the
       modules that are appropriate for application-X. These modules fall
       into one of four management groups (lower-center) and are stacked in
       the order they appear in the configuration file. These modules, when
-      called by <emphasis remap='B'>Linux-PAM</emphasis>, perform the
+      called by <emphasis remap="B">Linux-PAM</emphasis>, perform the
       various authentication tasks for the application. Textual information,
       required from/or offered to the user, can be exchanged through the
       use of the application-supplied <emphasis>conversation</emphasis>
@@ -216,34 +205,28 @@
     </para>
   </chapter>
 
-  <chapter id="sag-configuration">
+  <chapter xml:id="sag-configuration">
     <title>The Linux-PAM configuration file</title>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../man/pam.conf-desc.xml"
-     xpointer='xpointer(//section[@id = "pam.conf-desc"]/*)' />
-     <section id='sag-configuration-file'>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam.conf-desc.xml" xpointer='xpointer(id("pam.conf-desc")/*)'/>
+     <section xml:id="sag-configuration-file">
        <title>Configuration file syntax</title>
-       <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-        href="../man/pam.conf-syntax.xml"
-        xpointer='xpointer(//section[@id = "pam.conf-syntax"]/*)' />
+       <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam.conf-syntax.xml" xpointer='xpointer(id("pam.conf-syntax")/*)'/>
      </section>
-     <section id='sag-configuration-directory'>
+     <section xml:id="sag-configuration-directory">
        <title>Directory based configuration</title>
-       <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-        href="../man/pam.conf-dir.xml"
-        xpointer='xpointer(//section[@id = "pam.conf-dir"]/*)' />
+       <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../man/pam.conf-dir.xml" xpointer='xpointer(id("pam.conf-dir")/*)'/>
      </section>
-     <section id='sag-configuration-example'>
+     <section xml:id="sag-configuration-example">
        <title>Example configuration file entries</title>
        <para>
          In this section, we give some examples of entries that can
-         be present in the <emphasis remap='B'>Linux-PAM</emphasis>
+         be present in the <emphasis remap="B">Linux-PAM</emphasis>
          configuration file. As a first attempt at configuring your
          system you could do worse than to implement these.
        </para>
        <para>
          If a system is to be considered secure, it had better have a
-         reasonably secure '<emphasis remap='B'>other</emphasis> entry.
+         reasonably secure '<emphasis remap="B">other</emphasis> entry.
          The following is a paranoid setting (which is not a bad place
          to start!):
        </para>
@@ -311,7 +294,7 @@ session  required       pam_deny.so
        <para>
          On a less sensitive computer, one on which the system
          administrator wishes to remain ignorant of much of the
-         power of <emphasis remap='B'>Linux-PAM</emphasis>, the
+         power of <emphasis remap="B">Linux-PAM</emphasis>, the
          following selection of lines (in
          <filename>/etc/pam.d/other</filename>) is likely to
          mimic the historically familiar Linux setup.
@@ -331,21 +314,21 @@ session  required       pam_unix.so
      </section>
   </chapter>
 
-  <chapter id='sag-security-issues'>
+  <chapter xml:id="sag-security-issues">
     <title>Security issues</title>
-    <section id='sag-security-issues-wrong'>
+    <section xml:id="sag-security-issues-wrong">
       <title>If something goes wrong</title>
       <para>
-        <emphasis remap='B'>Linux-PAM</emphasis> has the potential
+        <emphasis remap="B">Linux-PAM</emphasis> has the potential
         to seriously change the security of your system. You can
         choose to have no security or absolute security (no access
-        permitted). In general, <emphasis remap='B'>Linux-PAM</emphasis>
+        permitted). In general, <emphasis remap="B">Linux-PAM</emphasis>
         errs towards the latter. Any number of configuration errors
         can disable access to your system partially, or completely.
       </para>
       <para>
         The most dramatic problem that is likely to be encountered when
-        configuring <emphasis remap='B'>Linux-PAM</emphasis> is that of
+        configuring <emphasis remap="B">Linux-PAM</emphasis> is that of
         <emphasis>deleting</emphasis> the configuration file(s):
         <filename>/etc/pam.d/*</filename> and/or
         <filename>/etc/pam.conf</filename>. This will lock you out of
@@ -357,11 +340,11 @@ session  required       pam_unix.so
         things from there.
       </para>
     </section>
-    <section id='sag-security-issues-other'>
+    <section xml:id="sag-security-issues-other">
       <title>Avoid having a weak `other' configuration</title>
       <para>
         It is not a good thing to have a weak default
-        (<emphasis remap='B'>other</emphasis>) entry.
+        (<emphasis remap="B">other</emphasis>) entry.
         This service is the default configuration for all PAM aware
         applications and if it is weak, your system is likely to be
         vulnerable to attack.
@@ -388,93 +371,57 @@ session   required   pam_warn.so
     </section>
   </chapter>
 
-  <chapter id='sag-module-reference'>
+  <chapter xml:id="sag-module-reference">
     <title>A reference guide for available modules</title>
     <para>
       Here, we collect together the descriptions of the various modules
       coming with Linux-PAM.
     </para>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_access.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_debug.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_deny.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_echo.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_env.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_exec.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_faildelay.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_faillock.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_filter.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_ftp.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_group.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_issue.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_keyinit.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_lastlog.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_limits.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_listfile.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_localuser.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_loginuid.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_mail.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_mkhomedir.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_motd.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_namespace.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_nologin.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_permit.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_pwhistory.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_rhosts.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_rootok.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_securetty.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_selinux.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_shells.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_succeed_if.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_time.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_timestamp.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_umask.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_unix.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_userdb.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_warn.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_wheel.xml"/>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="pam_xauth.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_access.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_deny.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_echo.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_env.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_exec.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faildelay.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_filter.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_ftp.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_group.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_issue.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_keyinit.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_lastlog.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_limits.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_listfile.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_localuser.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_loginuid.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mail.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mkhomedir.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_motd.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_namespace.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_permit.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_pwhistory.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rhosts.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rootok.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_securetty.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_selinux.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sepermit.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setquota.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_shells.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_succeed_if.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_time.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_umask.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_unix.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_userdb.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_warn.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_wheel.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.xml"/>
   </chapter>
 
-  <chapter id="sag-see-also">
+  <chapter xml:id="sag-see-also">
     <title>See also</title>
     <itemizedlist>
       <listitem>
@@ -497,7 +444,7 @@ session   required   pam_warn.so
     </itemizedlist>
   </chapter>
 
-  <chapter id='sag-author'>
+  <chapter xml:id="sag-author">
     <title>Author/acknowledgments</title>
     <para>
       This document was written by Andrew G. Morgan (morgan@kernel.org)
@@ -518,14 +465,14 @@ session   required   pam_warn.so
     <para>
       Thanks are also due to Sun Microsystems, especially to Vipin Samar and
       Charlie Lai for their advice. At an early stage in the development of
-      <emphasis remap='B'>Linux-PAM</emphasis>, Sun graciously made the
+      <emphasis remap="B">Linux-PAM</emphasis>, Sun graciously made the
       documentation for their implementation of PAM available. This act
       greatly accelerated the development of
-      <emphasis remap='B'>Linux-PAM</emphasis>.
+      <emphasis remap="B">Linux-PAM</emphasis>.
     </para>
   </chapter>
 
-  <chapter id='sag-copyright'>
+  <chapter xml:id="sag-copyright">
     <title>Copyright information for this document</title>
     <programlisting>
 Copyright (c) 2006 Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;

--- a/doc/sag/Makefile.am
+++ b/doc/sag/Makefile.am
@@ -7,7 +7,6 @@ CLEANFILES = Linux-PAM_SAG.fo *~
 EXTRA_DIST = $(XMLS)
 
 XMLS = Linux-PAM_SAG.xml $(shell ls $(srcdir)/pam_*.xml)
-
 DEP_XMLS = $(shell ls $(top_srcdir)/modules/pam_*/pam_*.xml)
 
 if ENABLE_REGENERATE_MAN
@@ -17,7 +16,7 @@ all: Linux-PAM_SAG.txt html/Linux-PAM_SAG.html Linux-PAM_SAG.pdf
 
 Linux-PAM_SAG.pdf: $(XMLS) $(DEP_XMLS)
 if ENABLE_GENERATE_PDF
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam generate.toc "book toc" \
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
@@ -29,7 +28,7 @@ else
 endif
 
 Linux-PAM_SAG.txt: $(XMLS) $(DEP_XMLS)
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam generate.toc "book toc" \
 	  --stringparam section.autolabel 1 \
 	  --stringparam section.label.includes.component.label 1 \
@@ -38,7 +37,7 @@ Linux-PAM_SAG.txt: $(XMLS) $(DEP_XMLS)
 
 html/Linux-PAM_SAG.html: $(XMLS) $(DEP_XMLS)
 	@test -d html || mkdir -p html
-	$(XMLLINT) --nonet --xinclude --postvalid --noent --noout $<
+	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noent --noout $<
 	$(XSLTPROC) --stringparam base.dir html/ \
 	  --stringparam root.filename Linux-PAM_SAG \
 	  --stringparam use.id.as.filename 1 \

--- a/doc/sag/pam_access.xml
+++ b/doc/sag/pam_access.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_access'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_access">
   <title>pam_access - logdaemon style login access control</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_access-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_access-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-description"]/*)'/>
+  <section xml:id="sag-pam_access-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-description")/*)'/>
   </section>
-  <section id='sag-access.conf-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/access.conf.5.xml" xpointer='xpointer(//refsect1[@id = "access.conf-description"]/*)'/>
+  <section xml:id="sag-access.conf-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/access.conf.5.xml" xpointer='xpointer(id("access.conf-description")/*)'/>
   </section>
-  <section id='sag-pam_access-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-options"]/*)'/>
+  <section xml:id="sag-pam_access-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-options")/*)'/>
   </section>
-  <section id='sag-pam_access-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-types"]/*)'/>
+  <section xml:id="sag-pam_access-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-types")/*)'/>
   </section>
-  <section id='sag-pam_access-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-return_values"]/*)'/>
+  <section xml:id="sag-pam_access-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-return_values")/*)'/>
   </section>
-  <section id='sag-pam_access-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-files"]/*)'/>
+  <section xml:id="sag-pam_access-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-files")/*)'/>
   </section>
-  <section id='sag-access.conf-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/access.conf.5.xml" xpointer='xpointer(//refsect1[@id = "access.conf-examples"]/*)'/>
+  <section xml:id="sag-access.conf-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/access.conf.5.xml" xpointer='xpointer(id("access.conf-examples")/*)'/>
   </section>
-  <section id='sag-pam_access-authors'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-authors"]/*)'/>
+  <section xml:id="sag-pam_access-authors">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_access/pam_access.8.xml" xpointer='xpointer(id("pam_access-authors")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_debug.xml
+++ b/doc/sag/pam_debug.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_debug'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_debug">
   <title>pam_debug - debug the PAM stack</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_debug-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_debug-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-description"]/*)'/>
+  <section xml:id="sag-pam_debug-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-description")/*)'/>
   </section>
-  <section id='sag-pam_debug-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-options"]/*)'/>
+  <section xml:id="sag-pam_debug-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-options")/*)'/>
   </section>
-  <section id='sag-pam_debug-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-types"]/*)'/>
+  <section xml:id="sag-pam_debug-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-types")/*)'/>
   </section>
-  <section id='sag-pam_debug-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-return_values"]/*)'/>
+  <section xml:id="sag-pam_debug-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-return_values")/*)'/>
   </section>
-  <section id='sag-pam_debug-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-examples"]/*)'/>
+  <section xml:id="sag-pam_debug-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-examples")/*)'/>
   </section>
-  <section id='sag-pam_debug-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-author"]/*)'/>
+  <section xml:id="sag-pam_debug-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_debug/pam_debug.8.xml" xpointer='xpointer(id("pam_debug-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_deny.xml
+++ b/doc/sag/pam_deny.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_deny'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_deny">
   <title>pam_deny - locking-out PAM module</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_deny-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_deny-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-description"]/*)'/>
+  <section xml:id="sag-pam_deny-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-description")/*)'/>
   </section>
-  <section id='sag-pam_deny-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-options"]/*)'/>
+  <section xml:id="sag-pam_deny-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-options")/*)'/>
   </section>
-  <section id='sag-pam_deny-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-types"]/*)'/>
+  <section xml:id="sag-pam_deny-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-types")/*)'/>
   </section>
-  <section id='sag-pam_deny-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-return_values"]/*)'/>
+  <section xml:id="sag-pam_deny-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-return_values")/*)'/>
   </section>
-  <section id='sag-pam_deny-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-examples"]/*)'/>
+  <section xml:id="sag-pam_deny-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-examples")/*)'/>
   </section>
-  <section id='sag-pam_deny-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-author"]/*)'/>
+  <section xml:id="sag-pam_deny-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_deny/pam_deny.8.xml" xpointer='xpointer(id("pam_deny-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_echo.xml
+++ b/doc/sag/pam_echo.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_echo'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_echo">
   <title>pam_echo - print text messages</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_echo-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_echo-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-description"]/*)'/>
+  <section xml:id="sag-pam_echo-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-description")/*)'/>
   </section>
-  <section id='sag-pam_echo-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-options"]/*)'/>
+  <section xml:id="sag-pam_echo-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-options")/*)'/>
   </section>
-  <section id='sag-pam_echo-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-types"]/*)'/>
+  <section xml:id="sag-pam_echo-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-types")/*)'/>
   </section>
-  <section id='sag-pam_echo-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-return_values"]/*)'/>
+  <section xml:id="sag-pam_echo-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-return_values")/*)'/>
   </section>
-  <section id='sag-pam_echo-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-examples"]/*)'/>
+  <section xml:id="sag-pam_echo-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-examples")/*)'/>
   </section>
-  <section id='sag-pam_echo-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-author"]/*)'/>
+  <section xml:id="sag-pam_echo-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_echo/pam_echo.8.xml" xpointer='xpointer(id("pam_echo-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_env.xml
+++ b/doc/sag/pam_env.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_env'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_env">
   <title>pam_env - set/unset environment variables</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_env-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_env-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-description"]/*)'/>
+  <section xml:id="sag-pam_env-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-description")/*)'/>
   </section>
-  <section id='sag-pam_env.conf-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.conf.5.xml" xpointer='xpointer(//refsect1[@id = "pam_env.conf-description"]/*)'/>
+  <section xml:id="sag-pam_env.conf-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.conf.5.xml" xpointer='xpointer(id("pam_env.conf-description")/*)'/>
   </section>
-  <section id='sag-pam_env-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-options"]/*)'/>
+  <section xml:id="sag-pam_env-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-options")/*)'/>
   </section>
-  <section id='sag-pam_env-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-types"]/*)'/>
+  <section xml:id="sag-pam_env-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-types")/*)'/>
   </section>
-  <section id='sag-pam_env-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-return_values"]/*)'/>
+  <section xml:id="sag-pam_env-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-return_values")/*)'/>
   </section>
-  <section id='sag-pam_env-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-files"]/*)'/>
+  <section xml:id="sag-pam_env-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-files")/*)'/>
   </section>
-  <section id='sag-pam_env.conf-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.conf.5.xml" xpointer='xpointer(//refsect1[@id = "pam_env.conf-examples"]/*)'/>
+  <section xml:id="sag-pam_env.conf-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.conf.5.xml" xpointer='xpointer(id("pam_env.conf-examples")/*)'/>
   </section>
-  <section id='sag-pam_env-authors'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-authors"]/*)'/>
+  <section xml:id="sag-pam_env-authors">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_env/pam_env.8.xml" xpointer='xpointer(id("pam_env-authors")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_exec.xml
+++ b/doc/sag/pam_exec.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_exec'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_exec">
   <title>pam_exec - call an external command</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_exec-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_exec-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-description"]/*)'/>
+  <section xml:id="sag-pam_exec-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-description")/*)'/>
   </section>
-  <section id='sag-pam_exec-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-options"]/*)'/>
+  <section xml:id="sag-pam_exec-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-options")/*)'/>
   </section>
-  <section id='sag-pam_exec-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-types"]/*)'/>
+  <section xml:id="sag-pam_exec-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-types")/*)'/>
   </section>
-  <section id='sag-pam_exec-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-return_values"]/*)'/>
+  <section xml:id="sag-pam_exec-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-return_values")/*)'/>
   </section>
-  <section id='sag-pam_exec-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-examples"]/*)'/>
+  <section xml:id="sag-pam_exec-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-examples")/*)'/>
   </section>
-  <section id='sag-pam_exec-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-author"]/*)'/>
+  <section xml:id="sag-pam_exec-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_exec/pam_exec.8.xml" xpointer='xpointer(id("pam_exec-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_faildelay.xml
+++ b/doc/sag/pam_faildelay.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_faildelay'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_faildelay">
   <title>pam_faildelay - change the delay on failure per-application</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_faildelay-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_faildelay-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-description"]/*)'/>
+  <section xml:id="sag-pam_faildelay-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-description")/*)'/>
   </section>
-  <section id='sag-pam_faildelay-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-options"]/*)'/>
+  <section xml:id="sag-pam_faildelay-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-options")/*)'/>
   </section>
-  <section id='sag-pam_faildelay-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-types"]/*)'/>
+  <section xml:id="sag-pam_faildelay-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-types")/*)'/>
   </section>
-  <section id='sag-pam_faildelay-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-return_values"]/*)'/>
+  <section xml:id="sag-pam_faildelay-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-return_values")/*)'/>
   </section>
-  <section id='sag-pam_faildelay-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-examples"]/*)'/>
+  <section xml:id="sag-pam_faildelay-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-examples")/*)'/>
   </section>
-  <section id='sag-pam_faildelay-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-author"]/*)'/>
+  <section xml:id="sag-pam_faildelay-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faildelay/pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_faillock.xml
+++ b/doc/sag/pam_faillock.xml
@@ -1,38 +1,27 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_faillock'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_faillock">
   <title>pam_faillock - temporarily locking access based on failed authentication attempts during an interval</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_faillock-cmdsynopsisauth"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-cmdsynopsisauth")/*)'/>
   </cmdsynopsis>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_faillock-cmdsynopsisacct"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-cmdsynopsisacct")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_faillock-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-description"]/*)'/>
+  <section xml:id="sag-pam_faillock-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-description")/*)'/>
   </section>
-  <section id='sag-pam_faillock-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-options"]/*)'/>
+  <section xml:id="sag-pam_faillock-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-options")/*)'/>
   </section>
-  <section id='sag-pam_faillock-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-types"]/*)'/>
+  <section xml:id="sag-pam_faillock-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-types")/*)'/>
   </section>
-  <section id='sag-pam_faillock-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-return_values"]/*)'/>
+  <section xml:id="sag-pam_faillock-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-return_values")/*)'/>
   </section>
-  <section id='sag-pam_faillock-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-examples"]/*)'/>
+  <section xml:id="sag-pam_faillock-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-examples")/*)'/>
   </section>
-  <section id='sag-pam_faillock-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-author"]/*)'/>
+  <section xml:id="sag-pam_faillock-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_faillock/pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_filter.xml
+++ b/doc/sag/pam_filter.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_filter'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_filter">
   <title>pam_filter - filter module</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_filter-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_filter-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-description"]/*)'/>
+  <section xml:id="sag-pam_filter-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-description")/*)'/>
   </section>
-  <section id='sag-pam_filter-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-options"]/*)'/>
+  <section xml:id="sag-pam_filter-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-options")/*)'/>
   </section>
-  <section id='sag-pam_filter-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-types"]/*)'/>
+  <section xml:id="sag-pam_filter-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-types")/*)'/>
   </section>
-  <section id='sag-pam_filter-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-return_values"]/*)'/>
+  <section xml:id="sag-pam_filter-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-return_values")/*)'/>
   </section>
-  <section id='sag-pam_filter-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-examples"]/*)'/>
+  <section xml:id="sag-pam_filter-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-examples")/*)'/>
   </section>
-  <section id='sag-pam_filter-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-author"]/*)'/>
+  <section xml:id="sag-pam_filter-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_filter/pam_filter.8.xml" xpointer='xpointer(id("pam_filter-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_ftp.xml
+++ b/doc/sag/pam_ftp.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_ftp'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_ftp">
   <title>pam_ftp - module for anonymous access</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_ftp-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_ftp-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-description"]/*)'/>
+  <section xml:id="sag-pam_ftp-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-description")/*)'/>
   </section>
-  <section id='sag-pam_ftp-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-options"]/*)'/>
+  <section xml:id="sag-pam_ftp-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-options")/*)'/>
   </section>
-  <section id='sag-pam_ftp-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-types"]/*)'/>
+  <section xml:id="sag-pam_ftp-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-types")/*)'/>
   </section>
-  <section id='sag-pam_ftp-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-return_values"]/*)'/>
+  <section xml:id="sag-pam_ftp-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-return_values")/*)'/>
   </section>
-  <section id='sag-pam_ftp-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-examples"]/*)'/>
+  <section xml:id="sag-pam_ftp-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-examples")/*)'/>
   </section>
-  <section id='sag-pam_ftp-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-author"]/*)'/>
+  <section xml:id="sag-pam_ftp-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_ftp/pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_group.xml
+++ b/doc/sag/pam_group.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_group'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_group">
   <title>pam_group - module to modify group access</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_group-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_group-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-description"]/*)'/>
+  <section xml:id="sag-pam_group-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-description")/*)'/>
   </section>
-  <section id='sag-group.conf-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/group.conf.5.xml" xpointer='xpointer(//refsect1[@id = "group.conf-description"]/*)'/>
+  <section xml:id="sag-group.conf-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/group.conf.5.xml" xpointer='xpointer(id("group.conf-description")/*)'/>
   </section>
-  <section id='sag-pam_group-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-options"]/*)'/>
+  <section xml:id="sag-pam_group-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-options")/*)'/>
   </section>
-  <section id='sag-pam_group-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-types"]/*)'/>
+  <section xml:id="sag-pam_group-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-types")/*)'/>
   </section>
-  <section id='sag-pam_group-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-return_values"]/*)'/>
+  <section xml:id="sag-pam_group-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-return_values")/*)'/>
   </section>
-  <section id='sag-pam_group-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-files"]/*)'/>
+  <section xml:id="sag-pam_group-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-files")/*)'/>
   </section>
-  <section id='sag-group.conf-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/group.conf.5.xml" xpointer='xpointer(//refsect1[@id = "group.conf-examples"]/*)'/>
+  <section xml:id="sag-group.conf-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/group.conf.5.xml" xpointer='xpointer(id("group.conf-examples")/*)'/>
   </section>
-  <section id='sag-pam_group-authors'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-authors"]/*)'/>
+  <section xml:id="sag-pam_group-authors">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_group/pam_group.8.xml" xpointer='xpointer(id("pam_group-authors")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_issue.xml
+++ b/doc/sag/pam_issue.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_issue'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_issue">
   <title>pam_issue - add issue file to user prompt</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_issue-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_issue-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-description"]/*)'/>
+  <section xml:id="sag-pam_issue-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-description")/*)'/>
   </section>
-  <section id='sag-pam_issue-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-options"]/*)'/>
+  <section xml:id="sag-pam_issue-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-options")/*)'/>
   </section>
-  <section id='sag-pam_issue-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-types"]/*)'/>
+  <section xml:id="sag-pam_issue-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-types")/*)'/>
   </section>
-  <section id='sag-pam_issue-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-return_values"]/*)'/>
+  <section xml:id="sag-pam_issue-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-return_values")/*)'/>
   </section>
-  <section id='sag-pam_issue-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-examples"]/*)'/>
+  <section xml:id="sag-pam_issue-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-examples")/*)'/>
   </section>
-  <section id='sag-pam_issue-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-author"]/*)'/>
+  <section xml:id="sag-pam_issue-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_issue/pam_issue.8.xml" xpointer='xpointer(id("pam_issue-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_keyinit.xml
+++ b/doc/sag/pam_keyinit.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_keyinit'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_keyinit">
   <title>pam_keyinit - display the keyinit file</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_keyinit-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_keyinit-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-description"]/*)'/>
+  <section xml:id="sag-pam_keyinit-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-description")/*)'/>
   </section>
-  <section id='sag-pam_keyinit-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-options"]/*)'/>
+  <section xml:id="sag-pam_keyinit-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-options")/*)'/>
   </section>
-  <section id='sag-pam_keyinit-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-types"]/*)'/>
+  <section xml:id="sag-pam_keyinit-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-types")/*)'/>
   </section>
-  <section id='sag-pam_keyinit-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-return_values"]/*)'/>
+  <section xml:id="sag-pam_keyinit-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-return_values")/*)'/>
   </section>
-  <section id='sag-pam_keyinit-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-examples"]/*)'/>
+  <section xml:id="sag-pam_keyinit-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-examples")/*)'/>
   </section>
-  <section id='sag-pam_keyinit-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-author"]/*)'/>
+  <section xml:id="sag-pam_keyinit-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_keyinit/pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_lastlog.xml
+++ b/doc/sag/pam_lastlog.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_lastlog'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_lastlog">
   <title>pam_lastlog - display date of last login</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_lastlog-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_lastlog-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-description"]/*)'/>
+  <section xml:id="sag-pam_lastlog-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-description")/*)'/>
   </section>
-  <section id='sag-pam_lastlog-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-options"]/*)'/>
+  <section xml:id="sag-pam_lastlog-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-options")/*)'/>
   </section>
-  <section id='sag-pam_lastlog-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-types"]/*)'/>
+  <section xml:id="sag-pam_lastlog-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-types")/*)'/>
   </section>
-  <section id='sag-pam_lastlog-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-return_values"]/*)'/>
+  <section xml:id="sag-pam_lastlog-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-return_values")/*)'/>
   </section>
-  <section id='sag-pam_lastlog-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-examples"]/*)'/>
+  <section xml:id="sag-pam_lastlog-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-examples")/*)'/>
   </section>
-  <section id='sag-pam_lastlog-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-author"]/*)'/>
+  <section xml:id="sag-pam_lastlog-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_lastlog/pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_limits.xml
+++ b/doc/sag/pam_limits.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_limits'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_limits">
   <title>pam_limits - limit resources</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_limits-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_limits-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-description"]/*)'/>
+  <section xml:id="sag-pam_limits-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-description")/*)'/>
   </section>
-  <section id='sag-limits.conf-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/limits.conf.5.xml" xpointer='xpointer(//refsect1[@id = "limits.conf-description"]/*)'/>
+  <section xml:id="sag-limits.conf-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/limits.conf.5.xml" xpointer='xpointer(id("limits.conf-description")/*)'/>
   </section>
-  <section id='sag-pam_limits-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-options"]/*)'/>
+  <section xml:id="sag-pam_limits-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-options")/*)'/>
   </section>
-  <section id='sag-pam_limits-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-types"]/*)'/>
+  <section xml:id="sag-pam_limits-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-types")/*)'/>
   </section>
-  <section id='sag-pam_limits-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-return_values"]/*)'/>
+  <section xml:id="sag-pam_limits-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-return_values")/*)'/>
   </section>
-  <section id='sag-pam_limits-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-files"]/*)'/>
+  <section xml:id="sag-pam_limits-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-files")/*)'/>
   </section>
-  <section id='sag-limits.conf-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/limits.conf.5.xml" xpointer='xpointer(//refsect1[@id = "limits.conf-examples"]/*)'/>
+  <section xml:id="sag-limits.conf-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/limits.conf.5.xml" xpointer='xpointer(id("limits.conf-examples")/*)'/>
   </section>
-  <section id='sag-pam_limits-authors'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-authors"]/*)'/>
+  <section xml:id="sag-pam_limits-authors">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_limits/pam_limits.8.xml" xpointer='xpointer(id("pam_limits-authors")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_listfile.xml
+++ b/doc/sag/pam_listfile.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_listfile'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_listfile">
   <title>pam_listfile - deny or allow services based on an arbitrary file</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_listfile-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_listfile-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-description"]/*)'/>
+  <section xml:id="sag-pam_listfile-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-description")/*)'/>
   </section>
-  <section id='sag-pam_listfile-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-options"]/*)'/>
+  <section xml:id="sag-pam_listfile-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-options")/*)'/>
   </section>
-  <section id='sag-pam_listfile-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-types"]/*)'/>
+  <section xml:id="sag-pam_listfile-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-types")/*)'/>
   </section>
-  <section id='sag-pam_listfile-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-return_values"]/*)'/>
+  <section xml:id="sag-pam_listfile-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-return_values")/*)'/>
   </section>
-  <section id='sag-pam_listfile-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-examples"]/*)'/>
+  <section xml:id="sag-pam_listfile-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-examples")/*)'/>
   </section>
-  <section id='sag-pam_listfile-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-author"]/*)'/>
+  <section xml:id="sag-pam_listfile-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_listfile/pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_localuser.xml
+++ b/doc/sag/pam_localuser.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_localuser'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_localuser">
   <title>pam_localuser - require users to be listed in /etc/passwd</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_localuser-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_localuser-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-description"]/*)'/>
+  <section xml:id="sag-pam_localuser-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-description")/*)'/>
   </section>
-  <section id='sag-pam_localuser-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-options"]/*)'/>
+  <section xml:id="sag-pam_localuser-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-options")/*)'/>
   </section>
-  <section id='sag-pam_localuser-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-types"]/*)'/>
+  <section xml:id="sag-pam_localuser-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-types")/*)'/>
   </section>
-  <section id='sag-pam_localuser-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-return_values"]/*)'/>
+  <section xml:id="sag-pam_localuser-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-return_values")/*)'/>
   </section>
-  <section id='sag-pam_localuser-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-examples"]/*)'/>
+  <section xml:id="sag-pam_localuser-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-examples")/*)'/>
   </section>
-  <section id='sag-pam_localuser-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-author"]/*)'/>
+  <section xml:id="sag-pam_localuser-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_localuser/pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_loginuid.xml
+++ b/doc/sag/pam_loginuid.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_loginuid'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_loginuid">
   <title>pam_loginuid - record user's login uid to the process attribute</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_loginuid-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_loginuid-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-description"]/*)'/>
+  <section xml:id="sag-pam_loginuid-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-description")/*)'/>
   </section>
-  <section id='sag-pam_loginuid-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-options"]/*)'/>
+  <section xml:id="sag-pam_loginuid-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-options")/*)'/>
   </section>
-  <section id='sag-pam_loginuid-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-types"]/*)'/>
+  <section xml:id="sag-pam_loginuid-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-types")/*)'/>
   </section>
-  <section id='sag-pam_loginuid-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-return_values"]/*)'/>
+  <section xml:id="sag-pam_loginuid-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-return_values")/*)'/>
   </section>
-  <section id='sag-pam_loginuid-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-examples"]/*)'/>
+  <section xml:id="sag-pam_loginuid-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-examples")/*)'/>
   </section>
-  <section id='sag-pam_loginuid-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-author"]/*)'/>
+  <section xml:id="sag-pam_loginuid-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_loginuid/pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_mail.xml
+++ b/doc/sag/pam_mail.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_mail'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_mail">
   <title>pam_mail - inform about available mail</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_mail-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_mail-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-description"]/*)'/>
+  <section xml:id="sag-pam_mail-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-description")/*)'/>
   </section>
-  <section id='sag-pam_mail-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-options"]/*)'/>
+  <section xml:id="sag-pam_mail-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-options")/*)'/>
   </section>
-  <section id='sag-pam_mail-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-types"]/*)'/>
+  <section xml:id="sag-pam_mail-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-types")/*)'/>
   </section>
-  <section id='sag-pam_mail-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-return_values"]/*)'/>
+  <section xml:id="sag-pam_mail-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-return_values")/*)'/>
   </section>
-  <section id='sag-pam_mail-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-examples"]/*)'/>
+  <section xml:id="sag-pam_mail-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-examples")/*)'/>
   </section>
-  <section id='sag-pam_mail-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-author"]/*)'/>
+  <section xml:id="sag-pam_mail-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mail/pam_mail.8.xml" xpointer='xpointer(id("pam_mail-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_mkhomedir.xml
+++ b/doc/sag/pam_mkhomedir.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_mkhomedir'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_mkhomedir">
   <title>pam_mkhomedir - create users home directory</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_mkhomedir-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_mkhomedir-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-description"]/*)'/>
+  <section xml:id="sag-pam_mkhomedir-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-description")/*)'/>
   </section>
-  <section id='sag-pam_mkhomedir-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-options"]/*)'/>
+  <section xml:id="sag-pam_mkhomedir-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-options")/*)'/>
   </section>
-  <section id='sag-pam_mkhomedir-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-types"]/*)'/>
+  <section xml:id="sag-pam_mkhomedir-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-types")/*)'/>
   </section>
-  <section id='sag-pam_mkhomedir-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-return_values"]/*)'/>
+  <section xml:id="sag-pam_mkhomedir-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-return_values")/*)'/>
   </section>
-  <section id='sag-pam_mkhomedir-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-examples"]/*)'/>
+  <section xml:id="sag-pam_mkhomedir-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-examples")/*)'/>
   </section>
-  <section id='sag-pam_mkhomedir-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-author"]/*)'/>
+  <section xml:id="sag-pam_mkhomedir-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_mkhomedir/pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_motd.xml
+++ b/doc/sag/pam_motd.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_motd'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_motd">
   <title>pam_motd - display the motd file</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_motd-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_motd-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-description"]/*)'/>
+  <section xml:id="sag-pam_motd-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-description")/*)'/>
   </section>
-  <section id='sag-pam_motd-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-options"]/*)'/>
+  <section xml:id="sag-pam_motd-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-options")/*)'/>
   </section>
-  <section id='sag-pam_motd-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-types"]/*)'/>
+  <section xml:id="sag-pam_motd-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-types")/*)'/>
   </section>
-  <section id='sag-pam_motd-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-return_values"]/*)'/>
+  <section xml:id="sag-pam_motd-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-return_values")/*)'/>
   </section>
-  <section id='sag-pam_motd-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-examples"]/*)'/>
+  <section xml:id="sag-pam_motd-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-examples")/*)'/>
   </section>
-  <section id='sag-pam_motd-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-author"]/*)'/>
+  <section xml:id="sag-pam_motd-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_motd/pam_motd.8.xml" xpointer='xpointer(id("pam_motd-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_namespace.xml
+++ b/doc/sag/pam_namespace.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_namespace'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_namespace">
   <title>pam_namespace - setup a private namespace</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_namespace-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_namespace-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-description"]/*)'/>
+  <section xml:id="sag-pam_namespace-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-description")/*)'/>
   </section>
-  <section id='sag-namespace.conf-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/namespace.conf.5.xml" xpointer='xpointer(//refsect1[@id = "namespace.conf-description"]/*)'/>
+  <section xml:id="sag-namespace.conf-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/namespace.conf.5.xml" xpointer='xpointer(id("namespace.conf-description")/*)'/>
   </section>
-  <section id='sag-pam_namespace-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-options"]/*)'/>
+  <section xml:id="sag-pam_namespace-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-options")/*)'/>
   </section>
-  <section id='sag-pam_namespace-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-types"]/*)'/>
+  <section xml:id="sag-pam_namespace-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-types")/*)'/>
   </section>
-  <section id='sag-pam_namespace-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-return_values"]/*)'/>
+  <section xml:id="sag-pam_namespace-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-return_values")/*)'/>
   </section>
-  <section id='sag-pam_namespace-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-files"]/*)'/>
+  <section xml:id="sag-pam_namespace-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-files")/*)'/>
   </section>
-  <section id='sag-namespace.conf-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/namespace.conf.5.xml" xpointer='xpointer(//refsect1[@id = "namespace.conf-examples"]/*)'/>
+  <section xml:id="sag-namespace.conf-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/namespace.conf.5.xml" xpointer='xpointer(id("namespace.conf-examples")/*)'/>
   </section>
-  <section id='sag-pam_namespace-authors'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-authors"]/*)'/>
+  <section xml:id="sag-pam_namespace-authors">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_namespace/pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-authors")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_nologin.xml
+++ b/doc/sag/pam_nologin.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_nologin'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_nologin">
   <title>pam_nologin - prevent non-root users from login</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_nologin-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_nologin-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-description"]/*)'/>
+  <section xml:id="sag-pam_nologin-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-description")/*)'/>
   </section>
-  <section id='sag-pam_nologin-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-options"]/*)'/>
+  <section xml:id="sag-pam_nologin-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-options")/*)'/>
   </section>
-  <section id='sag-pam_nologin-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-types"]/*)'/>
+  <section xml:id="sag-pam_nologin-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-types")/*)'/>
   </section>
-  <section id='sag-pam_nologin-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-return_values"]/*)'/>
+  <section xml:id="sag-pam_nologin-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-return_values")/*)'/>
   </section>
-  <section id='sag-pam_nologin-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-examples"]/*)'/>
+  <section xml:id="sag-pam_nologin-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-examples")/*)'/>
   </section>
-  <section id='sag-pam_nologin-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-author"]/*)'/>
+  <section xml:id="sag-pam_nologin-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_nologin/pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_permit.xml
+++ b/doc/sag/pam_permit.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_permit'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_permit">
   <title>pam_permit - the promiscuous module</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_permit-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_permit-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-description"]/*)'/>
+  <section xml:id="sag-pam_permit-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-description")/*)'/>
   </section>
-  <section id='sag-pam_permit-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-options"]/*)'/>
+  <section xml:id="sag-pam_permit-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-options")/*)'/>
   </section>
-  <section id='sag-pam_permit-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-types"]/*)'/>
+  <section xml:id="sag-pam_permit-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-types")/*)'/>
   </section>
-  <section id='sag-pam_permit-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-return_values"]/*)'/>
+  <section xml:id="sag-pam_permit-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-return_values")/*)'/>
   </section>
-  <section id='sag-pam_permit-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-examples"]/*)'/>
+  <section xml:id="sag-pam_permit-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-examples")/*)'/>
   </section>
-  <section id='sag-pam_permit-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-author"]/*)'/>
+  <section xml:id="sag-pam_permit-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_permit/pam_permit.8.xml" xpointer='xpointer(id("pam_permit-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_pwhistory.xml
+++ b/doc/sag/pam_pwhistory.xml
@@ -1,38 +1,27 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_pwhistory'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_pwhistory">
   <title>pam_pwhistory - grant access using .pwhistory file</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_pwhistory-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_pwhistory-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-description"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-description")/*)'/>
   </section>
-  <section id='sag-pam_pwhistory-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-options"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-options")/*)'/>
   </section>
-  <section id='sag-pam_pwhistory-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-types"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-types")/*)'/>
   </section>
-  <section id='sag-pam_pwhistory-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-return_values"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-return_values")/*)'/>
   </section>
-  <section id='sag-pam_pwhistory-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-files"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-files")/*)'/>
   </section>
-  <section id='sag-pam_pwhistory-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-examples"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-examples")/*)'/>
   </section>
-  <section id='sag-pam_pwhistory-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-author"]/*)'/>
+  <section xml:id="sag-pam_pwhistory-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_pwhistory/pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_rhosts.xml
+++ b/doc/sag/pam_rhosts.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_rhosts'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_rhosts">
   <title>pam_rhosts - grant access using .rhosts file</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_rhosts-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_rhosts-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-description"]/*)'/>
+  <section xml:id="sag-pam_rhosts-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-description")/*)'/>
   </section>
-  <section id='sag-pam_rhosts-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-options"]/*)'/>
+  <section xml:id="sag-pam_rhosts-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-options")/*)'/>
   </section>
-  <section id='sag-pam_rhosts-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-types"]/*)'/>
+  <section xml:id="sag-pam_rhosts-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-types")/*)'/>
   </section>
-  <section id='sag-pam_rhosts-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-return_values"]/*)'/>
+  <section xml:id="sag-pam_rhosts-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-return_values")/*)'/>
   </section>
-  <section id='sag-pam_rhosts-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-examples"]/*)'/>
+  <section xml:id="sag-pam_rhosts-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-examples")/*)'/>
   </section>
-  <section id='sag-pam_rhosts-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-author"]/*)'/>
+  <section xml:id="sag-pam_rhosts-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rhosts/pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_rootok.xml
+++ b/doc/sag/pam_rootok.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_rootok'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_rootok">
   <title>pam_rootok - gain only root access</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_rootok-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_rootok-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-description"]/*)'/>
+  <section xml:id="sag-pam_rootok-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-description")/*)'/>
   </section>
-  <section id='sag-pam_rootok-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-options"]/*)'/>
+  <section xml:id="sag-pam_rootok-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-options")/*)'/>
   </section>
-  <section id='sag-pam_rootok-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-types"]/*)'/>
+  <section xml:id="sag-pam_rootok-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-types")/*)'/>
   </section>
-  <section id='sag-pam_rootok-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-return_values"]/*)'/>
+  <section xml:id="sag-pam_rootok-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-return_values")/*)'/>
   </section>
-  <section id='sag-pam_rootok-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-examples"]/*)'/>
+  <section xml:id="sag-pam_rootok-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-examples")/*)'/>
   </section>
-  <section id='sag-pam_rootok-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-author"]/*)'/>
+  <section xml:id="sag-pam_rootok-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_rootok/pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_securetty.xml
+++ b/doc/sag/pam_securetty.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_securetty'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_securetty">
   <title>pam_securetty - limit root login to special devices</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_securetty-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_securetty-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-description"]/*)'/>
+  <section xml:id="sag-pam_securetty-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-description")/*)'/>
   </section>
-  <section id='sag-pam_securetty-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-options"]/*)'/>
+  <section xml:id="sag-pam_securetty-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-options")/*)'/>
   </section>
-  <section id='sag-pam_securetty-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-types"]/*)'/>
+  <section xml:id="sag-pam_securetty-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-types")/*)'/>
   </section>
-  <section id='sag-pam_securetty-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-return_values"]/*)'/>
+  <section xml:id="sag-pam_securetty-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-return_values")/*)'/>
   </section>
-  <section id='sag-pam_securetty-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-examples"]/*)'/>
+  <section xml:id="sag-pam_securetty-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-examples")/*)'/>
   </section>
-  <section id='sag-pam_securetty-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-author"]/*)'/>
+  <section xml:id="sag-pam_securetty-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_securetty/pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_selinux.xml
+++ b/doc/sag/pam_selinux.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_selinux'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_selinux">
   <title>pam_selinux - set the default security context</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_selinux-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_selinux-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-description"]/*)'/>
+  <section xml:id="sag-pam_selinux-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-description")/*)'/>
   </section>
-  <section id='sag-pam_selinux-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-options"]/*)'/>
+  <section xml:id="sag-pam_selinux-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-options")/*)'/>
   </section>
-  <section id='sag-pam_selinux-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-types"]/*)'/>
+  <section xml:id="sag-pam_selinux-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-types")/*)'/>
   </section>
-  <section id='sag-pam_selinux-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-return_values"]/*)'/>
+  <section xml:id="sag-pam_selinux-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-return_values")/*)'/>
   </section>
-  <section id='sag-pam_selinux-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-examples"]/*)'/>
+  <section xml:id="sag-pam_selinux-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-examples")/*)'/>
   </section>
-  <section id='sag-pam_selinux-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-author"]/*)'/>
+  <section xml:id="sag-pam_selinux-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_selinux/pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_sepermit.xml
+++ b/doc/sag/pam_sepermit.xml
@@ -1,38 +1,27 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_sepermit'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_sepermit">
   <title>pam_sepermit - allow/reject access based on SELinux mode</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_sepermit-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_sepermit-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-description"]/*)'/>
+  <section xml:id="sag-pam_sepermit-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-description")/*)'/>
   </section>
-  <section id='sag-pam_sepermit-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-options"]/*)'/>
+  <section xml:id="sag-pam_sepermit-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-options")/*)'/>
   </section>
-  <section id='sag-pam_sepermit-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-types"]/*)'/>
+  <section xml:id="sag-pam_sepermit-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-types")/*)'/>
   </section>
-  <section id='sag-pam_sepermit-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-return_values"]/*)'/>
+  <section xml:id="sag-pam_sepermit-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-return_values")/*)'/>
   </section>
-  <section id='sag-pam_sepermit-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-files"]/*)'/>
+  <section xml:id="sag-pam_sepermit-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-files")/*)'/>
   </section>
-  <section id='sag-pam_sepermit-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-examples"]/*)'/>
+  <section xml:id="sag-pam_sepermit-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-examples")/*)'/>
   </section>
-  <section id='sag-pam_sepermit-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-author"]/*)'/>
+  <section xml:id="sag-pam_sepermit-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_sepermit/pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_setquota.xml
+++ b/doc/sag/pam_setquota.xml
@@ -1,34 +1,24 @@
-﻿<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_setquota'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_setquota">
   <title>pam_setquota - set or modify disk quotas on session start</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_setquota-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_setquota-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-description"]/*)'/>
+  <section xml:id="sag-pam_setquota-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-description")/*)'/>
   </section>
-  <section id='sag-pam_setquota-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-options"]/*)'/>
+  <section xml:id="sag-pam_setquota-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-options")/*)'/>
   </section>
-  <section id='sag-pam_setquota-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-types"]/*)'/>
+  <section xml:id="sag-pam_setquota-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-types")/*)'/>
   </section>
-  <section id='sag-pam_setquota-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-return_values"]/*)'/>
+  <section xml:id="sag-pam_setquota-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-return_values")/*)'/>
   </section>
-  <section id='sag-pam_setquota-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-examples"]/*)'/>
+  <section xml:id="sag-pam_setquota-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-examples")/*)'/>
   </section>
-  <section id='sag-pam_setquota-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-author"]/*)'/>
+  <section xml:id="sag-pam_setquota-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_setquota/pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_shells.xml
+++ b/doc/sag/pam_shells.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_shells'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_shells">
   <title>pam_shells - check for valid login shell</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_shells-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_shells-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-description"]/*)'/>
+  <section xml:id="sag-pam_shells-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-description")/*)'/>
   </section>
-  <section id='sag-pam_shells-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-options"]/*)'/>
+  <section xml:id="sag-pam_shells-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-options")/*)'/>
   </section>
-  <section id='sag-pam_shells-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-types"]/*)'/>
+  <section xml:id="sag-pam_shells-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-types")/*)'/>
   </section>
-  <section id='sag-pam_shells-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-return_values"]/*)'/>
+  <section xml:id="sag-pam_shells-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-return_values")/*)'/>
   </section>
-  <section id='sag-pam_shells-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-examples"]/*)'/>
+  <section xml:id="sag-pam_shells-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-examples")/*)'/>
   </section>
-  <section id='sag-pam_shells-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-author"]/*)'/>
+  <section xml:id="sag-pam_shells-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_shells/pam_shells.8.xml" xpointer='xpointer(id("pam_shells-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_succeed_if.xml
+++ b/doc/sag/pam_succeed_if.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_succeed_if'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_succeed_if">
   <title>pam_succeed_if - test account characteristics</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_succeed_if-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_succeed_if-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-description"]/*)'/>
+  <section xml:id="sag-pam_succeed_if-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-description")/*)'/>
   </section>
-  <section id='sag-pam_succeed_if-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-options"]/*)'/>
+  <section xml:id="sag-pam_succeed_if-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-options")/*)'/>
   </section>
-  <section id='sag-pam_succeed_if-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-types"]/*)'/>
+  <section xml:id="sag-pam_succeed_if-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-types")/*)'/>
   </section>
-  <section id='sag-pam_succeed_if-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-return_values"]/*)'/>
+  <section xml:id="sag-pam_succeed_if-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-return_values")/*)'/>
   </section>
-  <section id='sag-pam_succeed_if-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-examples"]/*)'/>
+  <section xml:id="sag-pam_succeed_if-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-examples")/*)'/>
   </section>
-  <section id='sag-pam_succeed_if-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-author"]/*)'/>
+  <section xml:id="sag-pam_succeed_if-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_succeed_if/pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_time.xml
+++ b/doc/sag/pam_time.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_time'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_time">
   <title>pam_time - time controlled access</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_time-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_time-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-description"]/*)'/>
+  <section xml:id="sag-pam_time-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-description")/*)'/>
   </section>
-  <section id='sag-time.conf-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/time.conf.5.xml" xpointer='xpointer(//refsect1[@id = "time.conf-description"]/*)'/>
+  <section xml:id="sag-time.conf-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/time.conf.5.xml" xpointer='xpointer(id("time.conf-description")/*)'/>
   </section>
-  <section id='sag-pam_time-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-options"]/*)'/>
+  <section xml:id="sag-pam_time-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-options")/*)'/>
   </section>
-  <section id='sag-pam_time-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-types"]/*)'/>
+  <section xml:id="sag-pam_time-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-types")/*)'/>
   </section>
-  <section id='sag-pam_time-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-return_values"]/*)'/>
+  <section xml:id="sag-pam_time-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-return_values")/*)'/>
   </section>
-  <section id='sag-pam_time-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-files"]/*)'/>
+  <section xml:id="sag-pam_time-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-files")/*)'/>
   </section>
-  <section id='sag-time.conf-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/time.conf.5.xml" xpointer='xpointer(//refsect1[@id = "time.conf-examples"]/*)'/>
+  <section xml:id="sag-time.conf-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/time.conf.5.xml" xpointer='xpointer(id("time.conf-examples")/*)'/>
   </section>
-  <section id='sag-pam_time-authors'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-authors"]/*)'/>
+  <section xml:id="sag-pam_time-authors">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_time/pam_time.8.xml" xpointer='xpointer(id("pam_time-authors")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_timestamp.xml
+++ b/doc/sag/pam_timestamp.xml
@@ -1,42 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_timestamp'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_timestamp">
   <title>pam_timestamp - authenticate using cached successful authentication attempts</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_timestamp-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_timestamp-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-description"]/*)'/>
+  <section xml:id="sag-pam_timestamp-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-description")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-options"]/*)'/>
+  <section xml:id="sag-pam_timestamp-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-options")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-types"]/*)'/>
+  <section xml:id="sag-pam_timestamp-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-types")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-return_values"]/*)'/>
+  <section xml:id="sag-pam_timestamp-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-return_values")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-notes'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-notes"]/*)'/>
+  <section xml:id="sag-pam_timestamp-notes">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-notes")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-examples"]/*)'/>
+  <section xml:id="sag-pam_timestamp-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-examples")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-files'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-files"]/*)'/>
+  <section xml:id="sag-pam_timestamp-files">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-files")/*)'/>
   </section>
-  <section id='sag-pam_timestamp-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-author"]/*)'/>
+  <section xml:id="sag-pam_timestamp-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_timestamp/pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_tty_audit.xml
+++ b/doc/sag/pam_tty_audit.xml
@@ -1,38 +1,27 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_tty_audit'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_tty_audit">
   <title>pam_tty_audit - enable/disable tty auditing</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_tty_audit-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_tty_audit-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-description"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-description")/*)'/>
   </section>
-  <section id='sag-pam_tty_audit-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-options"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-options")/*)'/>
   </section>
-  <section id='sag-pam_tty_audit-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-types"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-types")/*)'/>
   </section>
-  <section id='sag-pam_tty_audit-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-return_values"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-return_values")/*)'/>
   </section>
-  <section id='sag-pam_tty_audit-notes'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-notes"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-notes">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-notes")/*)'/>
   </section>
-  <section id='sag-pam_tty_audit-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-examples"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-examples")/*)'/>
   </section>
-  <section id='sag-pam_tty_audit-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-author"]/*)'/>
+  <section xml:id="sag-pam_tty_audit-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_tty_audit/pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_umask.xml
+++ b/doc/sag/pam_umask.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_umask'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_umask">
   <title>pam_umask - set the file mode creation mask</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_umask-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_umask-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-description"]/*)'/>
+  <section xml:id="sag-pam_umask-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-description")/*)'/>
   </section>
-  <section id='sag-pam_umask-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-options"]/*)'/>
+  <section xml:id="sag-pam_umask-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-options")/*)'/>
   </section>
-  <section id='sag-pam_umask-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-types"]/*)'/>
+  <section xml:id="sag-pam_umask-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-types")/*)'/>
   </section>
-  <section id='sag-pam_umask-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-return_values"]/*)'/>
+  <section xml:id="sag-pam_umask-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-return_values")/*)'/>
   </section>
-  <section id='sag-pam_umask-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-examples"]/*)'/>
+  <section xml:id="sag-pam_umask-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-examples")/*)'/>
   </section>
-  <section id='sag-pam_umask-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-author"]/*)'/>
+  <section xml:id="sag-pam_umask-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_umask/pam_umask.8.xml" xpointer='xpointer(id("pam_umask-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_unix.xml
+++ b/doc/sag/pam_unix.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_unix'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_unix">
   <title>pam_unix - traditional password authentication</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_unix-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_unix-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-description"]/*)'/>
+  <section xml:id="sag-pam_unix-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-description")/*)'/>
   </section>
-  <section id='sag-pam_unix-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-options"]/*)'/>
+  <section xml:id="sag-pam_unix-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-options")/*)'/>
   </section>
-  <section id='sag-pam_unix-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-types"]/*)'/>
+  <section xml:id="sag-pam_unix-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-types")/*)'/>
   </section>
-  <section id='sag-pam_unix-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-return_values"]/*)'/>
+  <section xml:id="sag-pam_unix-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-return_values")/*)'/>
   </section>
-  <section id='sag-pam_unix-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-examples"]/*)'/>
+  <section xml:id="sag-pam_unix-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-examples")/*)'/>
   </section>
-  <section id='sag-pam_unix-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-author"]/*)'/>
+  <section xml:id="sag-pam_unix-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_unix/pam_unix.8.xml" xpointer='xpointer(id("pam_unix-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_userdb.xml
+++ b/doc/sag/pam_userdb.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_userdb'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_userdb">
   <title>pam_userdb - authenticate against a db database</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_userdb-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_userdb-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-description"]/*)'/>
+  <section xml:id="sag-pam_userdb-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-description")/*)'/>
   </section>
-  <section id='sag-pam_userdb-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-options"]/*)'/>
+  <section xml:id="sag-pam_userdb-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-options")/*)'/>
   </section>
-  <section id='sag-pam_userdb-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-types"]/*)'/>
+  <section xml:id="sag-pam_userdb-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-types")/*)'/>
   </section>
-  <section id='sag-pam_userdb-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-return_values"]/*)'/>
+  <section xml:id="sag-pam_userdb-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-return_values")/*)'/>
   </section>
-  <section id='sag-pam_userdb-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-examples"]/*)'/>
+  <section xml:id="sag-pam_userdb-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-examples")/*)'/>
   </section>
-  <section id='sag-pam_userdb-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-author"]/*)'/>
+  <section xml:id="sag-pam_userdb-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_userdb/pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_warn.xml
+++ b/doc/sag/pam_warn.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_warn'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_warn">
   <title>pam_warn - logs all PAM items</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_warn-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_warn-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-description"]/*)'/>
+  <section xml:id="sag-pam_warn-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-description")/*)'/>
   </section>
-  <section id='sag-pam_warn-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-options"]/*)'/>
+  <section xml:id="sag-pam_warn-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-options")/*)'/>
   </section>
-  <section id='sag-pam_warn-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-types"]/*)'/>
+  <section xml:id="sag-pam_warn-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-types")/*)'/>
   </section>
-  <section id='sag-pam_warn-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-return_values"]/*)'/>
+  <section xml:id="sag-pam_warn-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-return_values")/*)'/>
   </section>
-  <section id='sag-pam_warn-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-examples"]/*)'/>
+  <section xml:id="sag-pam_warn-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-examples")/*)'/>
   </section>
-  <section id='sag-pam_warn-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-author"]/*)'/>
+  <section xml:id="sag-pam_warn-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_warn/pam_warn.8.xml" xpointer='xpointer(id("pam_warn-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_wheel.xml
+++ b/doc/sag/pam_wheel.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_wheel'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_wheel">
   <title>pam_wheel - only permit root access to members of group wheel</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_wheel-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_wheel-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-description"]/*)'/>
+  <section xml:id="sag-pam_wheel-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-description")/*)'/>
   </section>
-  <section id='sag-pam_wheel-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-options"]/*)'/>
+  <section xml:id="sag-pam_wheel-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-options")/*)'/>
   </section>
-  <section id='sag-pam_wheel-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-types"]/*)'/>
+  <section xml:id="sag-pam_wheel-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-types")/*)'/>
   </section>
-  <section id='sag-pam_wheel-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-return_values"]/*)'/>
+  <section xml:id="sag-pam_wheel-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-return_values")/*)'/>
   </section>
-  <section id='sag-pam_wheel-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-examples"]/*)'/>
+  <section xml:id="sag-pam_wheel-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-examples")/*)'/>
   </section>
-  <section id='sag-pam_wheel-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-author"]/*)'/>
+  <section xml:id="sag-pam_wheel-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_wheel/pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-author")/*)'/>
   </section>
 </section>

--- a/doc/sag/pam_xauth.xml
+++ b/doc/sag/pam_xauth.xml
@@ -1,34 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-<section id='sag-pam_xauth'>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_xauth">
   <title>pam_xauth - forward xauth keys between users</title>
-  <cmdsynopsis>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//cmdsynopsis[@id = "pam_xauth-cmdsynopsis"]/*)'/>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-cmdsynopsis")/*)'/>
   </cmdsynopsis>
-  <section id='sag-pam_xauth-description'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-description"]/*)'/>
+  <section xml:id="sag-pam_xauth-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-description")/*)'/>
   </section>
-  <section id='sag-pam_xauth-options'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-options"]/*)'/>
+  <section xml:id="sag-pam_xauth-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-options")/*)'/>
   </section>
-  <section id='sag-pam_xauth-types'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-types"]/*)'/>
+  <section xml:id="sag-pam_xauth-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-types")/*)'/>
   </section>
-  <section id='sag-pam_xauth-return_values'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-return_values"]/*)'/>
+  <section xml:id="sag-pam_xauth-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-return_values")/*)'/>
   </section>
-  <section id='sag-pam_xauth-examples'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-examples"]/*)'/>
+  <section xml:id="sag-pam_xauth-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-examples")/*)'/>
   </section>
-  <section id='sag-pam_xauth-author'>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-     href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-author"]/*)'/>
+  <section xml:id="sag-pam_xauth-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_xauth/pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-author")/*)'/>
   </section>
 </section>

--- a/modules/pam_access/README.xml
+++ b/modules/pam_access/README.xml
@@ -1,39 +1,23 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_access.8.xml">
--->
-<!--
-<!ENTITY accessconf SYSTEM "access.conf.5.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_access.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_access-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_access.8.xml" xpointer='xpointer(id("pam_access-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_access.8.xml" xpointer='xpointer(id("pam_access-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_access.8.xml" xpointer='xpointer(//refsect1[@id = "pam_access-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_access.8.xml" xpointer='xpointer(id("pam_access-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="access.conf.5.xml" xpointer='xpointer(//refsect1[@id = "access.conf-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="access.conf.5.xml" xpointer='xpointer(id("access.conf-examples")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-        "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-
-<refentry id="access.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="access.conf">
 
   <refmeta>
     <refentrytitle>access.conf</refentrytitle>
@@ -16,7 +12,7 @@
   </refnamediv>
 
 
-  <refsect1 id='access.conf-description'>
+  <refsect1 xml:id="access.conf-description">
     <title>DESCRIPTION</title>
     <para>
       The <filename>/etc/security/access.conf</filename> file specifies
@@ -126,7 +122,7 @@
 
   </refsect1>
 
-  <refsect1 id="access.conf-examples">
+  <refsect1 xml:id="access.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -135,7 +131,7 @@
 
     <para>
       User <emphasis>root</emphasis> should be allowed to get access via
-      <emphasis>cron</emphasis>, X11 terminal <emphasis remap='I'>:0</emphasis>,
+      <emphasis>cron</emphasis>, X11 terminal <emphasis remap="I">:0</emphasis>,
       <emphasis>tty1</emphasis>, ..., <emphasis>tty5</emphasis>,
       <emphasis>tty6</emphasis>.
     </para>
@@ -216,7 +212,7 @@
 
   </refsect1>
 
-  <refsect1 id="access.conf-notes">
+  <refsect1 xml:id="access.conf-notes">
     <title>NOTES</title>
     <para>
       The default separators of list items in a field are space, ',', and tabulator
@@ -228,7 +224,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="access.conf-see_also">
+  <refsect1 xml:id="access.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_access</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -237,7 +233,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="access.conf-author">
+  <refsect1 xml:id="access.conf-author">
     <title>AUTHORS</title>
     <para>
       Original <citerefentry><refentrytitle>login.access</refentrytitle><manvolnum>5</manvolnum></citerefentry>

--- a/modules/pam_access/pam_access.8.xml
+++ b/modules/pam_access/pam_access.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_access'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_access">
 
   <refmeta>
     <refentrytitle>pam_access</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_access-name'>
+  <refnamediv xml:id="pam_access-name">
     <refname>pam_access</refname>
     <refpurpose>
       PAM module for logdaemon style login access control
@@ -20,31 +17,31 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_access-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_access-cmdsynopsis" sepchar=" ">
       <command>pam_access.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         nodefgroup
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         noaudit
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         accessfile=<replaceable>file</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         fieldsep=<replaceable>sep</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         listsep=<replaceable>sep</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_access-description">
+  <refsect1 xml:id="pam_access-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_access PAM module is mainly for access management.
@@ -92,13 +89,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_access-options">
+  <refsect1 xml:id="pam_access-options">
     <title>OPTIONS</title>
     <variablelist>
 
       <varlistentry>
         <term>
-          <option>accessfile=<replaceable>/path/to/access.conf</replaceable></option>
+          accessfile=/path/to/access.conf
         </term>
         <listitem>
           <para>
@@ -111,7 +108,7 @@
 
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -123,7 +120,7 @@
 
       <varlistentry>
         <term>
-          <option>noaudit</option>
+          noaudit
         </term>
         <listitem>
           <para>
@@ -134,19 +131,19 @@
 
       <varlistentry>
         <term>
-          <option>fieldsep=<replaceable>separators</replaceable></option>
+          fieldsep=separators
         </term>
         <listitem>
           <para>
             This option modifies the field separator character that
             pam_access will recognize when parsing the access
             configuration file. For example:
-            <emphasis remap='B'>fieldsep=|</emphasis> will cause the
+            <emphasis remap="B">fieldsep=|</emphasis> will cause the
             default `:' character to be treated as part of a field value
             and `|' becomes the field separator. Doing this may be
             useful in conjunction with a system that wants to use
             pam_access with X based applications, since the
-            <emphasis remap='B'>PAM_TTY</emphasis> item is likely to be
+            <emphasis remap="B">PAM_TTY</emphasis> item is likely to be
             of the form "hostname:0" which includes a `:' character in
             its value. But you should not need this.
           </para>
@@ -155,14 +152,14 @@
 
       <varlistentry>
         <term>
-          <option>listsep=<replaceable>separators</replaceable></option>
+          listsep=separators
         </term>
         <listitem>
           <para>
             This option modifies the list separator character that
             pam_access will recognize when parsing the access
             configuration file. For example:
-            <emphasis remap='B'>listsep=,</emphasis> will cause the
+            <emphasis remap="B">listsep=,</emphasis> will cause the
             default ` ' (space) and `\t' (tab) characters to be treated
             as part of a list element value and `,' becomes the only
             list element separator. Doing this may be useful on a system
@@ -175,7 +172,7 @@
 
       <varlistentry>
         <term>
-          <option>nodefgroup</option>
+          nodefgroup
         </term>
         <listitem>
           <para>
@@ -190,7 +187,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_access-types">
+  <refsect1 xml:id="pam_access-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -198,7 +195,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_access-return_values">
+  <refsect1 xml:id="pam_access-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -244,17 +241,17 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_access-files">
+  <refsect1 xml:id="pam_access-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/access.conf</filename></term>
+        <term>/etc/security/access.conf</term>
         <listitem>
           <para>Default configuration file</para>
         </listitem>
       </varlistentry>
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/security/access.conf</filename></term>
+        <term>%vendordir%/security/access.conf</term>
         <listitem>
           <para>Default configuration file if
 	  <filename>/etc/security/access.conf</filename> does not exist.</para>
@@ -263,7 +260,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_access-see_also">
+  <refsect1 xml:id="pam_access-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -278,7 +275,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_access-authors">
+  <refsect1 xml:id="pam_access-authors">
     <title>AUTHORS</title>
     <para>
       The logdaemon style login access control scheme was designed and implemented by

--- a/modules/pam_debug/README.xml
+++ b/modules/pam_debug/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_debug.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_debug.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_debug-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.8.xml" xpointer='xpointer(id("pam_debug-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.8.xml" xpointer='xpointer(id("pam_debug-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.8.xml" xpointer='xpointer(id("pam_debug-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.8.xml" xpointer='xpointer(id("pam_debug-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_debug.8.xml" xpointer='xpointer(//refsect1[@id = "pam_debug-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.8.xml" xpointer='xpointer(id("pam_debug-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_debug/pam_debug.8.xml
+++ b/modules/pam_debug/pam_debug.8.xml
@@ -1,51 +1,48 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_debug">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_debug">
 
   <refmeta>
     <refentrytitle>pam_debug</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_debug-name">
+  <refnamediv xml:id="pam_debug-name">
     <refname>pam_debug</refname>
     <refpurpose>PAM module to debug the PAM stack</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_debug-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_debug-cmdsynopsis" sepchar=" ">
       <command>pam_debug.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	auth=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	cred=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	acct=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	prechauthtok=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	chauthtok=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	auth=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	open_session=<replaceable>value</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	close_session=<replaceable>value</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_debug-description">
+  <refsect1 xml:id="pam_debug-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_debug PAM module is intended as a debugging aide for
@@ -54,12 +51,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_debug-options">
+  <refsect1 xml:id="pam_debug-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>auth=<replaceable>value</replaceable></option>
+          auth=value
         </term>
         <listitem>
           <para>
@@ -73,7 +70,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>cred=<replaceable>value</replaceable></option>
+          cred=value
         </term>
         <listitem>
           <para>
@@ -87,7 +84,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>acct=<replaceable>value</replaceable></option>
+          acct=value
         </term>
         <listitem>
           <para>
@@ -101,7 +98,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>prechauthtok=<replaceable>value</replaceable></option>
+          prechauthtok=value
         </term>
         <listitem>
           <para>
@@ -116,7 +113,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>chauthtok=<replaceable>value</replaceable></option>
+          chauthtok=value
         </term>
         <listitem>
           <para>
@@ -126,13 +123,13 @@
             </citerefentry> function will return
             <replaceable>value</replaceable> if the
             <emphasis>PAM_PRELIM_CHECK</emphasis> flag is
-            <emphasis remap='B'>not</emphasis> set.
+            <emphasis remap="B">not</emphasis> set.
           </para>
         </listitem>
       </varlistentry>
       <varlistentry>
         <term>
-          <option>open_session=<replaceable>value</replaceable></option>
+          open_session=value
         </term>
         <listitem>
           <para>
@@ -146,7 +143,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>close_session=<replaceable>value</replaceable></option>
+          close_session=value
         </term>
         <listitem>
           <para>
@@ -171,7 +168,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_debug-types">
+  <refsect1 xml:id="pam_debug-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -179,7 +176,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_debug-return_values'>
+  <refsect1 xml:id="pam_debug-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -194,7 +191,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_debug-examples'>
+  <refsect1 xml:id="pam_debug-examples">
     <title>EXAMPLES</title>
     <programlisting>
 auth    requisite       pam_permit.so
@@ -206,7 +203,7 @@ auth    sufficient      pam_debug.so auth=success cred=success
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_debug-see_also'>
+  <refsect1 xml:id="pam_debug-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -221,7 +218,7 @@ auth    sufficient      pam_debug.so auth=success cred=success
     </para>
   </refsect1>
 
-  <refsect1 id='pam_debug-author'>
+  <refsect1 xml:id="pam_debug-author">
     <title>AUTHOR</title>
       <para>
         pam_debug was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_deny/README.xml
+++ b/modules/pam_deny/README.xml
@@ -1,36 +1,23 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_deny.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_deny.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_deny-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_deny.8.xml" xpointer='xpointer(id("pam_deny-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_deny.8.xml" xpointer='xpointer(id("pam_deny-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_deny.8.xml" xpointer='xpointer(id("pam_deny-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_deny.8.xml" xpointer='xpointer(//refsect1[@id = "pam_deny-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_deny.8.xml" xpointer='xpointer(id("pam_deny-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_deny/pam_deny.8.xml
+++ b/modules/pam_deny/pam_deny.8.xml
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_deny">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_deny">
 
   <refmeta>
     <refentrytitle>pam_deny</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_deny-name">
+  <refnamediv xml:id="pam_deny-name">
     <refname>pam_deny</refname>
     <refpurpose>The locking-out PAM module</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_deny-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_deny-cmdsynopsis" sepchar=" ">
       <command>pam_deny.so</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_deny-description">
+  <refsect1 xml:id="pam_deny-description">
 
     <title>DESCRIPTION</title>
 
@@ -33,12 +30,12 @@
 
   </refsect1>
 
-  <refsect1 id="pam_deny-options">
+  <refsect1 xml:id="pam_deny-options">
     <title>OPTIONS</title>
     <para>This module does not recognise any options.</para>
   </refsect1>
 
-  <refsect1 id="pam_deny-types">
+  <refsect1 xml:id="pam_deny-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>account</option>, <option>auth</option>,
@@ -46,7 +43,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_deny-return_values'>
+  <refsect1 xml:id="pam_deny-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -91,7 +88,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_deny-examples'>
+  <refsect1 xml:id="pam_deny-examples">
     <title>EXAMPLES</title>
     <programlisting>
 #%PAM-1.0
@@ -110,7 +107,7 @@ other session  required       pam_deny.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_deny-see_also'>
+  <refsect1 xml:id="pam_deny-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -125,7 +122,7 @@ other session  required       pam_deny.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_deny-author'>
+  <refsect1 xml:id="pam_deny-author">
     <title>AUTHOR</title>
       <para>
         pam_deny was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;

--- a/modules/pam_echo/README.xml
+++ b/modules/pam_echo/README.xml
@@ -1,36 +1,23 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_echo.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_echo.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_echo-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_echo.8.xml" xpointer='xpointer(id("pam_echo-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_echo.8.xml" xpointer='xpointer(id("pam_echo-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_echo.8.xml" xpointer='xpointer(id("pam_echo-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_echo.8.xml" xpointer='xpointer(//refsect1[@id = "pam_echo-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_echo.8.xml" xpointer='xpointer(id("pam_echo-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_echo/pam_echo.8.xml
+++ b/modules/pam_echo/pam_echo.8.xml
@@ -1,15 +1,12 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_echo'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_echo">
   <refmeta>
     <refentrytitle>pam_echo</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_echo-name'>
+  <refnamediv xml:id="pam_echo-name">
     <refname>pam_echo</refname>
     <refpurpose>PAM module for printing text messages</refpurpose>
   </refnamediv>
@@ -17,15 +14,15 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_echo-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_echo-cmdsynopsis" sepchar=" ">
       <command>pam_echo.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         file=<replaceable>/path/message</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id='pam_echo-description'>
+  <refsect1 xml:id="pam_echo-description">
     <title>DESCRIPTION</title>
     <para>
       The <emphasis>pam_echo</emphasis> PAM module is for printing
@@ -35,37 +32,37 @@
     </para>
     <variablelist>
       <varlistentry>
-        <term><emphasis>%H</emphasis></term>
+        <term>%H</term>
         <listitem>
           <para>The name of the remote host (PAM_RHOST).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis>%h</emphasis></term>
+        <term>%h</term>
         <listitem>
           <para>The name of the local host.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis>%s</emphasis></term>
+        <term>%s</term>
         <listitem>
           <para>The service name (PAM_SERVICE).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis>%t</emphasis></term>
+        <term>%t</term>
         <listitem>
           <para>The name of the controlling terminal (PAM_TTY).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis>%U</emphasis></term>
+        <term>%U</term>
         <listitem>
           <para>The remote user name (PAM_RUSER).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis>%u</emphasis></term>
+        <term>%u</term>
         <listitem>
           <para>The local user name (PAM_USER).</para>
         </listitem>
@@ -79,12 +76,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_echo-options'>
+  <refsect1 xml:id="pam_echo-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>file=<replaceable>/path/message</replaceable></option>
+          file=/path/message
         </term>
         <listitem>
           <para>
@@ -96,7 +93,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_echo-types">
+  <refsect1 xml:id="pam_echo-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -106,7 +103,7 @@
   </refsect1>
 
 
-  <refsect1 id="pam_echo-return_values">
+  <refsect1 xml:id="pam_echo-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -137,7 +134,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_echo-examples'>
+  <refsect1 xml:id="pam_echo-examples">
     <title>EXAMPLES</title>
     <para>
       For an example of the use of this module, we show how it may be
@@ -150,7 +147,7 @@ password required pam_unix.so
   </refsect1>
 
 
-  <refsect1 id='pam_echo-see_also'><title>SEE ALSO</title>
+  <refsect1 xml:id="pam_echo-see_also"><title>SEE ALSO</title>
   <para>
     <citerefentry>
       <refentrytitle>pam.conf</refentrytitle><manvolnum>8</manvolnum>
@@ -163,7 +160,7 @@ password required pam_unix.so
     </citerefentry></para>
   </refsect1>
 
-  <refsect1 id='pam_echo-author'>
+  <refsect1 xml:id="pam_echo-author">
     <title>AUTHOR</title>
     <para>Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;</para>
   </refsect1>

--- a/modules/pam_env/README.xml
+++ b/modules/pam_env/README.xml
@@ -1,39 +1,21 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_env.8.xml">
--->
-<!--
-<!ENTITY accessconf SYSTEM "pam_env.conf.5.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
-
+  <info>
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_env.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_env-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_env.8.xml" xpointer='xpointer(id("pam_env-name")/*)'/>
     </title>
-
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_env.8.xml" xpointer='xpointer(id("pam_env-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_env.8.xml" xpointer='xpointer(//refsect1[@id = "pam_env-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_env.8.xml" xpointer='xpointer(id("pam_env-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_env.conf.5.xml" xpointer='xpointer(//refsect1[@id = "pam_env.conf-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_env.conf.5.xml" xpointer='xpointer(id("pam_env.conf-examples")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_env/pam_env.8.xml
+++ b/modules/pam_env/pam_env.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_env'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_env">
 
   <refmeta>
     <refentrytitle>pam_env</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_env-name'>
+  <refnamediv xml:id="pam_env-name">
     <refname>pam_env</refname>
     <refpurpose>
       PAM module to set/unset environment variables
@@ -20,31 +17,31 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_env-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_env-cmdsynopsis" sepchar=" ">
       <command>pam_env.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         conffile=<replaceable>conf-file</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         envfile=<replaceable>env-file</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         readenv=<replaceable>0|1</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         user_envfile=<replaceable>env-file</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         user_readenv=<replaceable>0|1</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_env-description">
+  <refsect1 xml:id="pam_env-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_env PAM module allows the (un)setting of environment
@@ -119,13 +116,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_env-options">
+  <refsect1 xml:id="pam_env-options">
     <title>OPTIONS</title>
     <variablelist>
 
       <varlistentry>
         <term>
-          <option>conffile=<replaceable>/path/to/pam_env.conf</replaceable></option>
+          conffile=/path/to/pam_env.conf
         </term>
         <listitem>
           <para>
@@ -138,7 +135,7 @@
 
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -150,7 +147,7 @@
 
       <varlistentry>
         <term>
-          <option>envfile=<replaceable>/path/to/environment</replaceable></option>
+          envfile=/path/to/environment
         </term>
         <listitem>
           <para>
@@ -166,7 +163,7 @@
 
       <varlistentry>
         <term>
-          <option>readenv=<replaceable>0|1</replaceable></option>
+          readenv=0|1
         </term>
         <listitem>
           <para>
@@ -179,7 +176,7 @@
 
       <varlistentry>
         <term>
-          <option>user_envfile=<replaceable>filename</replaceable></option>
+          user_envfile=filename
         </term>
         <listitem>
           <para>
@@ -195,7 +192,7 @@
 
       <varlistentry>
         <term>
-          <option>user_readenv=<replaceable>0|1</replaceable></option>
+          user_readenv=0|1
         </term>
         <listitem>
           <para>
@@ -216,7 +213,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_env-types">
+  <refsect1 xml:id="pam_env-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>session</option> module
@@ -224,7 +221,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_env-return_values">
+  <refsect1 xml:id="pam_env-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -262,25 +259,25 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_env-files">
+  <refsect1 xml:id="pam_env-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term condition="with_vendordir"><filename>/usr/etc/security/pam_env.conf</filename></term>
-        <term><filename>/etc/security/pam_env.conf</filename></term>
+        <term condition="with_vendordir">%vendordir%/security/pam_env.conf</term>
+        <term>/etc/security/pam_env.conf</term>
         <listitem>
           <para>Default configuration file</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term condition="with_vendordir"><filename>/usr/etc/environment</filename></term>
-        <term><filename>/etc/environment</filename></term>
+        <term condition="with_vendordir">%vendordir%/environment</term>
+        <term>/etc/environment</term>
         <listitem>
           <para>Default environment file</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><filename>$HOME/.pam_environment</filename></term>
+        <term>$HOME/.pam_environment</term>
         <listitem>
           <para>User specific environment file</para>
         </listitem>
@@ -288,7 +285,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_env-see_also">
+  <refsect1 xml:id="pam_env-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -306,7 +303,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_env-authors">
+  <refsect1 xml:id="pam_env-authors">
     <title>AUTHOR</title>
     <para>
       pam_env was written by Dave Kinchlea &lt;kinch@kinch.ark.com&gt;.

--- a/modules/pam_env/pam_env.conf.5.xml
+++ b/modules/pam_env/pam_env.conf.5.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_env.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_env.conf">
 
   <refmeta>
     <refentrytitle>pam_env.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -17,7 +14,7 @@
   </refnamediv>
 
 
-  <refsect1 id='pam_env.conf-description'>
+  <refsect1 xml:id="pam_env.conf-description">
     <title>DESCRIPTION</title>
 
     <para condition="with_vendordir">
@@ -87,7 +84,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_env.conf-examples">
+  <refsect1 xml:id="pam_env.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -133,7 +130,7 @@
     </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_env.conf-see_also">
+  <refsect1 xml:id="pam_env.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_env</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -143,7 +140,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_env.conf-author">
+  <refsect1 xml:id="pam_env.conf-author">
     <title>AUTHOR</title>
     <para>
       pam_env was written by Dave Kinchlea &lt;kinch@kinch.ark.com&gt;.

--- a/modules/pam_exec/README.xml
+++ b/modules/pam_exec/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_exec.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_exec.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_exec-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_exec.8.xml" xpointer='xpointer(id("pam_exec-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_exec.8.xml" xpointer='xpointer(id("pam_exec-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_exec.8.xml" xpointer='xpointer(id("pam_exec-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_exec.8.xml" xpointer='xpointer(id("pam_exec-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_exec.8.xml" xpointer='xpointer(//refsect1[@id = "pam_exec-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_exec.8.xml" xpointer='xpointer(id("pam_exec-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_exec/pam_exec.8.xml
+++ b/modules/pam_exec/pam_exec.8.xml
@@ -1,57 +1,54 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_exec">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_exec">
 
   <refmeta>
     <refentrytitle>pam_exec</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_exec-name">
+  <refnamediv xml:id="pam_exec-name">
     <refname>pam_exec</refname>
     <refpurpose>PAM module which calls an external command</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_exec-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_exec-cmdsynopsis" sepchar=" ">
       <command>pam_exec.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
          expose_authtok
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         seteuid
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         quiet
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         quiet_log
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         stdout
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         log=<replaceable>file</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         type=<replaceable>type</replaceable>
       </arg>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
        <replaceable>command</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         <replaceable>...</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_exec-description">
+  <refsect1 xml:id="pam_exec-description">
 
     <title>DESCRIPTION</title>
 
@@ -83,7 +80,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_exec-options">
+  <refsect1 xml:id="pam_exec-options">
 
     <title>OPTIONS</title>
     <para>
@@ -91,7 +88,7 @@
 
         <varlistentry>
           <term>
-            <option>debug</option>
+            debug
           </term>
           <listitem>
             <para>
@@ -102,7 +99,7 @@
 
         <varlistentry>
           <term>
-            <option>expose_authtok</option>
+            expose_authtok
           </term>
           <listitem>
             <para>
@@ -117,7 +114,7 @@
 
         <varlistentry>
           <term>
-            <option>log=<replaceable>file</replaceable></option>
+            log=file
           </term>
           <listitem>
             <para>
@@ -129,7 +126,7 @@
 
         <varlistentry>
           <term>
-            <option>type=<replaceable>type</replaceable></option>
+            type=type
           </term>
           <listitem>
             <para>
@@ -140,7 +137,7 @@
 
         <varlistentry>
           <term>
-            <option>stdout</option>
+            stdout
           </term>
           <listitem>
             <para>
@@ -151,7 +148,7 @@
 
         <varlistentry>
           <term>
-            <option>quiet</option>
+            quiet
           </term>
           <listitem>
             <para>
@@ -164,7 +161,7 @@
 
         <varlistentry>
           <term>
-            <option>quiet_log</option>
+            quiet_log
           </term>
           <listitem>
             <para>
@@ -177,7 +174,7 @@
 
         <varlistentry>
           <term>
-            <option>seteuid</option>
+            seteuid
           </term>
           <listitem>
             <para>
@@ -194,7 +191,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_exec-types">
+  <refsect1 xml:id="pam_exec-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -202,7 +199,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_exec-return_values'>
+  <refsect1 xml:id="pam_exec-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -278,7 +275,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_exec-examples'>
+  <refsect1 xml:id="pam_exec-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/passwd</filename> to
@@ -293,7 +290,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_exec-see_also'>
+  <refsect1 xml:id="pam_exec-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -308,7 +305,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_exec-author'>
+  <refsect1 xml:id="pam_exec-author">
     <title>AUTHOR</title>
       <para>
         pam_exec was written by Thorsten Kukuk &lt;kukuk@thkukuk.de&gt; and

--- a/modules/pam_faildelay/README.xml
+++ b/modules/pam_faildelay/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-"http://www.docbook.org/xml/4.4/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_faildelay.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faildelay.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_faildelay-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faildelay.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faildelay-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faildelay.8.xml" xpointer='xpointer(id("pam_faildelay-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_faildelay/pam_faildelay.8.xml
+++ b/modules/pam_faildelay/pam_faildelay.8.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-	"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
-
-<refentry id="pam_faildelay">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_faildelay">
 
   <refmeta>
     <refentrytitle>pam_faildelay</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_faildelay-name">
+  <refnamediv xml:id="pam_faildelay-name">
     <refname>pam_faildelay</refname>
     <refpurpose>Change the delay on failure per-application</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_faildelay-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_faildelay-cmdsynopsis" sepchar=" ">
       <command>pam_faildelay.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         delay=<replaceable>microseconds</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_faildelay-description">
+  <refsect1 xml:id="pam_faildelay-description">
 
     <title>DESCRIPTION</title>
 
@@ -41,13 +38,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_faildelay-options">
+  <refsect1 xml:id="pam_faildelay-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -57,7 +54,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>delay=<replaceable>N</replaceable></option>
+          delay=N
         </term>
         <listitem>
           <para>
@@ -68,14 +65,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_faildelay-types">
+  <refsect1 xml:id="pam_faildelay-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>auth</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_faildelay-return_values'>
+  <refsect1 xml:id="pam_faildelay-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -97,7 +94,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_faildelay-examples'>
+  <refsect1 xml:id="pam_faildelay-examples">
     <title>EXAMPLES</title>
     <para>
       The following example will set the delay on failure to
@@ -108,7 +105,7 @@ auth  optional  pam_faildelay.so  delay=10000000
     </para>
   </refsect1>
 
-  <refsect1 id='pam_faildelay-see_also'>
+  <refsect1 xml:id="pam_faildelay-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -126,7 +123,7 @@ auth  optional  pam_faildelay.so  delay=10000000
     </para>
   </refsect1>
 
-  <refsect1 id='pam_faildelay-author'>
+  <refsect1 xml:id="pam_faildelay-author">
     <title>AUTHOR</title>
       <para>
         pam_faildelay was written by Darren Tucker &lt;dtucker@zip.com.au&gt;.

--- a/modules/pam_faillock/README.xml
+++ b/modules/pam_faillock/README.xml
@@ -1,46 +1,31 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_faillock.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faillock.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_faillock-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-notes"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-notes")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_faillock.8.xml" xpointer='xpointer(//refsect1[@id = "pam_faillock-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_faillock.8.xml" xpointer='xpointer(id("pam_faillock-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_faillock/faillock.8.xml
+++ b/modules/pam_faillock/faillock.8.xml
@@ -1,36 +1,33 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="faillock">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="faillock">
 
   <refmeta>
     <refentrytitle>faillock</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_faillock-name">
+  <refnamediv xml:id="pam_faillock-name">
     <refname>faillock</refname>
     <refpurpose>Tool for displaying and modifying the authentication failure record files</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="faillock-cmdsynopsis">
+    <cmdsynopsis xml:id="faillock-cmdsynopsis" sepchar=" ">
       <command>faillock</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         --dir <replaceable>/path/to/tally-directory</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         --user <replaceable>username</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         --reset
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="faillock-description">
+  <refsect1 xml:id="faillock-description">
 
     <title>DESCRIPTION</title>
 
@@ -51,13 +48,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="faillock-options">
+  <refsect1 xml:id="faillock-options">
 
     <title>OPTIONS</title>
          <variablelist>
             <varlistentry>
               <term>
-                <option>--conf <replaceable>/path/to/config-file</replaceable></option>
+                --conf /path/to/config-file
               </term>
               <listitem>
                 <para>
@@ -68,7 +65,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>--dir <replaceable>/path/to/tally-directory</replaceable></option>
+                --dir /path/to/tally-directory
               </term>
               <listitem>
                 <para>
@@ -85,7 +82,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>--user <replaceable>username</replaceable></option>
+                --user username
               </term>
               <listitem>
                 <para>
@@ -95,7 +92,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>--reset</option>
+                --reset
               </term>
               <listitem>
                 <para>
@@ -106,11 +103,11 @@
         </variablelist>
   </refsect1>
 
-  <refsect1 id="faillock-files">
+  <refsect1 xml:id="faillock-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/var/run/faillock/*</filename></term>
+        <term>/var/run/faillock/*</term>
         <listitem>
           <para>the files logging the authentication failures for users</para>
         </listitem>
@@ -118,7 +115,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='faillock-see_also'>
+  <refsect1 xml:id="faillock-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -130,7 +127,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='faillock-author'>
+  <refsect1 xml:id="faillock-author">
     <title>AUTHOR</title>
       <para>
         faillock was written by Tomas Mraz.

--- a/modules/pam_faillock/faillock.conf.5.xml
+++ b/modules/pam_faillock/faillock.conf.5.xml
@@ -1,25 +1,22 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="faillock.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="faillock.conf">
 
   <refmeta>
     <refentrytitle>faillock.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="faillock.conf-name">
+  <refnamediv xml:id="faillock.conf-name">
     <refname>faillock.conf</refname>
     <refpurpose>pam_faillock configuration file</refpurpose>
   </refnamediv>
 
-  <refsect1 id="faillock.conf-description">
+  <refsect1 xml:id="faillock.conf-description">
 
     <title>DESCRIPTION</title>
     <para>
-       <emphasis remap='B'>faillock.conf</emphasis> provides a way to configure the
+       <emphasis remap="B">faillock.conf</emphasis> provides a way to configure the
        default settings for locking the user after multiple failed authentication attempts.
        This file is read by the <emphasis>pam_faillock</emphasis> module and is the
        preferred method over configuring <emphasis>pam_faillock</emphasis> directly.
@@ -31,13 +28,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="faillock.conf-options">
+  <refsect1 xml:id="faillock.conf-options">
 
     <title>OPTIONS</title>
          <variablelist>
             <varlistentry>
               <term>
-                <option>dir=<replaceable>/path/to/tally-directory</replaceable></option>
+                dir=/path/to/tally-directory
               </term>
               <listitem>
                 <para>
@@ -52,7 +49,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>audit</option>
+                audit
               </term>
               <listitem>
                 <para>
@@ -62,7 +59,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>silent</option>
+                silent
               </term>
               <listitem>
                 <para>
@@ -74,7 +71,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>no_log_info</option>
+                no_log_info
               </term>
               <listitem>
                 <para>
@@ -84,7 +81,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>local_users_only</option>
+                local_users_only
               </term>
               <listitem>
                 <para>
@@ -100,7 +97,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>nodelay</option>
+                nodelay
               </term>
               <listitem>
                 <para>
@@ -110,7 +107,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>deny=<replaceable>n</replaceable></option>
+                deny=n
               </term>
               <listitem>
                 <para>
@@ -122,7 +119,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>fail_interval=<replaceable>n</replaceable></option>
+                fail_interval=n
               </term>
               <listitem>
                 <para>
@@ -135,7 +132,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>unlock_time=<replaceable>n</replaceable></option>
+                unlock_time=n
               </term>
               <listitem>
                 <para>
@@ -163,7 +160,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>even_deny_root</option>
+                even_deny_root
               </term>
               <listitem>
                 <para>
@@ -173,7 +170,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>root_unlock_time=<replaceable>n</replaceable></option>
+                root_unlock_time=n
               </term>
               <listitem>
                 <para>
@@ -187,7 +184,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>admin_group=<replaceable>name</replaceable></option>
+                admin_group=name
               </term>
               <listitem>
                 <para>
@@ -202,7 +199,7 @@
         </variablelist>
   </refsect1>
 
-  <refsect1 id='faillock.conf-examples'>
+  <refsect1 xml:id="faillock.conf-examples">
     <title>EXAMPLES</title>
     <para>
       /etc/security/faillock.conf file example:
@@ -214,11 +211,11 @@ silent
     </programlisting>
   </refsect1>
 
-  <refsect1 id="faillock.conf-files">
+  <refsect1 xml:id="faillock.conf-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/faillock.conf</filename></term>
+        <term>/etc/security/faillock.conf</term>
         <listitem>
           <para>the config file for custom options</para>
         </listitem>
@@ -226,7 +223,7 @@ silent
     </variablelist>
   </refsect1>
 
-  <refsect1 id='faillock.conf-see_also'>
+  <refsect1 xml:id="faillock.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -247,7 +244,7 @@ silent
     </para>
   </refsect1>
 
-  <refsect1 id='faillock.conf-author'>
+  <refsect1 xml:id="faillock.conf-author">
     <title>AUTHOR</title>
       <para>
         pam_faillock was written by Tomas Mraz. The support for faillock.conf was written by Brian Ward.

--- a/modules/pam_faillock/pam_faillock.8.xml
+++ b/modules/pam_faillock/pam_faillock.8.xml
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_faillock">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_faillock">
 
   <refmeta>
     <refentrytitle>pam_faillock</refentrytitle>
@@ -10,63 +6,63 @@
     <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_faillock-name">
+  <refnamediv xml:id="pam_faillock-name">
     <refname>pam_faillock</refname>
     <refpurpose>Module counting authentication failures during a specified interval</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_faillock-cmdsynopsisauth">
+    <cmdsynopsis xml:id="pam_faillock-cmdsynopsisauth" sepchar=" ">
       <command>auth ... pam_faillock.so</command>
-      <arg choice="req">
+      <arg choice="req" rep="norepeat">
         preauth|authfail|authsucc
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         conf=<replaceable>/path/to/config-file</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         dir=<replaceable>/path/to/tally-directory</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         even_deny_root
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         deny=<replaceable>n</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         fail_interval=<replaceable>n</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         unlock_time=<replaceable>n</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         root_unlock_time=<replaceable>n</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         admin_group=<replaceable>name</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         audit
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         silent
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         no_log_info
       </arg>
     </cmdsynopsis>
-    <cmdsynopsis id="pam_faillock-cmdsynopsisacct">
+    <cmdsynopsis xml:id="pam_faillock-cmdsynopsisacct" sepchar=" ">
       <command>account ... pam_faillock.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         dir=<replaceable>/path/to/tally-directory</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         no_log_info
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_faillock-description">
+  <refsect1 xml:id="pam_faillock-description">
 
     <title>DESCRIPTION</title>
 
@@ -78,20 +74,20 @@
     </para>
     <para>
       Normally, failed attempts to authenticate <emphasis>root</emphasis> will
-      <emphasis remap='B'>not</emphasis> cause the root account to become
+      <emphasis remap="B">not</emphasis> cause the root account to become
       blocked, to prevent denial-of-service: if your users aren't given
       shell accounts and root may only login via <command>su</command> or
       at the machine console (not telnet/rsh, etc), this is safe.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_faillock-options">
+  <refsect1 xml:id="pam_faillock-options">
 
     <title>OPTIONS</title>
         <variablelist>
             <varlistentry>
               <term>
-                <option>{preauth|authfail|authsucc}</option>
+                {preauth|authfail|authsucc}
               </term>
               <listitem>
                 <para>
@@ -131,7 +127,7 @@
             </varlistentry>
             <varlistentry>
                <term>
-                 <option>conf=/path/to/config-file</option>
+                 conf=/path/to/config-file
                </term>
                <listitem>
                  <para condition="without_vendordir">
@@ -156,7 +152,7 @@
         </para>
   </refsect1>
 
-  <refsect1 id="pam_faillock-types">
+  <refsect1 xml:id="pam_faillock-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option> module types are
@@ -164,7 +160,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_faillock-return_values'>
+  <refsect1 xml:id="pam_faillock-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -222,7 +218,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_faillock-notes'>
+  <refsect1 xml:id="pam_faillock-notes">
     <title>NOTES</title>
     <para>
       Configuring options on the module command line is not recommend. The
@@ -234,7 +230,7 @@
     </para>
     <para>
       Individual files with the failure records are created as owned by
-      the user. This allows <emphasis remap='B'>pam_faillock.so</emphasis> module
+      the user. This allows <emphasis remap="B">pam_faillock.so</emphasis> module
       to work correctly when it is called from a screensaver.
     </para>
     <para>
@@ -249,7 +245,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_faillock-examples'>
+  <refsect1 xml:id="pam_faillock-examples">
     <title>EXAMPLES</title>
     <para>
       Here are two possible configuration examples for <filename>/etc/pam.d/login</filename>.
@@ -320,11 +316,11 @@ session  required       pam_selinux.so open
     </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_faillock-files">
+  <refsect1 xml:id="pam_faillock-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/var/run/faillock/*</filename></term>
+        <term>/var/run/faillock/*</term>
         <listitem>
           <para>the files logging the authentication failures for users</para>
           <para>
@@ -336,13 +332,13 @@ session  required       pam_selinux.so open
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><filename>/etc/security/faillock.conf</filename></term>
+        <term>/etc/security/faillock.conf</term>
         <listitem>
           <para>the config file for pam_faillock options</para>
         </listitem>
       </varlistentry>
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/security/faillock.conf</filename></term>
+        <term>%vendordir%/security/faillock.conf</term>
         <listitem>
           <para>
             the config file for pam_faillock options. It will be used if
@@ -353,7 +349,7 @@ session  required       pam_selinux.so open
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_faillock-see_also'>
+  <refsect1 xml:id="pam_faillock-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -374,7 +370,7 @@ session  required       pam_selinux.so open
     </para>
   </refsect1>
 
-  <refsect1 id='pam_faillock-author'>
+  <refsect1 xml:id="pam_faillock-author">
     <title>AUTHOR</title>
       <para>
         pam_faillock was written by Tomas Mraz.

--- a/modules/pam_filter/README.xml
+++ b/modules/pam_filter/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_filter.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_filter.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_filter-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_filter.8.xml" xpointer='xpointer(id("pam_filter-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_filter.8.xml" xpointer='xpointer(id("pam_filter-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_filter.8.xml" xpointer='xpointer(id("pam_filter-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_filter.8.xml" xpointer='xpointer(id("pam_filter-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_filter.8.xml" xpointer='xpointer(//refsect1[@id = "pam_filter-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_filter.8.xml" xpointer='xpointer(id("pam_filter-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_filter/pam_filter.8.xml
+++ b/modules/pam_filter/pam_filter.8.xml
@@ -1,45 +1,42 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_filter">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_filter">
 
   <refmeta>
     <refentrytitle>pam_filter</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_filter-name">
+  <refnamediv xml:id="pam_filter-name">
     <refname>pam_filter</refname>
     <refpurpose>PAM filter module</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_filter-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_filter-cmdsynopsis" sepchar=" ">
       <command>pam_filter.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         new_term
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         non_term
       </arg>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
         run1|run2
       </arg>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
         <replaceable>filter</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         <replaceable>...</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_filter-description">
+  <refsect1 xml:id="pam_filter-description">
 
     <title>DESCRIPTION</title>
 
@@ -66,7 +63,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_filter-options">
+  <refsect1 xml:id="pam_filter-options">
 
     <title>OPTIONS</title>
     <para>
@@ -74,7 +71,7 @@
 
         <varlistentry>
           <term>
-            <option>debug</option>
+            debug
           </term>
           <listitem>
             <para>
@@ -85,7 +82,7 @@
 
         <varlistentry>
           <term>
-            <option>new_term</option>
+            new_term
           </term>
           <listitem>
             <para>
@@ -101,7 +98,7 @@
 
         <varlistentry>
           <term>
-            <option>non_term</option>
+            non_term
           </term>
           <listitem>
             <para>
@@ -112,7 +109,7 @@
 
         <varlistentry>
           <term>
-            <option>runX</option>
+            runX
           </term>
           <listitem>
             <para>
@@ -174,7 +171,7 @@
 
         <varlistentry>
           <term>
-            <option>filter</option>
+            filter
           </term>
           <listitem>
             <para>
@@ -188,7 +185,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_filter-types">
+  <refsect1 xml:id="pam_filter-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -196,7 +193,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_filter-return_values'>
+  <refsect1 xml:id="pam_filter-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -223,7 +220,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_filter-examples'>
+  <refsect1 xml:id="pam_filter-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/login</filename> to
@@ -236,7 +233,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_filter-see_also'>
+  <refsect1 xml:id="pam_filter-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -251,7 +248,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_filter-author'>
+  <refsect1 xml:id="pam_filter-author">
     <title>AUTHOR</title>
       <para>
         pam_filter was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_ftp/README.xml
+++ b/modules/pam_ftp/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_ftp.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_ftp.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_ftp-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_ftp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_ftp-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_ftp.8.xml" xpointer='xpointer(id("pam_ftp-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_ftp/pam_ftp.8.xml
+++ b/modules/pam_ftp/pam_ftp.8.xml
@@ -1,36 +1,33 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_ftp">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_ftp">
 
   <refmeta>
     <refentrytitle>pam_ftp</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_ftp-name">
+  <refnamediv xml:id="pam_ftp-name">
     <refname>pam_ftp</refname>
     <refpurpose>PAM module for anonymous access module</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_ftp-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_ftp-cmdsynopsis" sepchar=" ">
       <command>pam_ftp.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ignore
       </arg>
-      <arg choice="opt" rep='repeat'>
+      <arg choice="opt" rep="repeat">
         users=<replaceable>XXX,YYY,</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_ftp-description">
+  <refsect1 xml:id="pam_ftp-description">
 
     <title>DESCRIPTION</title>
 
@@ -54,7 +51,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_ftp-options">
+  <refsect1 xml:id="pam_ftp-options">
 
     <title>OPTIONS</title>
     <para>
@@ -62,7 +59,7 @@
 
         <varlistentry>
           <term>
-            <option>debug</option>
+            debug
           </term>
           <listitem>
             <para>
@@ -73,7 +70,7 @@
 
         <varlistentry>
           <term>
-            <option>ignore</option>
+            ignore
           </term>
           <listitem>
             <para>
@@ -85,7 +82,7 @@
 
         <varlistentry>
           <term>
-            <option>ftp=<replaceable>XXX,YYY,...</replaceable></option>
+            ftp=XXX,YYY,...
           </term>
           <listitem>
             <para>
@@ -105,14 +102,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_ftp-types">
+  <refsect1 xml:id="pam_ftp-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>auth</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_ftp-return_values'>
+  <refsect1 xml:id="pam_ftp-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -139,7 +136,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_ftp-examples'>
+  <refsect1 xml:id="pam_ftp-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/ftpd</filename> to
@@ -158,7 +155,7 @@ auth    required    pam_listfile.so \
     </para>
   </refsect1>
 
-  <refsect1 id='pam_ftp-see_also'>
+  <refsect1 xml:id="pam_ftp-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -173,7 +170,7 @@ auth    required    pam_listfile.so \
     </para>
   </refsect1>
 
-  <refsect1 id='pam_ftp-author'>
+  <refsect1 xml:id="pam_ftp-author">
     <title>AUTHOR</title>
       <para>
         pam_ftp was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_group/README.xml
+++ b/modules/pam_group/README.xml
@@ -1,34 +1,19 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamgroup SYSTEM "pam_group.8.xml">
--->
-<!--
-<!ENTITY groupconf SYSTEM "group.conf.5.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_group.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_group-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_group.8.xml" xpointer='xpointer(id("pam_group-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_group.8.xml" xpointer='xpointer(//refsect1[@id = "pam_group-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_group.8.xml" xpointer='xpointer(id("pam_group-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="group.conf.5.xml" xpointer='xpointer(//refsect1[@id = "group.conf-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="group.conf.5.xml" xpointer='xpointer(id("group.conf-examples")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_group/group.conf.5.xml
+++ b/modules/pam_group/group.conf.5.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="group.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="group.conf">
 
   <refmeta>
     <refentrytitle>group.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -15,7 +12,7 @@
     <refpurpose>configuration file for the pam_group module</refpurpose>
   </refnamediv>
 
-  <refsect1 id='group.conf-description'>
+  <refsect1 xml:id="group.conf-description">
     <title>DESCRIPTION</title>
 
     <para>
@@ -98,7 +95,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="group.conf-examples">
+  <refsect1 xml:id="group.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -129,7 +126,7 @@ xsh; tty* ;%admin;Al0000-2400;plugdev
 
   </refsect1>
 
-  <refsect1 id="group.conf-see_also">
+  <refsect1 xml:id="group.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_group</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -138,7 +135,7 @@ xsh; tty* ;%admin;Al0000-2400;plugdev
     </para>
   </refsect1>
 
-  <refsect1 id="group.conf-author">
+  <refsect1 xml:id="group.conf-author">
     <title>AUTHOR</title>
     <para>
       pam_group was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_group/pam_group.8.xml
+++ b/modules/pam_group/pam_group.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_group'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_group">
 
   <refmeta>
     <refentrytitle>pam_group</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_group-name'>
+  <refnamediv xml:id="pam_group-name">
     <refname>pam_group</refname>
     <refpurpose>
       PAM module for group access
@@ -20,13 +17,13 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_group-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_group-cmdsynopsis" sepchar=" ">
       <command>pam_group.so</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_group-description">
+  <refsect1 xml:id="pam_group-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_group PAM module does not authenticate the user, but instead
@@ -64,19 +61,19 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_group-options">
+  <refsect1 xml:id="pam_group-options">
     <title>OPTIONS</title>
     <para>This module does not recognise any options.</para>
   </refsect1>
 
-  <refsect1 id="pam_group-types">
+  <refsect1 xml:id="pam_group-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>auth</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_group-return_values">
+  <refsect1 xml:id="pam_group-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -130,11 +127,11 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_group-files">
+  <refsect1 xml:id="pam_group-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/group.conf</filename></term>
+        <term>/etc/security/group.conf</term>
         <listitem>
           <para>Default configuration file</para>
         </listitem>
@@ -142,7 +139,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_group-see_also">
+  <refsect1 xml:id="pam_group-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -157,7 +154,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_group-authors">
+  <refsect1 xml:id="pam_group-authors">
     <title>AUTHORS</title>
     <para>
       pam_group was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_issue/README.xml
+++ b/modules/pam_issue/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_issue.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_issue.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_issue-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_issue.8.xml" xpointer='xpointer(id("pam_issue-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_issue.8.xml" xpointer='xpointer(id("pam_issue-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_issue.8.xml" xpointer='xpointer(id("pam_issue-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_issue.8.xml" xpointer='xpointer(id("pam_issue-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_issue.8.xml" xpointer='xpointer(//refsect1[@id = "pam_issue-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_issue.8.xml" xpointer='xpointer(id("pam_issue-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_issue/pam_issue.8.xml
+++ b/modules/pam_issue/pam_issue.8.xml
@@ -1,110 +1,107 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_issue">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_issue">
 
   <refmeta>
     <refentrytitle>pam_issue</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_issue-name">
+  <refnamediv xml:id="pam_issue-name">
     <refname>pam_issue</refname>
     <refpurpose>PAM module to add issue file to user prompt</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_issue-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_issue-cmdsynopsis" sepchar=" ">
       <command>pam_issue.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         noesc
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         issue=<replaceable>issue-file-name</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_issue-description">
+  <refsect1 xml:id="pam_issue-description">
 
     <title>DESCRIPTION</title>
 
     <para>
       pam_issue is a PAM module to prepend an issue file to the username
       prompt. It also by default parses escape codes in the issue file
-      similar to some common getty's (using &bsol;x format).
+      similar to some common getty's (using \x format).
     </para>
     <para>
       Recognized escapes:
     </para>
     <variablelist>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;d</emphasis></term>
+        <term>\d</term>
         <listitem>
           <para>current day</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;l</emphasis></term>
+        <term>\l</term>
         <listitem>
           <para>name of this tty</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;m</emphasis></term>
+        <term>\m</term>
         <listitem>
           <para>machine architecture (uname -m)</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;n</emphasis></term>
+        <term>\n</term>
         <listitem>
           <para>machine's network node hostname (uname -n)</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;o</emphasis></term>
+        <term>\o</term>
         <listitem>
           <para>domain name of this system</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;r</emphasis></term>
+        <term>\r</term>
         <listitem>
           <para>release number of operating system (uname -r)</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;t</emphasis></term>
+        <term>\t</term>
         <listitem>
           <para>current time</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;s</emphasis></term>
+        <term>\s</term>
         <listitem>
           <para>operating system name (uname -s)</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;u</emphasis></term>
+        <term>\u</term>
         <listitem>
           <para>number of users currently logged in</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;U</emphasis></term>
+        <term>\U</term>
         <listitem>
           <para>
-            same as &bsol;u except it is suffixed with "user" or
+            same as \u except it is suffixed with "user" or
             "users" (eg. "1 user" or "10 users")
           </para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><emphasis remap='B'>&bsol;v</emphasis></term>
+        <term>\v</term>
         <listitem>
           <para>operating system version and build date (uname -v)</para>
         </listitem>
@@ -113,7 +110,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_issue-options">
+  <refsect1 xml:id="pam_issue-options">
 
     <title>OPTIONS</title>
     <para>
@@ -121,7 +118,7 @@
 
         <varlistentry>
           <term>
-            <option>noesc</option>
+            noesc
           </term>
           <listitem>
             <para>
@@ -132,7 +129,7 @@
 
         <varlistentry>
           <term>
-            <option>issue=<replaceable>issue-file-name</replaceable></option>
+            issue=issue-file-name
           </term>
           <listitem>
             <para>
@@ -146,14 +143,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_issue-types">
+  <refsect1 xml:id="pam_issue-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>auth</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_issue-return_values'>
+  <refsect1 xml:id="pam_issue-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -198,7 +195,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_issue-examples'>
+  <refsect1 xml:id="pam_issue-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/login</filename> to
@@ -209,7 +206,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_issue-see_also'>
+  <refsect1 xml:id="pam_issue-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -224,7 +221,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_issue-author'>
+  <refsect1 xml:id="pam_issue-author">
     <title>AUTHOR</title>
       <para>
         pam_issue was written by Ben Collins &lt;bcollins@debian.org&gt;.

--- a/modules/pam_keyinit/README.xml
+++ b/modules/pam_keyinit/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_keyinit.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_keyinit.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_keyinit-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_keyinit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_keyinit-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_keyinit.8.xml" xpointer='xpointer(id("pam_keyinit-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_keyinit/pam_keyinit.8.xml
+++ b/modules/pam_keyinit/pam_keyinit.8.xml
@@ -1,36 +1,33 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_keyinit">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_keyinit">
 
   <refmeta>
     <refentrytitle>pam_keyinit</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_keyinit-name">
+  <refnamediv xml:id="pam_keyinit-name">
     <refname>pam_keyinit</refname>
     <refpurpose>Kernel session keyring initialiser module</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_keyinit-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_keyinit-cmdsynopsis" sepchar=" ">
       <command>pam_keyinit.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	force
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	revoke
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_keyinit-description">
+  <refsect1 xml:id="pam_keyinit-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_keyinit PAM module ensures that the invoking process has a
@@ -71,7 +68,7 @@
     </para>
     <para>
       This module should not, generally, be invoked by programs like
-      <emphasis remap='B'>su</emphasis>, since it is usually desirable for the
+      <emphasis remap="B">su</emphasis>, since it is usually desirable for the
       key set to percolate through to the alternate context.  The keys have
       their own permissions system to manage this.
     </para>
@@ -80,18 +77,18 @@
       can be obtained from:
     </para>
     <para>
-      <ulink url="http://people.redhat.com/~dhowells/keyutils/">
+      <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://people.redhat.com/~dhowells/keyutils/">
 	Keyutils
-      </ulink>
+      </link>
     </para>
   </refsect1>
 
-  <refsect1 id="pam_keyinit-options">
+  <refsect1 xml:id="pam_keyinit-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -104,7 +101,7 @@
 
       <varlistentry>
         <term>
-          <option>force</option>
+          force
         </term>
         <listitem>
           <para>
@@ -116,7 +113,7 @@
 
       <varlistentry>
         <term>
-          <option>revoke</option>
+          revoke
         </term>
         <listitem>
           <para>
@@ -130,14 +127,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_keyinit-types">
+  <refsect1 xml:id="pam_keyinit-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_keyinit-return_values'>
+  <refsect1 xml:id="pam_keyinit-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -207,7 +204,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_keyinit-examples'>
+  <refsect1 xml:id="pam_keyinit-examples">
     <title>EXAMPLES</title>
     <para>
       Add this line to your login entries to start each login session with its
@@ -222,7 +219,7 @@ session  required  pam_keyinit.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_keyinit-see_also'>
+  <refsect1 xml:id="pam_keyinit-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -240,7 +237,7 @@ session  required  pam_keyinit.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_keyinit-author'>
+  <refsect1 xml:id="pam_keyinit-author">
     <title>AUTHOR</title>
       <para>
         pam_keyinit was written by David Howells, &lt;dhowells@redhat.com&gt;.

--- a/modules/pam_lastlog/README.xml
+++ b/modules/pam_lastlog/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_lastlog.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_lastlog.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_lastlog-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_lastlog.8.xml" xpointer='xpointer(//refsect1[@id = "pam_lastlog-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_lastlog.8.xml" xpointer='xpointer(id("pam_lastlog-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_lastlog/pam_lastlog.8.xml
+++ b/modules/pam_lastlog/pam_lastlog.8.xml
@@ -1,60 +1,57 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_lastlog">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_lastlog">
 
   <refmeta>
     <refentrytitle>pam_lastlog</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_lastlog-name">
+  <refnamediv xml:id="pam_lastlog-name">
     <refname>pam_lastlog</refname>
     <refpurpose>PAM module to display date of last login and perform inactive account lock out</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_lastlog-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_lastlog-cmdsynopsis" sepchar=" ">
       <command>pam_lastlog.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         silent
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         never
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         nodate
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         nohost
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         noterm
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         nowtmp
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         noupdate
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         showfailed
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         inactive=&lt;days&gt;
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         unlimited
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_lastlog-description">
+  <refsect1 xml:id="pam_lastlog-description">
 
     <title>DESCRIPTION</title>
 
@@ -83,13 +80,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_lastlog-options">
+  <refsect1 xml:id="pam_lastlog-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -99,7 +96,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>silent</option>
+          silent
         </term>
         <listitem>
           <para>
@@ -111,7 +108,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>never</option>
+          never
         </term>
         <listitem>
           <para>
@@ -124,7 +121,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nodate</option>
+          nodate
         </term>
         <listitem>
           <para>
@@ -134,7 +131,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>noterm</option>
+          noterm
         </term>
         <listitem>
           <para>
@@ -145,7 +142,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nohost</option>
+          nohost
         </term>
         <listitem>
           <para>
@@ -156,7 +153,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nowtmp</option>
+          nowtmp
         </term>
         <listitem>
           <para>
@@ -166,7 +163,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>noupdate</option>
+          noupdate
         </term>
         <listitem>
           <para>
@@ -176,7 +173,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>showfailed</option>
+          showfailed
         </term>
         <listitem>
           <para>
@@ -188,7 +185,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>inactive=&lt;days&gt;</option>
+          inactive=&lt;days&gt;
         </term>
         <listitem>
           <para>
@@ -201,7 +198,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>unlimited</option>
+          unlimited
         </term>
         <listitem>
           <para>
@@ -214,7 +211,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_lastlog-types">
+  <refsect1 xml:id="pam_lastlog-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option> module type
@@ -225,7 +222,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_lastlog-return_values'>
+  <refsect1 xml:id="pam_lastlog-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -282,7 +279,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_lastlog-examples'>
+  <refsect1 xml:id="pam_lastlog-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/login</filename> to
@@ -300,11 +297,11 @@
       </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_lastlog-files">
+  <refsect1 xml:id="pam_lastlog-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/var/log/lastlog</filename></term>
+        <term>/var/log/lastlog</term>
         <listitem>
           <para>Lastlog logging file</para>
         </listitem>
@@ -312,7 +309,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_lastlog-see_also'>
+  <refsect1 xml:id="pam_lastlog-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -330,7 +327,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_lastlog-author'>
+  <refsect1 xml:id="pam_lastlog-author">
     <title>AUTHOR</title>
       <para>
         pam_lastlog was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_limits/README.xml
+++ b/modules/pam_limits/README.xml
@@ -1,39 +1,23 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamlimits SYSTEM "pam_limits.8.xml">
--->
-<!--
-<!ENTITY limitsconf SYSTEM "limits.conf.5.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_limits.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_limits-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_limits.8.xml" xpointer='xpointer(id("pam_limits-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_limits.8.xml" xpointer='xpointer(id("pam_limits-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_limits.8.xml" xpointer='xpointer(//refsect1[@id = "pam_limits-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_limits.8.xml" xpointer='xpointer(id("pam_limits-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="limits.conf.5.xml" xpointer='xpointer(//refsect1[@id = "limits.conf-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="limits.conf.5.xml" xpointer='xpointer(id("limits.conf-examples")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_limits/limits.conf.5.xml
+++ b/modules/pam_limits/limits.conf.5.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="limits.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="limits.conf">
 
   <refmeta>
     <refentrytitle>limits.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -15,7 +12,7 @@
     <refpurpose>configuration file for the pam_limits module</refpurpose>
   </refnamediv>
 
-  <refsect1 id='limits.conf-description'>
+  <refsect1 xml:id="limits.conf-description">
     <title>DESCRIPTION</title>
     <para>
       The <emphasis>pam_limits.so</emphasis> module applies ulimit limits,
@@ -38,7 +35,7 @@
     <variablelist>
       <varlistentry>
         <term>
-          <option>&lt;domain&gt;</option>
+          &lt;domain&gt;
         </term>
         <listitem>
           <itemizedlist>
@@ -49,38 +46,35 @@
             </listitem>
             <listitem>
               <para>
-                a groupname, with <emphasis remap='B'>@group</emphasis> syntax.
+                a groupname, with <emphasis remap="B">@group</emphasis> syntax.
                 This should not be confused with netgroups.
               </para>
             </listitem>
             <listitem>
               <para>
-                the wildcard <emphasis remap='B'>*</emphasis>, for default entry.
+                the wildcard <emphasis remap="B">*</emphasis>, for default entry.
               </para>
             </listitem>
             <listitem>
               <para>
-                the wildcard <emphasis remap='B'>%</emphasis>, for maxlogins limit only,
-                can also be used with <emphasis remap='B'>%group</emphasis> syntax. If the
-                <emphasis remap='B'>%</emphasis> wildcard is used alone it is identical
-                to using <emphasis remap='B'>*</emphasis> with maxsyslogins limit. With
-                a group specified after <emphasis remap='B'>%</emphasis> it limits the total
+                the wildcard <emphasis remap="B">%</emphasis>, for maxlogins limit only,
+                can also be used with <emphasis remap="B">%group</emphasis> syntax. If the
+                <emphasis remap="B">%</emphasis> wildcard is used alone it is identical
+                to using <emphasis remap="B">*</emphasis> with maxsyslogins limit. With
+                a group specified after <emphasis remap="B">%</emphasis> it limits the total
                 number of logins of all users that are member of the group.
               </para>
             </listitem>
             <listitem>
               <para>
-                an uid range specified as <replaceable>&lt;min_uid&gt;</replaceable><emphasis
-                remap='B'>:</emphasis><replaceable>&lt;max_uid&gt;</replaceable>. If min_uid
+                an uid range specified as <replaceable>&lt;min_uid&gt;</replaceable><emphasis remap="B">:</emphasis><replaceable>&lt;max_uid&gt;</replaceable>. If min_uid
                 is omitted, the match is exact for the max_uid. If max_uid is omitted, all
                 uids greater than or equal min_uid match.
               </para>
             </listitem>
             <listitem>
               <para>
-                a gid range specified as <emphasis
-                remap='B'>@</emphasis><replaceable>&lt;min_gid&gt;</replaceable><emphasis
-                remap='B'>:</emphasis><replaceable>&lt;max_gid&gt;</replaceable>. If min_gid
+                a gid range specified as <emphasis remap="B">@</emphasis><replaceable>&lt;min_gid&gt;</replaceable><emphasis remap="B">:</emphasis><replaceable>&lt;max_gid&gt;</replaceable>. If min_gid
                 is omitted, the match is exact for the max_gid. If max_gid is omitted, all
                 gids greater than or equal min_gid match. For the exact match all groups including
                 the user's supplementary groups are examined. For the range matches only
@@ -89,8 +83,7 @@
             </listitem>
             <listitem>
               <para>
-                a gid specified as <emphasis
-                remap='B'>%:</emphasis><replaceable>&lt;gid&gt;</replaceable> applicable
+                a gid specified as <emphasis remap="B">%:</emphasis><replaceable>&lt;gid&gt;</replaceable> applicable
                 to maxlogins limit only. It limits the total number of logins of all users
                 that are member of the group with the specified gid.
               </para>
@@ -101,38 +94,38 @@
 
       <varlistentry>
         <term>
-          <option>&lt;type&gt;</option>
+          &lt;type&gt;
         </term>
         <listitem>
           <variablelist>
             <varlistentry>
-              <term><option>hard</option></term>
+              <term>hard</term>
               <listitem>
                 <para>
-                  for enforcing <emphasis remap='B'>hard</emphasis> resource limits.
+                  for enforcing <emphasis remap="B">hard</emphasis> resource limits.
                   These limits are set by the superuser and enforced by the Kernel.
                   The user cannot raise his requirement of system resources above such values.
                 </para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>soft</option></term>
+              <term>soft</term>
               <listitem>
                 <para>
-                  for enforcing <emphasis remap='B'>soft</emphasis> resource limits.
+                  for enforcing <emphasis remap="B">soft</emphasis> resource limits.
                   These limits are ones that the user can move up or down within the
-                  permitted range by any pre-existing <emphasis remap='B'>hard</emphasis>
+                  permitted range by any pre-existing <emphasis remap="B">hard</emphasis>
                   limits. The values specified with this token can be thought of as
                   <emphasis>default</emphasis> values, for normal system usage.
                 </para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>-</option></term>
+              <term>-</term>
               <listitem>
                 <para>
-                  for enforcing both <emphasis remap='B'>soft</emphasis> and
-                  <emphasis remap='B'>hard</emphasis> resource limits together.
+                  for enforcing both <emphasis remap="B">soft</emphasis> and
+                  <emphasis remap="B">hard</emphasis> resource limits together.
                 </para>
                 <para>
                   Note, if you specify a type of '-' but neglect to supply the
@@ -147,79 +140,79 @@
 
       <varlistentry>
         <term>
-          <option>&lt;item&gt;</option>
+          &lt;item&gt;
         </term>
         <listitem>
           <variablelist>
             <varlistentry>
-              <term><option>core</option></term>
+              <term>core</term>
               <listitem>
                 <para>limits the core file size (KB)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>data</option></term>
+              <term>data</term>
               <listitem>
                 <para>maximum data size (KB)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>fsize</option></term>
+              <term>fsize</term>
               <listitem>
                 <para>maximum filesize (KB)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>memlock</option></term>
+              <term>memlock</term>
               <listitem>
                 <para>maximum locked-in-memory address space (KB)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>nofile</option></term>
+              <term>nofile</term>
               <listitem>
                 <para>maximum number of open file descriptors</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>rss</option></term>
+              <term>rss</term>
               <listitem>
                 <para>maximum resident set size (KB) (Ignored in Linux 2.4.30 and higher)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>stack</option></term>
+              <term>stack</term>
               <listitem>
                 <para>maximum stack size (KB)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>cpu</option></term>
+              <term>cpu</term>
               <listitem>
                 <para>maximum CPU time (minutes)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>nproc</option></term>
+              <term>nproc</term>
               <listitem>
                 <para>maximum number of processes</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>as</option></term>
+              <term>as</term>
               <listitem>
                 <para>address space limit (KB)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>maxlogins</option></term>
+              <term>maxlogins</term>
               <listitem>
                 <para>maximum number of logins for this user (this limit does
                   not apply to user with <emphasis>uid=0</emphasis>)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>maxsyslogins</option></term>
+              <term>maxsyslogins</term>
               <listitem>
                 <para>maximum number of all logins on system; user is not
                   allowed to log-in if total number of all user logins is
@@ -228,46 +221,46 @@
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>nonewprivs</option></term>
+              <term>nonewprivs</term>
               <listitem>
                 <para>value of 0 or 1; if set to 1 disables acquiring new
                   privileges by invoking prctl(PR_SET_NO_NEW_PRIVS)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>priority</option></term>
+              <term>priority</term>
               <listitem>
                 <para>the priority to run user process with (negative
                   values boost process priority)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>locks</option></term>
+              <term>locks</term>
               <listitem>
                 <para>maximum locked files (Linux 2.4 and higher)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>sigpending</option></term>
+              <term>sigpending</term>
               <listitem>
                 <para>maximum number of pending signals (Linux 2.6 and higher)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>msgqueue</option></term>
+              <term>msgqueue</term>
               <listitem>
                 <para>maximum memory used by POSIX message queues (bytes)
                   (Linux 2.6 and higher)</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>nice</option></term>
+              <term>nice</term>
               <listitem>
                 <para>maximum nice priority allowed to raise to (Linux 2.6.12 and higher) values: [-20,19]</para>
               </listitem>
             </varlistentry>
             <varlistentry>
-              <term><option>rtprio</option></term>
+              <term>rtprio</term>
               <listitem>
                 <para>maximum realtime priority allowed for non-privileged processes
                   (Linux 2.6.12 and higher)</para>
@@ -281,9 +274,9 @@
     <para>
       All items support the values <emphasis>-1</emphasis>,
       <emphasis>unlimited</emphasis> or <emphasis>infinity</emphasis> indicating no limit,
-      except for <emphasis remap='B'>priority</emphasis>, <emphasis remap='B'>nice</emphasis>,
-      and <emphasis remap='B'>nonewprivs</emphasis>.
-      If <emphasis remap='B'>nofile</emphasis> is to be set to one of these values,
+      except for <emphasis remap="B">priority</emphasis>, <emphasis remap="B">nice</emphasis>,
+      and <emphasis remap="B">nonewprivs</emphasis>.
+      If <emphasis remap="B">nofile</emphasis> is to be set to one of these values,
       it will be set to the contents of /proc/sys/fs/nr_open instead (see setrlimit(3)).
     </para>
     <para>
@@ -309,7 +302,7 @@
     </para>
     <para>
       In the <emphasis>limits</emphasis> configuration file, the
-      '<emphasis remap='B'>#</emphasis>' character introduces a comment
+      '<emphasis remap="B">#</emphasis>' character introduces a comment
       - after which the rest of the line is ignored.
     </para>
     <para>
@@ -319,7 +312,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="limits.conf-examples">
+  <refsect1 xml:id="limits.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -340,7 +333,7 @@ ftp             hard    nproc           0
     </programlisting>
   </refsect1>
 
-  <refsect1 id="limits.conf-see_also">
+  <refsect1 xml:id="limits.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_limits</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -351,7 +344,7 @@ ftp             hard    nproc           0
     </para>
   </refsect1>
 
-  <refsect1 id="limits.conf-author">
+  <refsect1 xml:id="limits.conf-author">
     <title>AUTHOR</title>
     <para>
       pam_limits was initially written by Cristian Gafton &lt;gafton@redhat.com&gt;

--- a/modules/pam_limits/pam_limits.8.xml
+++ b/modules/pam_limits/pam_limits.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_limits'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_limits">
 
   <refmeta>
     <refentrytitle>pam_limits</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_limits-name'>
+  <refnamediv xml:id="pam_limits-name">
     <refname>pam_limits</refname>
     <refpurpose>
       PAM module to limit resources
@@ -20,28 +17,28 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_limits-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_limits-cmdsynopsis" sepchar=" ">
       <command>pam_limits.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         conf=<replaceable>/path/to/limits.conf</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         set_all
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         utmp_early
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         noaudit
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_limits-description">
+  <refsect1 xml:id="pam_limits-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_limits PAM module sets limits on the system resources that can be
@@ -84,12 +81,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_limits-options">
+  <refsect1 xml:id="pam_limits-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>conf=<replaceable>/path/to/limits.conf</replaceable></option>
+          conf=/path/to/limits.conf
         </term>
         <listitem>
           <para>
@@ -100,7 +97,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -110,7 +107,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>set_all</option>
+          set_all
         </term>
         <listitem>
           <para>
@@ -124,7 +121,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>utmp_early</option>
+          utmp_early
         </term>
         <listitem>
           <para>
@@ -139,7 +136,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>noaudit</option>
+          noaudit
         </term>
         <listitem>
           <para>
@@ -150,14 +147,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_limits-types">
+  <refsect1 xml:id="pam_limits-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_limits-return_values">
+  <refsect1 xml:id="pam_limits-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -219,17 +216,17 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_limits-files">
+  <refsect1 xml:id="pam_limits-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/limits.conf</filename></term>
+        <term>/etc/security/limits.conf</term>
         <listitem>
           <para>Default configuration file</para>
         </listitem>
       </varlistentry>
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/security/limits.conf</filename></term>
+        <term>%vendordir%/security/limits.conf</term>
         <listitem>
           <para>Default configuration file if
 	  <filename>/etc/security/limits.conf</filename> does not exist.</para>
@@ -238,7 +235,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_limits-examples'>
+  <refsect1 xml:id="pam_limits-examples">
     <title>EXAMPLES</title>
     <para>
       For the services you need resources limits (login for example) put a
@@ -257,7 +254,7 @@ session  required  pam_limits.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_limits-see_also">
+  <refsect1 xml:id="pam_limits-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -272,7 +269,7 @@ session  required  pam_limits.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_limits-authors">
+  <refsect1 xml:id="pam_limits-authors">
     <title>AUTHORS</title>
     <para>
       pam_limits was initially written by Cristian Gafton &lt;gafton@redhat.com&gt;

--- a/modules/pam_listfile/README.xml
+++ b/modules/pam_listfile/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_listfile.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_listfile.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_listfile-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_listfile.8.xml" xpointer='xpointer(//refsect1[@id = "pam_listfile-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_listfile.8.xml" xpointer='xpointer(id("pam_listfile-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_listfile/pam_listfile.8.xml
+++ b/modules/pam_listfile/pam_listfile.8.xml
@@ -1,45 +1,42 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_listfile">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_listfile">
 
   <refmeta>
     <refentrytitle>pam_listfile</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_listfile-name">
+  <refnamediv xml:id="pam_listfile-name">
     <refname>pam_listfile</refname>
     <refpurpose>deny or allow services based on an arbitrary file</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_listfile-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_listfile-cmdsynopsis" sepchar=" ">
       <command>pam_listfile.so</command>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
 	item=[tty|user|rhost|ruser|group|shell]
       </arg>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
         sense=[allow|deny]
       </arg>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
         file=<replaceable>/path/filename</replaceable>
       </arg>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
         onerr=[succeed|fail]
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         apply=[<replaceable>user</replaceable>|<replaceable>@group</replaceable>]
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         quiet
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_listfile-description">
+  <refsect1 xml:id="pam_listfile-description">
 
     <title>DESCRIPTION</title>
 
@@ -93,7 +90,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_listfile-options">
+  <refsect1 xml:id="pam_listfile-options">
 
     <title>OPTIONS</title>
     <para>
@@ -101,7 +98,7 @@
 
         <varlistentry>
           <term>
-            <option>item=[tty|user|rhost|ruser|group|shell]</option>
+            item=[tty|user|rhost|ruser|group|shell]
           </term>
           <listitem>
             <para>
@@ -112,7 +109,7 @@
 
         <varlistentry>
           <term>
-            <option>sense=[allow|deny]</option>
+            sense=[allow|deny]
           </term>
           <listitem>
             <para>
@@ -124,7 +121,7 @@
 
         <varlistentry>
           <term>
-            <option>file=<replaceable>/path/filename</replaceable></option>
+            file=/path/filename
           </term>
           <listitem>
             <para>
@@ -136,7 +133,7 @@
 
         <varlistentry>
           <term>
-            <option>onerr=[succeed|fail]</option>
+            onerr=[succeed|fail]
           </term>
           <listitem>
             <para>
@@ -148,7 +145,7 @@
 
         <varlistentry>
           <term>
-            <option>apply=[<replaceable>user</replaceable>|<replaceable>@group</replaceable>]</option>
+            apply=[user|@group]
           </term>
           <listitem>
             <para>
@@ -161,7 +158,7 @@
 
         <varlistentry>
           <term>
-            <option>quiet</option>
+            quiet
           </term>
           <listitem>
             <para>
@@ -175,7 +172,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_listfile-types">
+  <refsect1 xml:id="pam_listfile-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -183,7 +180,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_listfile-return_values'>
+  <refsect1 xml:id="pam_listfile-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -235,7 +232,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_listfile-examples'>
+  <refsect1 xml:id="pam_listfile-examples">
     <title>EXAMPLES</title>
     <para>
       Classic 'ftpusers' authentication can be implemented with this entry
@@ -271,7 +268,7 @@ auth    required       pam_listfile.so \
     </para>
   </refsect1>
 
-  <refsect1 id='pam_listfile-see_also'>
+  <refsect1 xml:id="pam_listfile-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -286,7 +283,7 @@ auth    required       pam_listfile.so \
     </para>
   </refsect1>
 
-  <refsect1 id='pam_listfile-author'>
+  <refsect1 xml:id="pam_listfile-author">
     <title>AUTHOR</title>
       <para>
         pam_listfile was written by Michael K. Johnson &lt;johnsonm@redhat.com&gt;

--- a/modules/pam_localuser/README.xml
+++ b/modules/pam_localuser/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_localuser.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_localuser.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_localuser-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_localuser.8.xml" xpointer='xpointer(//refsect1[@id = "pam_localuser-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_localuser.8.xml" xpointer='xpointer(id("pam_localuser-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_localuser/pam_localuser.8.xml
+++ b/modules/pam_localuser/pam_localuser.8.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_localuser">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_localuser">
 
   <refmeta>
     <refentrytitle>pam_localuser</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_localuser-name">
+  <refnamediv xml:id="pam_localuser-name">
     <refname>pam_localuser</refname>
     <refpurpose>require users to be listed in /etc/passwd</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_localuser-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_localuser-cmdsynopsis" sepchar=" ">
       <command>pam_localuser.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         file=<replaceable>/path/passwd</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_localuser-description">
+  <refsect1 xml:id="pam_localuser-description">
 
     <title>DESCRIPTION</title>
 
@@ -47,7 +44,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_localuser-options">
+  <refsect1 xml:id="pam_localuser-options">
 
     <title>OPTIONS</title>
     <para>
@@ -55,7 +52,7 @@
 
         <varlistentry>
           <term>
-            <option>debug</option>
+            debug
           </term>
           <listitem>
             <para>
@@ -66,7 +63,7 @@
 
         <varlistentry>
           <term>
-            <option>file=<replaceable>/path/passwd</replaceable></option>
+            file=/path/passwd
           </term>
           <listitem>
             <para>
@@ -80,7 +77,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_localuser-types">
+  <refsect1 xml:id="pam_localuser-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>account</option>, <option>auth</option>,
@@ -88,7 +85,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_localuser-return_values'>
+  <refsect1 xml:id="pam_localuser-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -153,7 +150,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_localuser-examples'>
+  <refsect1 xml:id="pam_localuser-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following lines to <filename>/etc/pam.d/su</filename> to
@@ -165,11 +162,11 @@ account required pam_wheel.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_localuser-files">
+  <refsect1 xml:id="pam_localuser-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/passwd</filename></term>
+        <term>/etc/passwd</term>
         <listitem>
           <para>Local user account information.</para>
         </listitem>
@@ -177,7 +174,7 @@ account required pam_wheel.so
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_localuser-see_also'>
+  <refsect1 xml:id="pam_localuser-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -192,7 +189,7 @@ account required pam_wheel.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_localuser-author'>
+  <refsect1 xml:id="pam_localuser-author">
     <title>AUTHOR</title>
       <para>
         pam_localuser was written by Nalin Dahyabhai &lt;nalin@redhat.com&gt;.

--- a/modules/pam_loginuid/README.xml
+++ b/modules/pam_loginuid/README.xml
@@ -1,36 +1,23 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_loginuid.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_loginuid.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_loginuid-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_loginuid.8.xml" xpointer='xpointer(//refsect1[@id = "pam_loginuid-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_loginuid.8.xml" xpointer='xpointer(id("pam_loginuid-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_loginuid/pam_loginuid.8.xml
+++ b/modules/pam_loginuid/pam_loginuid.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_loginuid">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_loginuid">
 
   <refmeta>
     <refentrytitle>pam_loginuid</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_loginuid-name">
+  <refnamediv xml:id="pam_loginuid-name">
     <refname>pam_loginuid</refname>
     <refpurpose>Record user's login uid to the process attribute</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_loginuid-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_loginuid-cmdsynopsis" sepchar=" ">
       <command>pam_loginuid.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         require_auditd
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_loginuid-description">
+  <refsect1 xml:id="pam_loginuid-description">
 
     <title>DESCRIPTION</title>
 
@@ -40,12 +37,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_loginuid-options">
+  <refsect1 xml:id="pam_loginuid-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>require_auditd</option>
+          require_auditd
         </term>
         <listitem>
           <para>
@@ -57,14 +54,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_loginuid-types">
+  <refsect1 xml:id="pam_loginuid-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_loginuid-return_values'>
+  <refsect1 xml:id="pam_loginuid-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -98,7 +95,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_loginuid-examples'>
+  <refsect1 xml:id="pam_loginuid-examples">
     <title>EXAMPLES</title>
     <programlisting>
 #%PAM-1.0
@@ -111,7 +108,7 @@ session    required     pam_loginuid.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_loginuid-see_also'>
+  <refsect1 xml:id="pam_loginuid-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -132,7 +129,7 @@ session    required     pam_loginuid.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_loginuid-author'>
+  <refsect1 xml:id="pam_loginuid-author">
     <title>AUTHOR</title>
       <para>
         pam_loginuid was written by Steve Grubb &lt;sgrubb@redhat.com&gt;

--- a/modules/pam_mail/README.xml
+++ b/modules/pam_mail/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_mail.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mail.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_mail-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mail.8.xml" xpointer='xpointer(id("pam_mail-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mail.8.xml" xpointer='xpointer(id("pam_mail-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mail.8.xml" xpointer='xpointer(id("pam_mail-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mail.8.xml" xpointer='xpointer(id("pam_mail-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mail.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mail-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mail.8.xml" xpointer='xpointer(id("pam_mail-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_mail/pam_mail.8.xml
+++ b/modules/pam_mail/pam_mail.8.xml
@@ -1,54 +1,51 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_mail">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_mail">
 
   <refmeta>
     <refentrytitle>pam_mail</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_mail-name">
+  <refnamediv xml:id="pam_mail-name">
     <refname>pam_mail</refname>
     <refpurpose>Inform about available mail</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_mail-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_mail-cmdsynopsis" sepchar=" ">
       <command>pam_mail.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	close
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         dir=<replaceable>maildir</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	empty
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	hash=<replaceable>count</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	noenv
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	nopen
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	quiet
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	standard
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_mail-description">
+  <refsect1 xml:id="pam_mail-description">
 
     <title>DESCRIPTION</title>
 
@@ -58,18 +55,18 @@
       that has credential or session hooks. It gives a single message
       indicating the <emphasis>newness</emphasis> of any mail it finds
       in the user's mail folder. This module also sets the PAM
-      environment variable, <emphasis remap='B'>MAIL</emphasis>, to the
+      environment variable, <emphasis remap="B">MAIL</emphasis>, to the
       user's mail directory.
     </para>
     <para>
       If the mail spool file (be it <filename>/var/mail/$USER</filename>
       or a pathname given with the <option>dir=</option> parameter) is
       a directory then pam_mail assumes it is in the
-      <emphasis remap='I'>Maildir</emphasis> format.
+      <emphasis remap="I">Maildir</emphasis> format.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_mail-options">
+  <refsect1 xml:id="pam_mail-options">
 
     <title>OPTIONS</title>
     <para>
@@ -77,7 +74,7 @@
 
         <varlistentry>
           <term>
-            <option>close</option>
+            close
           </term>
           <listitem>
             <para>
@@ -88,7 +85,7 @@
 
         <varlistentry>
           <term>
-            <option>debug</option>
+            debug
           </term>
           <listitem>
             <para>
@@ -99,7 +96,7 @@
 
         <varlistentry>
           <term>
-            <option>dir=<replaceable>maildir</replaceable></option>
+            dir=maildir
           </term>
           <listitem>
             <para>
@@ -116,7 +113,7 @@
 
         <varlistentry>
           <term>
-            <option>empty</option>
+            empty
           </term>
           <listitem>
             <para>
@@ -127,7 +124,7 @@
 
         <varlistentry>
           <term>
-            <option>hash=<replaceable>count</replaceable></option>
+            hash=count
           </term>
           <listitem>
             <para>
@@ -141,11 +138,11 @@
 
         <varlistentry>
           <term>
-            <option>noenv</option>
+            noenv
           </term>
           <listitem>
             <para>
-	      Do not set the <emphasis remap='B'>MAIL</emphasis>
+	      Do not set the <emphasis remap="B">MAIL</emphasis>
               environment variable.
             </para>
           </listitem>
@@ -153,12 +150,12 @@
 
         <varlistentry>
           <term>
-            <option>nopen</option>
+            nopen
           </term>
           <listitem>
             <para>
 	      Don't print any mail information on login. This flag is
-              useful to get the <emphasis remap='B'>MAIL</emphasis>
+              useful to get the <emphasis remap="B">MAIL</emphasis>
               environment variable set, but to not display any information
               about it.
             </para>
@@ -167,7 +164,7 @@
 
         <varlistentry>
           <term>
-            <option>quiet</option>
+            quiet
           </term>
           <listitem>
             <para>
@@ -178,7 +175,7 @@
 
         <varlistentry>
           <term>
-            <option>standard</option>
+            standard
           </term>
           <listitem>
             <para>
@@ -193,7 +190,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_mail-types">
+  <refsect1 xml:id="pam_mail-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>session</option> and
@@ -202,7 +199,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_mail-return_values'>
+  <refsect1 xml:id="pam_mail-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -244,7 +241,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_mail-examples'>
+  <refsect1 xml:id="pam_mail-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/login</filename> to
@@ -255,7 +252,7 @@ session  optional  pam_mail.so standard
     </para>
   </refsect1>
 
-  <refsect1 id='pam_mail-see_also'>
+  <refsect1 xml:id="pam_mail-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -270,7 +267,7 @@ session  optional  pam_mail.so standard
     </para>
   </refsect1>
 
-  <refsect1 id='pam_mail-author'>
+  <refsect1 xml:id="pam_mail-author">
     <title>AUTHOR</title>
       <para>
         pam_mail was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_mkhomedir/README.xml
+++ b/modules/pam_mkhomedir/README.xml
@@ -1,36 +1,23 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_mkhomedir.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mkhomedir.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_mkhomedir-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_mkhomedir.8.xml" xpointer='xpointer(//refsect1[@id = "pam_mkhomedir-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_mkhomedir.8.xml" xpointer='xpointer(id("pam_mkhomedir-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_mkhomedir/mkhomedir_helper.8.xml
+++ b/modules/pam_mkhomedir/mkhomedir_helper.8.xml
@@ -1,31 +1,28 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="mkhomedir_helper">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="mkhomedir_helper">
 
   <refmeta>
     <refentrytitle>mkhomedir_helper</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="mkhomedir_helper-name">
+  <refnamediv xml:id="mkhomedir_helper-name">
     <refname>mkhomedir_helper</refname>
     <refpurpose>Helper binary that creates home directories</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="mkhomedir_helper-cmdsynopsis">
+    <cmdsynopsis xml:id="mkhomedir_helper-cmdsynopsis" sepchar=" ">
       <command>mkhomedir_helper</command>
-      <arg choice="req">
+      <arg choice="req" rep="norepeat">
         <replaceable>user</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         <replaceable>umask</replaceable>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         <replaceable>path-to-skel</replaceable>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         <replaceable>home_mode</replaceable>
       </arg>
       </arg>
@@ -33,7 +30,7 @@
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="mkhomedir_helper-description">
+  <refsect1 xml:id="mkhomedir_helper-description">
 
     <title>DESCRIPTION</title>
 
@@ -63,7 +60,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='mkhomedir_helper-see_also'>
+  <refsect1 xml:id="mkhomedir_helper-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -72,7 +69,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='mkhomedir_helper-author'>
+  <refsect1 xml:id="mkhomedir_helper-author">
     <title>AUTHOR</title>
       <para>
         Written by Tomas Mraz based on the code originally in

--- a/modules/pam_mkhomedir/pam_mkhomedir.8.xml
+++ b/modules/pam_mkhomedir/pam_mkhomedir.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_mkhomedir'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_mkhomedir">
 
   <refmeta>
     <refentrytitle>pam_mkhomedir</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_mkhomedir-name'>
+  <refnamediv xml:id="pam_mkhomedir-name">
     <refname>pam_mkhomedir</refname>
     <refpurpose>
       PAM module to create users home directory
@@ -20,25 +17,25 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_mkhomedir-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_mkhomedir-cmdsynopsis" sepchar=" ">
       <command>pam_mkhomedir.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         silent
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         umask=<replaceable>mode</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         skel=<replaceable>skeldir</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_mkhomedir-description">
+  <refsect1 xml:id="pam_mkhomedir-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_mkhomedir PAM module will create a users home directory
@@ -55,13 +52,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_mkhomedir-options">
+  <refsect1 xml:id="pam_mkhomedir-options">
     <title>OPTIONS</title>
     <variablelist>
 
       <varlistentry>
         <term>
-          <option>silent</option>
+          silent
         </term>
         <listitem>
           <para>
@@ -72,7 +69,7 @@
 
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -86,7 +83,7 @@
 
       <varlistentry>
         <term>
-          <option>umask=<replaceable>mask</replaceable></option>
+          umask=mask
         </term>
         <listitem>
           <para>
@@ -106,7 +103,7 @@
 
       <varlistentry>
         <term>
-          <option>skel=<replaceable>/path/to/skel/directory</replaceable></option>
+          skel=/path/to/skel/directory
         </term>
         <listitem>
           <para>
@@ -119,14 +116,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_mkhomedir-types">
+  <refsect1 xml:id="pam_mkhomedir-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_mkhomedir-return_values">
+  <refsect1 xml:id="pam_mkhomedir-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -165,11 +162,11 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_mkhomedir-files">
+  <refsect1 xml:id="pam_mkhomedir-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/skel</filename></term>
+        <term>/etc/skel</term>
         <listitem>
           <para>Default skel directory</para>
         </listitem>
@@ -177,7 +174,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_mkhomedir-examples'>
+  <refsect1 xml:id="pam_mkhomedir-examples">
     <title>EXAMPLES</title>
     <para>
       A sample /etc/pam.d/login file:
@@ -198,7 +195,7 @@
   </refsect1>
 
 
-  <refsect1 id="pam_mkhomedir-see_also">
+  <refsect1 xml:id="pam_mkhomedir-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -210,7 +207,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_mkhomedir-author">
+  <refsect1 xml:id="pam_mkhomedir-author">
     <title>AUTHOR</title>
     <para>
       pam_mkhomedir was written by Jason Gunthorpe &lt;jgg@debian.org&gt;.

--- a/modules/pam_motd/README.xml
+++ b/modules/pam_motd/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_motd.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_motd.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_motd-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_motd.8.xml" xpointer='xpointer(id("pam_motd-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_motd.8.xml" xpointer='xpointer(id("pam_motd-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_motd.8.xml" xpointer='xpointer(id("pam_motd-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_motd.8.xml" xpointer='xpointer(id("pam_motd-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_motd.8.xml" xpointer='xpointer(//refsect1[@id = "pam_motd-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_motd.8.xml" xpointer='xpointer(id("pam_motd-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_motd/pam_motd.8.xml
+++ b/modules/pam_motd/pam_motd.8.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_motd">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_motd">
 
   <refmeta>
     <refentrytitle>pam_motd</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_motd-name">
+  <refnamediv xml:id="pam_motd-name">
     <refname>pam_motd</refname>
     <refpurpose>Display the motd file</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_motd-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_motd-cmdsynopsis" sepchar=" ">
       <command>pam_motd.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         motd=<replaceable>/path/filename</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         motd_dir=<replaceable>/path/dirname.d</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_motd-description">
+  <refsect1 xml:id="pam_motd-description">
 
     <title>DESCRIPTION</title>
 
@@ -38,7 +35,7 @@
       following locations:
     </para>
     <para>
-      <simplelist type='vert'>
+      <simplelist type="vert">
         <member><filename>/etc/motd</filename></member>
         <member><filename>/run/motd</filename></member>
         <member><filename>/usr/lib/motd</filename></member>
@@ -79,19 +76,19 @@
       <command>ln -s /dev/null /etc/motd.d/my_motd</command>
     </para>
     <para>
-      The <emphasis remap='B'>MOTD_SHOWN=pam</emphasis> environment variable
+      The <emphasis remap="B">MOTD_SHOWN=pam</emphasis> environment variable
       is set after showing the motd files, even when all of them were silenced
       using symbolic links.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_motd-options">
+  <refsect1 xml:id="pam_motd-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>motd=<replaceable>/path/filename</replaceable></option>
+          motd=/path/filename
         </term>
         <listitem>
           <para>
@@ -104,7 +101,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>motd_dir=<replaceable>/path/dirname.d</replaceable></option>
+          motd_dir=/path/dirname.d
         </term>
         <listitem>
           <para>
@@ -123,14 +120,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_motd-types">
+  <refsect1 xml:id="pam_motd-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_motd-return_values'>
+  <refsect1 xml:id="pam_motd-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -160,7 +157,7 @@
     </variablelist>
      </refsect1>
 
-  <refsect1 id='pam_motd-examples'>
+  <refsect1 xml:id="pam_motd-examples">
     <title>EXAMPLES</title>
     <para>
       The suggested usage for <filename>/etc/pam.d/login</filename> is:
@@ -183,7 +180,7 @@ session  optional  pam_motd.so motd=/elsewhere/motd motd_dir=/elsewhere/motd.d
     </para>
   </refsect1>
 
-  <refsect1 id='pam_motd-see_also'>
+  <refsect1 xml:id="pam_motd-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -201,7 +198,7 @@ session  optional  pam_motd.so motd=/elsewhere/motd motd_dir=/elsewhere/motd.d
     </para>
   </refsect1>
 
-  <refsect1 id='pam_motd-author'>
+  <refsect1 xml:id="pam_motd-author">
     <title>AUTHOR</title>
       <para>
         pam_motd was written by Ben Collins &lt;bcollins@debian.org&gt;.

--- a/modules/pam_namespace/README.xml
+++ b/modules/pam_namespace/README.xml
@@ -1,44 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamns SYSTEM "pam_namespace.8.xml">
--->
-<!--
-<!ENTITY nsconf SYSTEM "namespace.conf.5.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_namespace.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_namespace-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_namespace.8.xml" xpointer='xpointer(//refsect1[@id = "pam_namespace-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_namespace.8.xml" xpointer='xpointer(id("pam_namespace-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="namespace.conf.5.xml" xpointer='xpointer(//refsect1[@id = "namespace.conf-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="namespace.conf.5.xml" xpointer='xpointer(id("namespace.conf-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="namespace.conf.5.xml" xpointer='xpointer(//refsect1[@id = "namespace.conf-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="namespace.conf.5.xml" xpointer='xpointer(id("namespace.conf-examples")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_namespace/namespace.conf.5.xml
+++ b/modules/pam_namespace/namespace.conf.5.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="namespace.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="namespace.conf">
 
   <refmeta>
     <refentrytitle>namespace.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -16,7 +13,7 @@
   </refnamediv>
 
 
-  <refsect1 id='namespace.conf-description'>
+  <refsect1 xml:id="namespace.conf-description">
     <title>DESCRIPTION</title>
 
     <para>
@@ -175,7 +172,7 @@
 
   </refsect1>
 
-  <refsect1 id="namespace.conf-examples">
+  <refsect1 xml:id="namespace.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -220,7 +217,7 @@
 
   </refsect1>
 
-  <refsect1 id="namespace.conf-see_also">
+  <refsect1 xml:id="namespace.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_namespace</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -229,7 +226,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="namespace.conf-author">
+  <refsect1 xml:id="namespace.conf-author">
     <title>AUTHORS</title>
     <para>
       The namespace.conf manual page was written by Janak Desai &lt;janak@us.ibm.com&gt;.

--- a/modules/pam_namespace/pam_namespace.8.xml
+++ b/modules/pam_namespace/pam_namespace.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_namespace'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_namespace">
 
   <refmeta>
     <refentrytitle>pam_namespace</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_namespace-name'>
+  <refnamediv xml:id="pam_namespace-name">
     <refname>pam_namespace</refname>
     <refpurpose>
       PAM module for configuring namespace for a session
@@ -20,46 +17,46 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_namespace-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_namespace-cmdsynopsis" sepchar=" ">
       <command>pam_namespace.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         unmnt_remnt
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         unmnt_only
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         require_selinux
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         gen_hash
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ignore_config_error
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ignore_instance_parent_mode
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         unmount_on_close
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         use_current_context
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         use_default_context
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         mount_private
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_namespace-description">
+  <refsect1 xml:id="pam_namespace-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_namespace PAM module sets up a private namespace for a session
@@ -94,13 +91,13 @@
 
   </refsect1>
 
-  <refsect1 id="pam_namespace-options">
+  <refsect1 xml:id="pam_namespace-options">
     <title>OPTIONS</title>
     <variablelist>
 
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -111,7 +108,7 @@
 
       <varlistentry>
         <term>
-          <option>unmnt_remnt</option>
+          unmnt_remnt
         </term>
         <listitem>
           <para>
@@ -131,7 +128,7 @@
 
       <varlistentry>
         <term>
-          <option>unmnt_only</option>
+          unmnt_only
         </term>
         <listitem>
           <para>
@@ -146,7 +143,7 @@
 
       <varlistentry>
         <term>
-          <option>require_selinux</option>
+          require_selinux
         </term>
         <listitem>
           <para>
@@ -157,7 +154,7 @@
 
       <varlistentry>
         <term>
-          <option>gen_hash</option>
+          gen_hash
         </term>
         <listitem>
           <para>
@@ -170,7 +167,7 @@
 
       <varlistentry>
         <term>
-          <option>ignore_config_error</option>
+          ignore_config_error
         </term>
         <listitem>
           <para>
@@ -186,7 +183,7 @@
 
       <varlistentry>
         <term>
-          <option>ignore_instance_parent_mode</option>
+          ignore_instance_parent_mode
         </term>
         <listitem>
           <para>
@@ -201,7 +198,7 @@
 
       <varlistentry>
         <term>
-          <option>unmount_on_close</option>
+          unmount_on_close
         </term>
         <listitem>
           <para>
@@ -218,7 +215,7 @@
 
       <varlistentry>
         <term>
-          <option>use_current_context</option>
+          use_current_context
         </term>
         <listitem>
           <para>
@@ -232,7 +229,7 @@
 
       <varlistentry>
         <term>
-          <option>use_default_context</option>
+          use_default_context
         </term>
         <listitem>
           <para>
@@ -246,7 +243,7 @@
 
       <varlistentry>
         <term>
-          <option>mount_private</option>
+          mount_private
         </term>
         <listitem>
           <para>
@@ -271,7 +268,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_namespace-types">
+  <refsect1 xml:id="pam_namespace-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
@@ -279,7 +276,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_namespace-return_values">
+  <refsect1 xml:id="pam_namespace-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -309,18 +306,18 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_namespace-files">
+  <refsect1 xml:id="pam_namespace-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/namespace.conf</filename></term>
+        <term>/etc/security/namespace.conf</term>
         <listitem>
           <para>Main configuration file</para>
         </listitem>
       </varlistentry>
 
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/security/namespace.conf</filename></term>
+        <term>%vendordir%/security/namespace.conf</term>
         <listitem>
           <para>Default configuration file if
 	  <filename>/etc/security/namespace.conf</filename> does not exist.</para>
@@ -328,28 +325,28 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>/etc/security/namespace.d</filename></term>
+        <term>/etc/security/namespace.d</term>
         <listitem>
           <para>Directory for additional configuration files</para>
         </listitem>
       </varlistentry>
 
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/security/namespace.d</filename></term>
+        <term>%vendordir%/security/namespace.d</term>
         <listitem>
           <para>Directory for additional vendor specific configuration files.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><filename>/etc/security/namespace.init</filename></term>
+        <term>/etc/security/namespace.init</term>
         <listitem>
           <para>Init script for instance directories</para>
         </listitem>
       </varlistentry>
 
       <varlistentry condition="with_vendordir">
-        <term><filename>%vendordir%/security/namespace.init</filename></term>
+        <term>%vendordir%/security/namespace.init</term>
         <listitem>
           <para>Vendor init script for instance directories if
 	  /etc/security/namespace.init does not exist.
@@ -359,7 +356,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_namespace-examples">
+  <refsect1 xml:id="pam_namespace-examples">
     <title>EXAMPLES</title>
 
     <para>
@@ -379,7 +376,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_namespace-see_also">
+  <refsect1 xml:id="pam_namespace-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -397,7 +394,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_namespace-authors">
+  <refsect1 xml:id="pam_namespace-authors">
     <title>AUTHORS</title>
     <para>
       The namespace setup scheme was designed by Stephen Smalley, Janak Desai

--- a/modules/pam_namespace/pam_namespace_helper.8.xml
+++ b/modules/pam_namespace/pam_namespace_helper.8.xml
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_namespace_helper">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_namespace_helper">
 
   <refmeta>
     <refentrytitle>pam_namespace_helper</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_namespace_helper-name">
+  <refnamediv xml:id="pam_namespace_helper-name">
     <refname>pam_namespace_helper</refname>
     <refpurpose>Helper binary that creates home directories</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_namespace_helper-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_namespace_helper-cmdsynopsis" sepchar=" ">
       <command>pam_namespace_helper</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_namespace_helper-description">
+  <refsect1 xml:id="pam_namespace_helper-description">
 
     <title>DESCRIPTION</title>
 
@@ -43,7 +40,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_namespace_helper-see_also'>
+  <refsect1 xml:id="pam_namespace_helper-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -52,7 +49,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_namespace_helper-author'>
+  <refsect1 xml:id="pam_namespace_helper-author">
     <title>AUTHOR</title>
       <para>
         Written by Topi Miettinen.

--- a/modules/pam_nologin/README.xml
+++ b/modules/pam_nologin/README.xml
@@ -1,46 +1,31 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_nologin.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_nologin.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_nologin-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-note"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-note")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_nologin.8.xml" xpointer='xpointer(//refsect1[@id = "pam_nologin-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_nologin.8.xml" xpointer='xpointer(id("pam_nologin-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_nologin/pam_nologin.8.xml
+++ b/modules/pam_nologin/pam_nologin.8.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_nologin">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_nologin">
 
   <refmeta>
     <refentrytitle>pam_nologin</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_nologin-name">
+  <refnamediv xml:id="pam_nologin-name">
     <refname>pam_nologin</refname>
     <refpurpose>Prevent non-root users from login</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_nologin-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_nologin-cmdsynopsis" sepchar=" ">
       <command>pam_nologin.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         file=<replaceable>/path/nologin</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         successok
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_nologin-description">
+  <refsect1 xml:id="pam_nologin-description">
 
     <title>DESCRIPTION</title>
 
@@ -40,13 +37,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_nologin-options">
+  <refsect1 xml:id="pam_nologin-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>file=<replaceable>/path/nologin</replaceable></option>
+          file=/path/nologin
         </term>
         <listitem>
           <para>
@@ -58,7 +55,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>successok</option>
+          successok
         </term>
         <listitem>
           <para>
@@ -69,7 +66,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_nologin-types">
+  <refsect1 xml:id="pam_nologin-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option> module
@@ -77,7 +74,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_nologin-return_values'>
+  <refsect1 xml:id="pam_nologin-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -123,7 +120,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_nologin-examples'>
+  <refsect1 xml:id="pam_nologin-examples">
     <title>EXAMPLES</title>
     <para>
       The suggested usage for <filename>/etc/pam.d/login</filename> is:
@@ -132,7 +129,7 @@ auth  required  pam_nologin.so
       </programlisting>
     </para>
   </refsect1>
-  <refsect1 id='pam_nologin-note'>
+  <refsect1 xml:id="pam_nologin-note">
     <title>NOTES</title>
     <para>
       In order to make this module effective, all login methods should be
@@ -147,7 +144,7 @@ auth  required  pam_nologin.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_nologin-see_also'>
+  <refsect1 xml:id="pam_nologin-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -165,7 +162,7 @@ auth  required  pam_nologin.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_nologin-author'>
+  <refsect1 xml:id="pam_nologin-author">
     <title>AUTHOR</title>
       <para>
         pam_nologin was written by Michael K. Johnson &lt;johnsonm@redhat.com&gt;.

--- a/modules/pam_permit/README.xml
+++ b/modules/pam_permit/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_permit.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_permit.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_permit-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_permit.8.xml" xpointer='xpointer(id("pam_permit-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_permit.8.xml" xpointer='xpointer(id("pam_permit-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_permit.8.xml" xpointer='xpointer(id("pam_permit-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_permit.8.xml" xpointer='xpointer(id("pam_permit-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_permit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_permit-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_permit.8.xml" xpointer='xpointer(id("pam_permit-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_permit/pam_permit.8.xml
+++ b/modules/pam_permit/pam_permit.8.xml
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_permit">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_permit">
 
   <refmeta>
     <refentrytitle>pam_permit</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_permit-name">
+  <refnamediv xml:id="pam_permit-name">
     <refname>pam_permit</refname>
     <refpurpose>The promiscuous module</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_permit-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_permit-cmdsynopsis" sepchar=" ">
       <command>pam_permit.so</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_permit-description">
+  <refsect1 xml:id="pam_permit-description">
 
     <title>DESCRIPTION</title>
 
@@ -41,13 +38,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_permit-options">
+  <refsect1 xml:id="pam_permit-options">
 
     <title>OPTIONS</title>
     <para> This module does not recognise any options.</para>
   </refsect1>
 
-  <refsect1 id="pam_permit-types">
+  <refsect1 xml:id="pam_permit-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option>, <option>account</option>,
@@ -56,7 +53,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_permit-return_values'>
+  <refsect1 xml:id="pam_permit-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -70,7 +67,7 @@
     </variablelist>
      </refsect1>
 
-  <refsect1 id='pam_permit-examples'>
+  <refsect1 xml:id="pam_permit-examples">
     <title>EXAMPLES</title>
     <para>
       Add this line to your other login entries to disable account
@@ -81,7 +78,7 @@ account  required  pam_permit.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_permit-see_also'>
+  <refsect1 xml:id="pam_permit-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -96,7 +93,7 @@ account  required  pam_permit.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_permit-author'>
+  <refsect1 xml:id="pam_permit-author">
     <title>AUTHOR</title>
       <para>
         pam_permit was written by Andrew G. Morgan, &lt;morgan@kernel.org&gt;.

--- a/modules/pam_pwhistory/README.xml
+++ b/modules/pam_pwhistory/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_pwhistory.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_pwhistory.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_pwhistory-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_pwhistory.8.xml" xpointer='xpointer(//refsect1[@id = "pam_pwhistory-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_pwhistory.8.xml" xpointer='xpointer(id("pam_pwhistory-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_pwhistory/pam_pwhistory.8.xml
+++ b/modules/pam_pwhistory/pam_pwhistory.8.xml
@@ -1,52 +1,49 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_pwhistory">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_pwhistory">
 
   <refmeta>
     <refentrytitle>pam_pwhistory</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_pwhistory-name">
+  <refnamediv xml:id="pam_pwhistory-name">
     <refname>pam_pwhistory</refname>
     <refpurpose>PAM module to remember last passwords</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_pwhistory-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_pwhistory-cmdsynopsis" sepchar=" ">
       <command>pam_pwhistory.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         use_authtok
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         enforce_for_root
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         remember=<replaceable>N</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         retry=<replaceable>N</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         authtok_type=<replaceable>STRING</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	      file=<replaceable>/path/filename</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	      conf=<replaceable>/path/to/config-file</replaceable>
       </arg>
 
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_pwhistory-description">
+  <refsect1 xml:id="pam_pwhistory-description">
 
     <title>DESCRIPTION</title>
 
@@ -64,12 +61,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_pwhistory-options">
+  <refsect1 xml:id="pam_pwhistory-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -82,7 +79,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_authtok</option>
+          use_authtok
         </term>
         <listitem>
           <para>
@@ -95,7 +92,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>enforce_for_root</option>
+          enforce_for_root
         </term>
         <listitem>
           <para>
@@ -105,7 +102,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>remember=<replaceable>N</replaceable></option>
+          remember=N
         </term>
         <listitem>
           <para>
@@ -119,7 +116,7 @@
       </varlistentry>
       <varlistentry>
           <term>
-            <option>retry=<replaceable>N</replaceable></option>
+            retry=N
           </term>
           <listitem>
             <para>
@@ -132,7 +129,7 @@
 
         <varlistentry>
           <term>
-            <option>authtok_type=<replaceable>STRING</replaceable></option>
+            authtok_type=STRING
           </term>
           <listitem>
             <para>
@@ -145,7 +142,7 @@
 
         <varlistentry>
           <term>
-            <option>file=<replaceable>/path/filename</replaceable></option>
+            file=/path/filename
           </term>
           <listitem>
             <para>
@@ -158,7 +155,7 @@
 
         <varlistentry>
           <term>
-            <option>conf=<replaceable>/path/to/config-file</replaceable></option>
+            conf=/path/to/config-file
           </term>
           <listitem>
             <para>
@@ -178,14 +175,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_pwhistory-types">
+  <refsect1 xml:id="pam_pwhistory-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>password</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_pwhistory-return_values'>
+  <refsect1 xml:id="pam_pwhistory-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -224,7 +221,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_pwhistory-examples'>
+  <refsect1 xml:id="pam_pwhistory-examples">
     <title>EXAMPLES</title>
     <para>
       An example password section would be:
@@ -245,11 +242,11 @@ password     required       pam_unix.so        use_authtok
     </para>
   </refsect1>
 
-  <refsect1 id="pam_pwhistory-files">
+  <refsect1 xml:id="pam_pwhistory-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/opasswd</filename></term>
+        <term>/etc/security/opasswd</term>
         <listitem>
           <para>Default file with password history</para>
         </listitem>
@@ -257,7 +254,7 @@ password     required       pam_unix.so        use_authtok
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_pwhistory-see_also'>
+  <refsect1 xml:id="pam_pwhistory-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -278,7 +275,7 @@ password     required       pam_unix.so        use_authtok
     </para>
   </refsect1>
 
-  <refsect1 id='pam_pwhistory-author'>
+  <refsect1 xml:id="pam_pwhistory-author">
     <title>AUTHOR</title>
       <para>
         pam_pwhistory was written by Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;

--- a/modules/pam_pwhistory/pwhistory.conf.5.xml
+++ b/modules/pam_pwhistory/pwhistory.conf.5.xml
@@ -1,25 +1,22 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pwhistory.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pwhistory.conf">
 
   <refmeta>
     <refentrytitle>pwhistory.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pwhistory.conf-name">
+  <refnamediv xml:id="pwhistory.conf-name">
     <refname>pwhistory.conf</refname>
     <refpurpose>pam_pwhistory configuration file</refpurpose>
   </refnamediv>
 
-  <refsect1 id="pwhistory.conf-description">
+  <refsect1 xml:id="pwhistory.conf-description">
 
     <title>DESCRIPTION</title>
     <para>
-       <emphasis remap='B'>pwhistory.conf</emphasis> provides a way to configure the
+       <emphasis remap="B">pwhistory.conf</emphasis> provides a way to configure the
        default settings for saving the last passwords for each user.
        This file is read by the <emphasis>pam_pwhistory</emphasis> module and is the
        preferred method over configuring <emphasis>pam_pwhistory</emphasis> directly.
@@ -31,13 +28,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pwhistory.conf-options">
+  <refsect1 xml:id="pwhistory.conf-options">
 
     <title>OPTIONS</title>
          <variablelist>
             <varlistentry>
               <term>
-                <option>debug</option>
+                debug
               </term>
               <listitem>
                 <para>
@@ -50,7 +47,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>enforce_for_root</option>
+                enforce_for_root
               </term>
               <listitem>
                 <para>
@@ -60,7 +57,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>remember=<replaceable>N</replaceable></option>
+                remember=N
               </term>
               <listitem>
                 <para>
@@ -74,7 +71,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>retry=<replaceable>N</replaceable></option>
+                retry=N
               </term>
               <listitem>
                 <para>
@@ -85,7 +82,7 @@
             </varlistentry>
             <varlistentry>
               <term>
-                <option>file=<replaceable>/path/filename</replaceable></option>
+                file=/path/filename
               </term>
               <listitem>
                 <para>
@@ -99,7 +96,7 @@
         </variablelist>
   </refsect1>
 
-  <refsect1 id='pwhistory.conf-examples'>
+  <refsect1 xml:id="pwhistory.conf-examples">
     <title>EXAMPLES</title>
     <para>
       /etc/security/pwhistory.conf file example:
@@ -111,11 +108,11 @@ file=/tmp/opasswd
     </programlisting>
   </refsect1>
 
-  <refsect1 id="pwhistory.conf-files">
+  <refsect1 xml:id="pwhistory.conf-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/pwhistory.conf</filename></term>
+        <term>/etc/security/pwhistory.conf</term>
         <listitem>
           <para>the config file for custom options</para>
         </listitem>
@@ -123,7 +120,7 @@ file=/tmp/opasswd
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pwhistory.conf-see_also'>
+  <refsect1 xml:id="pwhistory.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -144,7 +141,7 @@ file=/tmp/opasswd
     </para>
   </refsect1>
 
-  <refsect1 id='pwhistory.conf-author'>
+  <refsect1 xml:id="pwhistory.conf-author">
     <title>AUTHOR</title>
       <para>
         pam_pwhistory was written by Thorsten Kukuk. The support for

--- a/modules/pam_pwhistory/pwhistory_helper.8.xml
+++ b/modules/pam_pwhistory/pwhistory_helper.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pwhistory_helper">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pwhistory_helper">
 
   <refmeta>
     <refentrytitle>pwhistory_helper</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pwhistory_helper-name">
+  <refnamediv xml:id="pwhistory_helper-name">
     <refname>pwhistory_helper</refname>
     <refpurpose>Helper binary that transfers password hashes from passwd or shadow to opasswd</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pwhistory_helper-cmdsynopsis">
+    <cmdsynopsis xml:id="pwhistory_helper-cmdsynopsis" sepchar=" ">
       <command>pwhistory_helper</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ...
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pwhistory_helper-description">
+  <refsect1 xml:id="pwhistory_helper-description">
 
     <title>DESCRIPTION</title>
 
@@ -48,7 +45,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pwhistory_helper-see_also'>
+  <refsect1 xml:id="pwhistory_helper-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -57,7 +54,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pwhistory_helper-author'>
+  <refsect1 xml:id="pwhistory_helper-author">
     <title>AUTHOR</title>
       <para>
         Written by Tomas Mraz based on the code originally in

--- a/modules/pam_rhosts/README.xml
+++ b/modules/pam_rhosts/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_rhosts.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rhosts.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_rhosts-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rhosts.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rhosts-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rhosts.8.xml" xpointer='xpointer(id("pam_rhosts-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_rhosts/pam_rhosts.8.xml
+++ b/modules/pam_rhosts/pam_rhosts.8.xml
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_rhosts">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_rhosts">
 
   <refmeta>
     <refentrytitle>pam_rhosts</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_rhosts-name">
+  <refnamediv xml:id="pam_rhosts-name">
     <refname>pam_rhosts</refname>
     <refpurpose>The rhosts PAM module</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_rhosts-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_rhosts-cmdsynopsis" sepchar=" ">
       <command>pam_rhosts.so</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_rhosts-description">
+  <refsect1 xml:id="pam_rhosts-description">
 
     <title>DESCRIPTION</title>
 
@@ -53,12 +50,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_rhosts-options">
+  <refsect1 xml:id="pam_rhosts-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -68,7 +65,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>silent</option>
+          silent
         </term>
         <listitem>
           <para>
@@ -78,7 +75,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>superuser=<replaceable>account</replaceable></option>
+          superuser=account
         </term>
         <listitem>
           <para>
@@ -89,14 +86,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_rhosts-types">
+  <refsect1 xml:id="pam_rhosts-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>auth</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_rhosts-return_values'>
+  <refsect1 xml:id="pam_rhosts-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -120,7 +117,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_rhosts-examples'>
+  <refsect1 xml:id="pam_rhosts-examples">
     <title>EXAMPLES</title>
     <para>
       To grant a remote user access by <filename>/etc/hosts.equiv</filename>
@@ -137,7 +134,7 @@ auth     required       pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_rhosts-see_also'>
+  <refsect1 xml:id="pam_rhosts-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -161,7 +158,7 @@ auth     required       pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_rhosts-author'>
+  <refsect1 xml:id="pam_rhosts-author">
     <title>AUTHOR</title>
       <para>
         pam_rhosts was written by Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;

--- a/modules/pam_rootok/README.xml
+++ b/modules/pam_rootok/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_rootok.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rootok.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_rootok-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_rootok.8.xml" xpointer='xpointer(//refsect1[@id = "pam_rootok-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_rootok.8.xml" xpointer='xpointer(id("pam_rootok-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_rootok/pam_rootok.8.xml
+++ b/modules/pam_rootok/pam_rootok.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_rootok">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_rootok">
 
   <refmeta>
     <refentrytitle>pam_rootok</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_rootok-name">
+  <refnamediv xml:id="pam_rootok-name">
     <refname>pam_rootok</refname>
     <refpurpose>Gain only root access</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_rootok-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_rootok-cmdsynopsis" sepchar=" ">
       <command>pam_rootok.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_rootok-description">
+  <refsect1 xml:id="pam_rootok-description">
 
     <title>DESCRIPTION</title>
 
@@ -38,12 +35,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_rootok-options">
+  <refsect1 xml:id="pam_rootok-options">
     <title>OPTIONS</title>
         <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -54,7 +51,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_rootok-types">
+  <refsect1 xml:id="pam_rootok-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option>, <option>account</option> and
@@ -62,7 +59,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_rootok-return_values'>
+  <refsect1 xml:id="pam_rootok-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -77,7 +74,7 @@
         <term>PAM_AUTH_ERR</term>
         <listitem>
           <para>
-            The <emphasis>UID</emphasis> is <emphasis remap='B'>not</emphasis>
+            The <emphasis>UID</emphasis> is <emphasis remap="B">not</emphasis>
             <emphasis>0</emphasis>.
           </para>
         </listitem>
@@ -85,7 +82,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_rootok-examples'>
+  <refsect1 xml:id="pam_rootok-examples">
     <title>EXAMPLES</title>
     <para>
       In the case of the <citerefentry>
@@ -103,7 +100,7 @@ auth  required     pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_rootok-see_also'>
+  <refsect1 xml:id="pam_rootok-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -121,7 +118,7 @@ auth  required     pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_rootok-author'>
+  <refsect1 xml:id="pam_rootok-author">
     <title>AUTHOR</title>
       <para>
         pam_rootok was written by Andrew G. Morgan, &lt;morgan@kernel.org&gt;.

--- a/modules/pam_securetty/README.xml
+++ b/modules/pam_securetty/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_securetty.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_securetty.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_securetty-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_securetty.8.xml" xpointer='xpointer(//refsect1[@id = "pam_securetty-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_securetty.8.xml" xpointer='xpointer(id("pam_securetty-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_securetty/pam_securetty.8.xml
+++ b/modules/pam_securetty/pam_securetty.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_securetty">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_securetty">
 
   <refmeta>
     <refentrytitle>pam_securetty</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_securetty-name">
+  <refnamediv xml:id="pam_securetty-name">
     <refname>pam_securetty</refname>
     <refpurpose>Limit root login to special devices</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_securetty-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_securetty-cmdsynopsis" sepchar=" ">
       <command>pam_securetty.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_securetty-description">
+  <refsect1 xml:id="pam_securetty-description">
 
     <title>DESCRIPTION</title>
 
@@ -43,23 +40,23 @@
     </para>
     <para>
       This module has no effect on non-root users and requires that the
-      application fills in the <emphasis remap='B'>PAM_TTY</emphasis>
+      application fills in the <emphasis remap="B">PAM_TTY</emphasis>
       item correctly.
     </para>
     <para>
       For canonical usage, should be listed as a
-      <emphasis remap='B'>required</emphasis> authentication method
-      before any <emphasis remap='B'>sufficient</emphasis>
+      <emphasis remap="B">required</emphasis> authentication method
+      before any <emphasis remap="B">sufficient</emphasis>
       authentication methods.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_securetty-options">
+  <refsect1 xml:id="pam_securetty-options">
     <title>OPTIONS</title>
         <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -69,7 +66,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>noconsole</option>
+          noconsole
         </term>
         <listitem>
           <para>
@@ -83,14 +80,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_securetty-types">
+  <refsect1 xml:id="pam_securetty-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>auth</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_securetty-return_values'>
+  <refsect1 xml:id="pam_securetty-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -164,7 +161,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_securetty-examples'>
+  <refsect1 xml:id="pam_securetty-examples">
     <title>EXAMPLES</title>
     <para>
       <programlisting>
@@ -174,7 +171,7 @@ auth  required  pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_securetty-see_also'>
+  <refsect1 xml:id="pam_securetty-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -192,7 +189,7 @@ auth  required  pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_securetty-author'>
+  <refsect1 xml:id="pam_securetty-author">
     <title>AUTHOR</title>
       <para>
         pam_securetty was written by Elliot Lee &lt;sopwith@cuc.edu&gt;.

--- a/modules/pam_selinux/README.xml
+++ b/modules/pam_selinux/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_selinux.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_selinux.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_selinux-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_selinux.8.xml" xpointer='xpointer(//refsect1[@id = "pam_selinux-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_selinux.8.xml" xpointer='xpointer(id("pam_selinux-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_selinux/pam_selinux.8.xml
+++ b/modules/pam_selinux/pam_selinux.8.xml
@@ -1,54 +1,51 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_selinux">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_selinux">
 
   <refmeta>
     <refentrytitle>pam_selinux</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_selinux-name">
+  <refnamediv xml:id="pam_selinux-name">
     <refname>pam_selinux</refname>
     <refpurpose>PAM module to set the default security context</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_selinux-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_selinux-cmdsynopsis" sepchar=" ">
       <command>pam_selinux.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	open
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	close
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	restore
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	nottys
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	verbose
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	select_context
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	env_params
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	use_current_range
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_selinux-description">
+  <refsect1 xml:id="pam_selinux-description">
     <title>DESCRIPTION</title>
     <para>
       pam_selinux is a PAM module that sets up the default SELinux security
@@ -79,12 +76,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_selinux-options">
+  <refsect1 xml:id="pam_selinux-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>open</option>
+          open
         </term>
         <listitem>
           <para>
@@ -94,7 +91,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>close</option>
+          close
         </term>
         <listitem>
           <para>
@@ -104,7 +101,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>restore</option>
+          restore
         </term>
         <listitem>
           <para>
@@ -117,7 +114,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nottys</option>
+          nottys
         </term>
         <listitem>
           <para>
@@ -127,7 +124,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -140,7 +137,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>verbose</option>
+          verbose
         </term>
         <listitem>
           <para>
@@ -150,7 +147,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>select_context</option>
+          select_context
         </term>
         <listitem>
           <para>
@@ -161,7 +158,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>env_params</option>
+          env_params
         </term>
         <listitem>
           <para>
@@ -178,7 +175,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_current_range</option>
+          use_current_range
         </term>
         <listitem>
           <para>
@@ -191,14 +188,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_selinux-types">
+  <refsect1 xml:id="pam_selinux-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_selinux-return_values'>
+  <refsect1 xml:id="pam_selinux-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -236,7 +233,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_selinux-examples'>
+  <refsect1 xml:id="pam_selinux-examples">
     <title>EXAMPLES</title>
     <programlisting>
 auth     required  pam_unix.so
@@ -245,7 +242,7 @@ session  optional  pam_selinux.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_selinux-see_also'>
+  <refsect1 xml:id="pam_selinux-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -266,7 +263,7 @@ session  optional  pam_selinux.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_selinux-author'>
+  <refsect1 xml:id="pam_selinux-author">
     <title>AUTHOR</title>
       <para>
         pam_selinux was written by Dan Walsh &lt;dwalsh@redhat.com&gt;.

--- a/modules/pam_sepermit/README.xml
+++ b/modules/pam_sepermit/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_sepermit.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_sepermit.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_sepermit-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_sepermit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_sepermit-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_sepermit.8.xml" xpointer='xpointer(id("pam_sepermit-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_sepermit/pam_sepermit.8.xml
+++ b/modules/pam_sepermit/pam_sepermit.8.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_sepermit">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_sepermit">
 
   <refmeta>
     <refentrytitle>pam_sepermit</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_sepermit-name">
+  <refnamediv xml:id="pam_sepermit-name">
     <refname>pam_sepermit</refname>
     <refpurpose>PAM module to allow/deny login depending on SELinux enforcement state</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_sepermit-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_sepermit-cmdsynopsis" sepchar=" ">
       <command>pam_sepermit.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	conf=<replaceable>/path/to/config/file</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_sepermit-description">
+  <refsect1 xml:id="pam_sepermit-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_sepermit module allows or denies login depending on SELinux
@@ -61,12 +58,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_sepermit-options">
+  <refsect1 xml:id="pam_sepermit-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -79,7 +76,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>conf=<replaceable>/path/to/config/file</replaceable></option>
+          conf=/path/to/config/file
         </term>
         <listitem>
           <para>
@@ -90,7 +87,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_sepermit-types">
+  <refsect1 xml:id="pam_sepermit-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option>
@@ -98,7 +95,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_sepermit-return_values'>
+  <refsect1 xml:id="pam_sepermit-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -145,11 +142,11 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_sepermit-files">
+  <refsect1 xml:id="pam_sepermit-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/sepermit.conf</filename></term>
+        <term>/etc/security/sepermit.conf</term>
         <listitem>
           <para>Default configuration file</para>
         </listitem>
@@ -157,7 +154,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_sepermit-examples'>
+  <refsect1 xml:id="pam_sepermit-examples">
     <title>EXAMPLES</title>
     <programlisting>
 auth     [success=done ignore=ignore default=bad] pam_sepermit.so
@@ -167,7 +164,7 @@ session  required  pam_permit.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_sepermit-see_also'>
+  <refsect1 xml:id="pam_sepermit-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -188,7 +185,7 @@ session  required  pam_permit.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_sepermit-author'>
+  <refsect1 xml:id="pam_sepermit-author">
     <title>AUTHOR</title>
       <para>
         pam_sepermit and this manual page were written by Tomas Mraz &lt;tmraz@redhat.com&gt;.

--- a/modules/pam_sepermit/sepermit.conf.5.xml
+++ b/modules/pam_sepermit/sepermit.conf.5.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="sepermit.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sepermit.conf">
 
   <refmeta>
     <refentrytitle>sepermit.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -15,7 +12,7 @@
     <refpurpose>configuration file for the pam_sepermit module</refpurpose>
   </refnamediv>
 
-  <refsect1 id='sepermit.conf-description'>
+  <refsect1 xml:id="sepermit.conf-description">
     <title>DESCRIPTION</title>
     <para>
       The lines of the configuration file have the following syntax:
@@ -24,7 +21,7 @@
       <replaceable>&lt;user&gt;</replaceable>[:<replaceable>&lt;option&gt;</replaceable>:<replaceable>&lt;option&gt;</replaceable>...]
     </para>
     <para>
-      The <emphasis remap='B'>user</emphasis> can be specified in the following manner:
+      The <emphasis remap="B">user</emphasis> can be specified in the following manner:
     </para>
     <itemizedlist>
         <listitem>
@@ -34,13 +31,13 @@
         </listitem>
         <listitem>
               <para>
-                a groupname, with <emphasis remap='B'>@group</emphasis> syntax.
+                a groupname, with <emphasis remap="B">@group</emphasis> syntax.
                 This should not be confused with netgroups.
               </para>
         </listitem>
         <listitem>
               <para>
-                a SELinux user name with <emphasis remap='B'>%seuser</emphasis> syntax.
+                a SELinux user name with <emphasis remap="B">%seuser</emphasis> syntax.
               </para>
         </listitem>
     </itemizedlist>
@@ -51,7 +48,7 @@
 
     <variablelist>
         <varlistentry>
-              <term><option>exclusive</option></term>
+              <term>exclusive</term>
               <listitem>
                 <para>
                   Only single login session will be allowed for the user
@@ -60,7 +57,7 @@
               </listitem>
         </varlistentry>
         <varlistentry>
-              <term><option>ignore</option></term>
+              <term>ignore</term>
               <listitem>
                 <para>
                   The module will never return PAM_SUCCESS status for the user.
@@ -78,7 +75,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="sepermit.conf-examples">
+  <refsect1 xml:id="sepermit.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -91,7 +88,7 @@
     </programlisting>
   </refsect1>
 
-  <refsect1 id="sepermit.conf-see_also">
+  <refsect1 xml:id="sepermit.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_sepermit</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -101,7 +98,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="sepermit.conf-author">
+  <refsect1 xml:id="sepermit.conf-author">
     <title>AUTHOR</title>
     <para>
       pam_sepermit and this manual page were written by Tomas Mraz &lt;tmraz@redhat.com&gt;

--- a/modules/pam_setquota/README.xml
+++ b/modules/pam_setquota/README.xml
@@ -1,41 +1,27 @@
-﻿<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_setquota.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_setquota.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_setquota-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_setquota.8.xml" xpointer='xpointer(//refsect1[@id = "pam_setquota-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_setquota.8.xml" xpointer='xpointer(id("pam_setquota-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_setquota/pam_setquota.8.xml
+++ b/modules/pam_setquota/pam_setquota.8.xml
@@ -1,53 +1,51 @@
-﻿<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_setquota">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_setquota">
 
   <refmeta>
     <refentrytitle>pam_setquota</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_setquota-name">
+  <refnamediv xml:id="pam_setquota-name">
     <refname>pam_setquota</refname>
     <refpurpose>PAM module to set or modify disk quotas on session start</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_setquota-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_setquota-cmdsynopsis" sepchar=" ">
       <command>pam_setquota.so</command>
-       <arg choice="opt">
+       <arg choice="opt" rep="norepeat">
         fs=<replaceable>/home</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         overwrite=<replaceable>0</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug=<replaceable>0</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         startuid=<replaceable>1000</replaceable>
       </arg>
-       <arg choice="opt">
+       <arg choice="opt" rep="norepeat">
         enduid=<replaceable>0</replaceable>
       </arg>
-       <arg choice="opt">
+       <arg choice="opt" rep="norepeat">
         bsoftlimit=<replaceable>19000</replaceable>
       </arg>
-       <arg choice="opt">
+       <arg choice="opt" rep="norepeat">
         bhardlimit=<replaceable>20000</replaceable>
       </arg>
-       <arg choice="opt">
+       <arg choice="opt" rep="norepeat">
         isoftlimit=<replaceable>3000</replaceable>
       </arg>
-       <arg choice="opt">
+       <arg choice="opt" rep="norepeat">
         ihardlimit=<replaceable>4000</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_setquota-description">
+  <refsect1 xml:id="pam_setquota-description">
 
     <title>DESCRIPTION</title>
 
@@ -60,14 +58,14 @@
 
   </refsect1>
 
-  <refsect1 id="pam_setquota-options">
+  <refsect1 xml:id="pam_setquota-options">
 
     <title>OPTIONS</title>
     <para>
       <variablelist>
         <varlistentry>
           <term>
-            <option>fs=<replaceable>/home</replaceable></option>
+            fs=/home
           </term>
           <listitem>
             <para>
@@ -78,7 +76,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>overwrite=<replaceable>0</replaceable></option>
+            overwrite=0
           </term>
           <listitem>
             <para>
@@ -91,7 +89,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>debug=<replaceable>0</replaceable></option>
+            debug=0
           </term>
           <listitem>
             <para>
@@ -103,7 +101,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>startuid=<replaceable>1000</replaceable></option>
+            startuid=1000
           </term>
           <listitem>
             <para>
@@ -115,7 +113,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>enduid=<replaceable>0</replaceable></option>
+            enduid=0
           </term>
           <listitem>
             <para>
@@ -128,7 +126,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>bsoftlimit=<replaceable>19000</replaceable></option>
+            bsoftlimit=19000
           </term>
           <listitem>
             <para>
@@ -142,7 +140,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>bhardlimit=<replaceable>20000</replaceable></option>
+            bhardlimit=20000
           </term>
           <listitem>
             <para>
@@ -156,7 +154,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>isoftlimit=<replaceable>3000</replaceable></option>
+            isoftlimit=3000
           </term>
           <listitem>
             <para>
@@ -169,7 +167,7 @@
         </varlistentry>
         <varlistentry>
           <term>
-            <option>ihardlimit=<replaceable>4000</replaceable></option>
+            ihardlimit=4000
           </term>
           <listitem>
             <para>
@@ -184,14 +182,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_setquota-types">
+  <refsect1 xml:id="pam_setquota-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
        Only the <option>session</option> module type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_setquota-return_values'>
+  <refsect1 xml:id="pam_setquota-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -255,7 +253,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_setquota-examples'>
+  <refsect1 xml:id="pam_setquota-examples">
     <title>EXAMPLES</title>
     <para>
     A single invocation of `pam_setquota` applies a specific policy to a UID
@@ -270,7 +268,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_setquota-see_also'>
+  <refsect1 xml:id="pam_setquota-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -285,7 +283,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_setquota-author'>
+  <refsect1 xml:id="pam_setquota-author">
     <title>AUTHOR</title>
       <para>
        pam_setquota was originally written by

--- a/modules/pam_shells/README.xml
+++ b/modules/pam_shells/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_shells.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_shells.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_shells-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_shells.8.xml" xpointer='xpointer(id("pam_shells-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_shells.8.xml" xpointer='xpointer(id("pam_shells-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_shells.8.xml" xpointer='xpointer(id("pam_shells-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_shells.8.xml" xpointer='xpointer(id("pam_shells-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_shells.8.xml" xpointer='xpointer(//refsect1[@id = "pam_shells-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_shells.8.xml" xpointer='xpointer(id("pam_shells-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_shells/pam_shells.8.xml
+++ b/modules/pam_shells/pam_shells.8.xml
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_shells">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_shells">
 
   <refmeta>
     <refentrytitle>pam_shells</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_shells-name">
+  <refnamediv xml:id="pam_shells-name">
     <refname>pam_shells</refname>
     <refpurpose>PAM module to check for valid login shell</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_shells-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_shells-cmdsynopsis" sepchar=" ">
       <command>pam_shells.so</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_shells-description">
+  <refsect1 xml:id="pam_shells-description">
 
     <title>DESCRIPTION</title>
 
@@ -43,13 +40,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_shells-options">
+  <refsect1 xml:id="pam_shells-options">
 
     <title>OPTIONS</title>
     <para> This module does not recognise any options.</para>
   </refsect1>
 
-  <refsect1 id="pam_shells-types">
+  <refsect1 xml:id="pam_shells-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option>
@@ -57,7 +54,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_shells-return_values'>
+  <refsect1 xml:id="pam_shells-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -88,7 +85,7 @@
     </variablelist>
      </refsect1>
 
-  <refsect1 id='pam_shells-examples'>
+  <refsect1 xml:id="pam_shells-examples">
     <title>EXAMPLES</title>
     <para>
       <programlisting>
@@ -97,7 +94,7 @@ auth  required  pam_shells.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_shells-see_also'>
+  <refsect1 xml:id="pam_shells-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -115,7 +112,7 @@ auth  required  pam_shells.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_shells-author'>
+  <refsect1 xml:id="pam_shells-author">
     <title>AUTHOR</title>
       <para>
         pam_shells was written by Erik Troan &lt;ewt@redhat.com&gt;.

--- a/modules/pam_stress/README.xml
+++ b/modules/pam_stress/README.xml
@@ -1,31 +1,19 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamstress SYSTEM "pam_stress.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_stress.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_stress-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_stress.8.xml" xpointer='xpointer(id("pam_stress-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_stress.8.xml" xpointer='xpointer(//refsect1[@id = "pam_stress-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_stress.8.xml" xpointer='xpointer(id("pam_stress-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_stress.8.xml" xpointer='xpointer(//refsect1[@id = "pam_stress-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_stress.8.xml" xpointer='xpointer(id("pam_stress-options")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_stress/pam_stress.8.xml
+++ b/modules/pam_stress/pam_stress.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_stress'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_stress">
 
   <refmeta>
     <refentrytitle>pam_stress</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_stress-name'>
+  <refnamediv xml:id="pam_stress-name">
     <refname>pam_stress</refname>
     <refpurpose>The stress-testing PAM module</refpurpose>
   </refnamediv>
@@ -18,42 +15,42 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_stress-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_stress-cmdsynopsis" sepchar=" ">
       <command>pam_stress.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         no_warn
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         use_first_pass
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         try_first_pass
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         rootok
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         expired
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         fail_1
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         fail_2
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         prelim
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         required
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_stress-description">
+  <refsect1 xml:id="pam_stress-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_stress PAM module is mainly intended to give the impression of failing as a fully
@@ -61,13 +58,13 @@ functioning module might.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_stress-options">
+  <refsect1 xml:id="pam_stress-options">
     <title>OPTIONS</title>
     <variablelist>
 
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -79,7 +76,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>no_warn</option>
+          no_warn
         </term>
         <listitem>
           <para>
@@ -91,7 +88,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>use_first_pass</option>
+          use_first_pass
         </term>
         <listitem>
           <para>
@@ -103,7 +100,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>try_first_pass</option>
+          try_first_pass
         </term>
         <listitem>
           <para>
@@ -115,7 +112,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>rootok</option>
+          rootok
         </term>
         <listitem>
           <para>
@@ -128,7 +125,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>expired</option>
+          expired
         </term>
         <listitem>
           <para>
@@ -141,7 +138,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>fail_1</option>
+          fail_1
         </term>
         <listitem>
           <para>
@@ -152,7 +149,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>fail_2</option>
+          fail_2
         </term>
         <listitem>
           <para>
@@ -164,7 +161,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>prelim</option>
+          prelim
         </term>
         <listitem>
           <para>
@@ -175,7 +172,7 @@ functioning module might.
 
       <varlistentry>
         <term>
-          <option>required</option>
+          required
         </term>
         <listitem>
           <para>
@@ -189,7 +186,7 @@ functioning module might.
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_stress-types">
+  <refsect1 xml:id="pam_stress-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>auth</option>, <option>account</option>,
@@ -197,7 +194,7 @@ functioning module might.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_stress-return_values">
+  <refsect1 xml:id="pam_stress-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -307,7 +304,7 @@ functioning module might.
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_stress-notes'>
+  <refsect1 xml:id="pam_stress-notes">
     <title>NOTES</title>
     <para>
       This module uses the stress_new_pwd data string which tells
@@ -316,7 +313,7 @@ functioning module might.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_stress-examples'>
+  <refsect1 xml:id="pam_stress-examples">
     <title>EXAMPLES</title>
     <programlisting>
 #%PAM-1.0
@@ -329,7 +326,7 @@ session  required pam_stress.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_stress-see_also">
+  <refsect1 xml:id="pam_stress-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -344,7 +341,7 @@ session  required pam_stress.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_stress-authors">
+  <refsect1 xml:id="pam_stress-authors">
     <title>AUTHORS</title>
     <para>
       The pam_stress PAM module was developed by

--- a/modules/pam_succeed_if/README.xml
+++ b/modules/pam_succeed_if/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_succeed_if.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_succeed_if.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_succeed_if-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_succeed_if.8.xml" xpointer='xpointer(//refsect1[@id = "pam_succeed_if-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_succeed_if.8.xml" xpointer='xpointer(id("pam_succeed_if-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_succeed_if/pam_succeed_if.8.xml
+++ b/modules/pam_succeed_if/pam_succeed_if.8.xml
@@ -1,34 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-
-<refentry id='pam_succeed_if'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_succeed_if">
 <!--  Copyright 2003, 2004 Red Hat, Inc. -->
 <!--  Written by Nalin Dahyabhai &lt;nalin@redhat.com&gt; -->
 
   <refmeta>
     <refentrytitle>pam_succeed_if</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='sectdesc'>Linux-PAM</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_succeed_if-name'>
+  <refnamediv xml:id="pam_succeed_if-name">
     <refname>pam_succeed_if</refname>
     <refpurpose>test account characteristics</refpurpose>
   </refnamediv>
 
 
   <refsynopsisdiv>
-    <cmdsynopsis id='pam_succeed_if-cmdsynopsis'>
+    <cmdsynopsis xml:id="pam_succeed_if-cmdsynopsis" sepchar=" ">
       <command>pam_succeed_if.so</command>
-      <arg choice='opt' rep='repeat'><replaceable>flag</replaceable></arg>
-      <arg choice='opt' rep='repeat'><replaceable>condition</replaceable></arg>
+      <arg choice="opt" rep="repeat"><replaceable>flag</replaceable></arg>
+      <arg choice="opt" rep="repeat"><replaceable>condition</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_succeed_if-description'>
+  <refsect1 xml:id="pam_succeed_if-description">
     <title>DESCRIPTION</title>
     <para>
       pam_succeed_if.so is designed to succeed or fail authentication
@@ -43,7 +39,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_succeed_if-options">
+  <refsect1 xml:id="pam_succeed_if-options">
     <title>OPTIONS</title>
     <para>
       The following <emphasis>flag</emphasis>s are supported:
@@ -51,13 +47,13 @@
 
     <variablelist>
       <varlistentry>
-        <term><option>debug</option></term>
+        <term>debug</term>
         <listitem>
           <para>Turns on debugging messages sent to syslog.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>use_uid</option></term>
+        <term>use_uid</term>
         <listitem>
           <para>
             Evaluate conditions using the account of the user whose UID
@@ -67,13 +63,13 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>quiet</option></term>
+        <term>quiet</term>
         <listitem>
           <para>Don't log failure or success to the system log.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>quiet_fail</option></term>
+        <term>quiet_fail</term>
         <listitem>
           <para>
             Don't log failure to the system log.
@@ -81,7 +77,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>quiet_success</option></term>
+        <term>quiet_success</term>
         <listitem>
           <para>
             Don't log success to the system log.
@@ -89,7 +85,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>audit</option></term>
+        <term>audit</term>
         <listitem>
           <para>
             Log unknown users to the system log.
@@ -112,13 +108,13 @@
 
     <variablelist>
       <varlistentry>
-        <term><option>field &lt; number</option></term>
+        <term>field &lt; number</term>
         <listitem>
           <para>Field has a value numerically less than number.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field &lt;= number</option></term>
+        <term>field &lt;= number</term>
         <listitem>
           <para>
             Field has a value numerically less than or equal to number.
@@ -126,7 +122,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field eq number</option></term>
+        <term>field eq number</term>
         <listitem>
           <para>
             Field has a value numerically equal to number.
@@ -134,7 +130,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field &gt;= number</option></term>
+        <term>field &gt;= number</term>
         <listitem>
           <para>
             Field has a value numerically greater than or equal to number.
@@ -142,7 +138,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field &gt; number</option></term>
+        <term>field &gt; number</term>
         <listitem>
           <para>
             Field has a value numerically greater than number.
@@ -150,7 +146,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field ne number</option></term>
+        <term>field ne number</term>
         <listitem>
           <para>
             Field has a value numerically different from number.
@@ -158,7 +154,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field = string</option></term>
+        <term>field = string</term>
         <listitem>
           <para>
             Field exactly matches the given string.
@@ -166,7 +162,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field != string</option></term>
+        <term>field != string</term>
         <listitem>
           <para>
             Field does not match the given string.
@@ -174,49 +170,49 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field =~ glob</option></term>
+        <term>field =~ glob</term>
         <listitem>
           <para>Field matches the given glob.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field !~ glob</option></term>
+        <term>field !~ glob</term>
         <listitem>
           <para>Field does not match the given glob.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field in item:item:...</option></term>
+        <term>field in item:item:...</term>
         <listitem>
           <para>Field is contained in the list of items separated by colons.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>field notin item:item:...</option></term>
+        <term>field notin item:item:...</term>
         <listitem>
           <para>Field is not contained in the list of items separated by colons.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user ingroup group[:group:....]</option></term>
+        <term>user ingroup group[:group:....]</term>
         <listitem>
           <para>User is in given group(s).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user notingroup group[:group:....]</option></term>
+        <term>user notingroup group[:group:....]</term>
         <listitem>
           <para>User is not in given group(s).</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user innetgr netgroup</option></term>
+        <term>user innetgr netgroup</term>
         <listitem>
           <para>(user,host) is in given netgroup.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>user notinnetgr group</option></term>
+        <term>user notinnetgr group</term>
         <listitem>
           <para>(user,host) is not in given netgroup.</para>
         </listitem>
@@ -224,7 +220,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_succeed_if-types">
+  <refsect1 xml:id="pam_succeed_if-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>account</option>, <option>auth</option>,
@@ -232,7 +228,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_succeed_if-return_values'>
+  <refsect1 xml:id="pam_succeed_if-return_values">
     <title>RETURN VALUES</title>
      <variablelist>
 
@@ -267,7 +263,7 @@
   </refsect1>
 
 
-  <refsect1 id='pam_succeed_if-examples'>
+  <refsect1 xml:id="pam_succeed_if-examples">
     <title>EXAMPLES</title>
     <para>
       To emulate the behaviour of <emphasis>pam_wheel</emphasis>, except
@@ -288,7 +284,7 @@ type required othermodule.so arguments...
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_succeed_if-see_also'>
+  <refsect1 xml:id="pam_succeed_if-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -300,7 +296,7 @@ type required othermodule.so arguments...
     </para>
   </refsect1>
 
-  <refsect1 id='pam_succeed_if-author'>
+  <refsect1 xml:id="pam_succeed_if-author">
     <title>AUTHOR</title>
     <para>Nalin Dahyabhai &lt;nalin@redhat.com&gt;</para>
   </refsect1>

--- a/modules/pam_time/README.xml
+++ b/modules/pam_time/README.xml
@@ -1,34 +1,19 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamtime SYSTEM "pam_time.8.xml">
--->
-<!--
-<!ENTITY timeconf SYSTEM "time.conf.5.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_time.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_time-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_time.8.xml" xpointer='xpointer(id("pam_time-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_time.8.xml" xpointer='xpointer(//refsect1[@id = "pam_time-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_time.8.xml" xpointer='xpointer(id("pam_time-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="time.conf.5.xml" xpointer='xpointer(//refsect1[@id = "time.conf-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="time.conf.5.xml" xpointer='xpointer(id("time.conf-examples")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_time/pam_time.8.xml
+++ b/modules/pam_time/pam_time.8.xml
@@ -1,16 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
-
-<refentry id='pam_time'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_time">
 
   <refmeta>
     <refentrytitle>pam_time</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='setdesc'>Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_time-name'>
+  <refnamediv xml:id="pam_time-name">
     <refname>pam_time</refname>
     <refpurpose>
       PAM module for time control access
@@ -20,22 +17,22 @@
 <!-- body begins here -->
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_time-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_time-cmdsynopsis" sepchar=" ">
       <command>pam_time.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	conffile=conf-file
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         noaudit
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id="pam_time-description">
+  <refsect1 xml:id="pam_time-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_time PAM module does not authenticate the user, but instead
@@ -62,13 +59,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_time-options">
+  <refsect1 xml:id="pam_time-options">
     <title>OPTIONS</title>
     <variablelist>
 
      <varlistentry>
 	<term>
-	  <option>conffile=/path/to/time.conf</option>
+	  conffile=/path/to/time.conf
         </term>
         <listitem>
 	  <para>
@@ -79,7 +76,7 @@
 
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -91,7 +88,7 @@
 
       <varlistentry>
         <term>
-          <option>noaudit</option>
+          noaudit
         </term>
         <listitem>
           <para>
@@ -103,14 +100,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_time-types">
+  <refsect1 xml:id="pam_time-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>account</option> type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_time-return_values">
+  <refsect1 xml:id="pam_time-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -156,11 +153,11 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_time-files">
+  <refsect1 xml:id="pam_time-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/etc/security/time.conf</filename></term>
+        <term>/etc/security/time.conf</term>
         <listitem>
           <para>Default configuration file</para>
         </listitem>
@@ -168,7 +165,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_time-examples'>
+  <refsect1 xml:id="pam_time-examples">
     <title>EXAMPLES</title>
       <programlisting>
 #%PAM-1.0
@@ -179,7 +176,7 @@ login  account  required  pam_time.so
       </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_time-see_also">
+  <refsect1 xml:id="pam_time-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -194,7 +191,7 @@ login  account  required  pam_time.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_time-authors">
+  <refsect1 xml:id="pam_time-authors">
     <title>AUTHOR</title>
     <para>
       pam_time was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_time/time.conf.5.xml
+++ b/modules/pam_time/time.conf.5.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="time.conf">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="time.conf">
 
   <refmeta>
     <refentrytitle>time.conf</refentrytitle>
     <manvolnum>5</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -15,7 +12,7 @@
     <refpurpose>configuration file for the pam_time module</refpurpose>
   </refnamediv>
 
-  <refsect1 id='time.conf-description'>
+  <refsect1 xml:id="time.conf-description">
     <title>DESCRIPTION</title>
 
     <para>
@@ -43,9 +40,9 @@
     </para>
     <para>
       In words, each rule occupies a line, terminated with a newline
-      or the beginning of a comment; a '<emphasis remap='B'>#</emphasis>'.
+      or the beginning of a comment; a '<emphasis remap="B">#</emphasis>'.
       It contains four fields separated with semicolons,
-      '<emphasis remap='B'>;</emphasis>'.
+      '<emphasis remap="B">;</emphasis>'.
     </para>
 
     <para>
@@ -107,7 +104,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="time.conf-examples">
+  <refsect1 xml:id="time.conf-examples">
     <title>EXAMPLES</title>
     <para>
       These are some example lines which might be specified in
@@ -131,7 +128,7 @@ games ; * ; !waster ; Wd0000-2400 | Wk1800-0800
     </para>
   </refsect1>
 
-  <refsect1 id="time.conf-see_also">
+  <refsect1 xml:id="time.conf-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry><refentrytitle>pam_time</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
@@ -140,7 +137,7 @@ games ; * ; !waster ; Wd0000-2400 | Wk1800-0800
     </para>
   </refsect1>
 
-  <refsect1 id="time.conf-author">
+  <refsect1 xml:id="time.conf-author">
     <title>AUTHOR</title>
     <para>
       pam_time was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_timestamp/README.xml
+++ b/modules/pam_timestamp/README.xml
@@ -1,46 +1,31 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_timestamp.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_timestamp.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_timestamp-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-notes"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-notes")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_timestamp.8.xml" xpointer='xpointer(//refsect1[@id = "pam_timestamp-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_timestamp.8.xml" xpointer='xpointer(id("pam_timestamp-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_timestamp/pam_timestamp.8.xml
+++ b/modules/pam_timestamp/pam_timestamp.8.xml
@@ -1,39 +1,36 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_timestamp">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_timestamp">
 
   <refmeta>
     <refentrytitle>pam_timestamp</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_timestamp-name">
+  <refnamediv xml:id="pam_timestamp-name">
     <refname>pam_timestamp</refname>
     <refpurpose>Authenticate using cached successful authentication attempts</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_timestamp-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_timestamp-cmdsynopsis" sepchar=" ">
       <command>pam_timestamp.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         timestampdir=<replaceable>directory</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         timestamp_timeout=<replaceable>number</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         verbose
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         debug
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_timestamp-description">
+  <refsect1 xml:id="pam_timestamp-description">
 
     <title>DESCRIPTION</title>
 
@@ -52,18 +49,18 @@ file as grounds for succeeding.
     </para>
     <para condition="openssl_hmac">
       The default encryption hash is taken from the
-      <emphasis remap='B'>HMAC_CRYPTO_ALGO</emphasis> variable from
+      <emphasis remap="B">HMAC_CRYPTO_ALGO</emphasis> variable from
       <emphasis>/etc/login.defs</emphasis>.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_timestamp-options">
+  <refsect1 xml:id="pam_timestamp-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
          <term>
-            <option>timestampdir=<replaceable>directory</replaceable></option>
+            timestampdir=directory
          </term>
          <listitem>
             <para>
@@ -74,7 +71,7 @@ file as grounds for succeeding.
       </varlistentry>
       <varlistentry>
          <term>
-            <option>timestamp_timeout=<replaceable>number</replaceable></option>
+            timestamp_timeout=number
          </term>
          <listitem>
             <para>
@@ -86,7 +83,7 @@ file as grounds for succeeding.
       </varlistentry>
       <varlistentry>
          <term>
-            <option>verbose</option>
+            verbose
          </term>
          <listitem>
             <para>
@@ -96,7 +93,7 @@ file as grounds for succeeding.
       </varlistentry>
       <varlistentry>
          <term>
-            <option>debug</option>
+            debug
          </term>
          <listitem>
             <para>
@@ -109,7 +106,7 @@ file as grounds for succeeding.
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_timestamp-types">
+  <refsect1 xml:id="pam_timestamp-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>session</option>
@@ -117,7 +114,7 @@ file as grounds for succeeding.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-return_values'>
+  <refsect1 xml:id="pam_timestamp-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -148,7 +145,7 @@ file as grounds for succeeding.
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-notes'>
+  <refsect1 xml:id="pam_timestamp-notes">
     <title>NOTES</title>
     <para>
       Users can get confused when they are not always asked for passwords when
@@ -157,7 +154,7 @@ noticing that it is not being asked for.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-examples'>
+  <refsect1 xml:id="pam_timestamp-examples">
     <title>EXAMPLES</title>
     <programlisting>
 auth sufficient pam_timestamp.so verbose
@@ -168,11 +165,11 @@ session optional pam_timestamp.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_timestamp-files">
+  <refsect1 xml:id="pam_timestamp-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/var/run/pam_timestamp/...</filename></term>
+        <term>/var/run/pam_timestamp/...</term>
         <listitem>
           <para>timestamp files and directories</para>
         </listitem>
@@ -180,7 +177,7 @@ session optional pam_timestamp.so
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-see_also'>
+  <refsect1 xml:id="pam_timestamp-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -198,7 +195,7 @@ session optional pam_timestamp.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-author'>
+  <refsect1 xml:id="pam_timestamp-author">
     <title>AUTHOR</title>
       <para>
         pam_timestamp was written by Nalin Dahyabhai.

--- a/modules/pam_timestamp/pam_timestamp_check.8.xml
+++ b/modules/pam_timestamp/pam_timestamp_check.8.xml
@@ -1,36 +1,33 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_timestamp_check">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_timestamp_check">
 
   <refmeta>
     <refentrytitle>pam_timestamp_check</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_timestamp_check-name">
+  <refnamediv xml:id="pam_timestamp_check-name">
     <refname>pam_timestamp_check</refname>
     <refpurpose>Check to see if the default timestamp is valid</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_timestamp_check-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_timestamp_check-cmdsynopsis" sepchar=" ">
       <command>pam_timestamp_check</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	-k
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         -d
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         <replaceable>target_user</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_timestamp_check-description">
+  <refsect1 xml:id="pam_timestamp_check-description">
 
     <title>DESCRIPTION</title>
 
@@ -40,13 +37,13 @@ see if the default timestamp is valid, or optionally remove it.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_timestamp_check-options">
+  <refsect1 xml:id="pam_timestamp_check-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
          <term>
-            <option>-k</option>
+            -k
          </term>
          <listitem>
             <para>
@@ -57,7 +54,7 @@ see if the default timestamp is valid, or optionally remove it.
       </varlistentry>
       <varlistentry>
          <term>
-            <option>-d</option>
+            -d
          </term>
          <listitem>
             <para>
@@ -69,7 +66,7 @@ see if the default timestamp is valid, or optionally remove it.
       </varlistentry>
       <varlistentry>
          <term>
-            <option><replaceable>target_user</replaceable></option>
+            target_user
          </term>
          <listitem>
             <para>
@@ -85,7 +82,7 @@ see if the default timestamp is valid, or optionally remove it.
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_timestamp_check-return_values'>
+  <refsect1 xml:id="pam_timestamp_check-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -147,7 +144,7 @@ see if the default timestamp is valid, or optionally remove it.
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-notes'>
+  <refsect1 xml:id="pam_timestamp-notes">
     <title>NOTES</title>
     <para>
       Users can get confused when they are not always asked for passwords when
@@ -156,7 +153,7 @@ noticing that it is not being asked for.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-examples'>
+  <refsect1 xml:id="pam_timestamp-examples">
     <title>EXAMPLES</title>
     <programlisting>
 auth sufficient pam_timestamp.so verbose
@@ -167,11 +164,11 @@ session optional pam_timestamp.so
     </programlisting>
   </refsect1>
 
-  <refsect1 id="pam_timestamp-files">
+  <refsect1 xml:id="pam_timestamp-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>/var/run/sudo/...</filename></term>
+        <term>/var/run/sudo/...</term>
         <listitem>
           <para>timestamp files and directories</para>
         </listitem>
@@ -179,7 +176,7 @@ session optional pam_timestamp.so
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-see_also'>
+  <refsect1 xml:id="pam_timestamp-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -197,7 +194,7 @@ session optional pam_timestamp.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_timestamp-author'>
+  <refsect1 xml:id="pam_timestamp-author">
     <title>AUTHOR</title>
       <para>
         pam_timestamp was written by Nalin Dahyabhai.

--- a/modules/pam_tty_audit/README.xml
+++ b/modules/pam_tty_audit/README.xml
@@ -1,41 +1,31 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd">
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_tty_audit.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_tty_audit-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-notes"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-notes")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_tty_audit.8.xml" xpointer='xpointer(//refsect1[@id = "pam_tty_audit-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_tty_audit.8.xml" xpointer='xpointer(id("pam_tty_audit-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_tty_audit/pam_tty_audit.8.xml
+++ b/modules/pam_tty_audit/pam_tty_audit.8.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_tty_audit">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_tty_audit">
 
   <refmeta>
     <refentrytitle>pam_tty_audit</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_tty_audit-name">
+  <refnamediv xml:id="pam_tty_audit-name">
     <refname>pam_tty_audit</refname>
     <refpurpose>Enable or disable TTY auditing for specified users</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_tty_audit-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_tty_audit-cmdsynopsis" sepchar=" ">
       <command>pam_tty_audit.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	disable=<replaceable>patterns</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	enable=<replaceable>patterns</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_tty_audit-description">
+  <refsect1 xml:id="pam_tty_audit-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_tty_audit PAM module is used to enable or disable TTY auditing.
@@ -35,12 +32,12 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_tty_audit-options">
+  <refsect1 xml:id="pam_tty_audit-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>disable=<replaceable>patterns</replaceable></option>
+          disable=patterns
         </term>
         <listitem>
           <para>
@@ -53,7 +50,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>enable=<replaceable>patterns</replaceable></option>
+          enable=patterns
         </term>
         <listitem>
           <para>
@@ -66,7 +63,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>open_only</option>
+          open_only
         </term>
         <listitem>
           <para>
@@ -79,7 +76,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>log_passwd</option>
+          log_passwd
         </term>
         <listitem>
           <para>
@@ -93,14 +90,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_tty_audit-types">
+  <refsect1 xml:id="pam_tty_audit-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
-      Only the <emphasis remap='B'>session</emphasis> type is supported.
+      Only the <emphasis remap="B">session</emphasis> type is supported.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_tty_audit-return_values'>
+  <refsect1 xml:id="pam_tty_audit-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -125,7 +122,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_tty_audit-notes'>
+  <refsect1 xml:id="pam_tty_audit-notes">
     <title>NOTES</title>
     <para>
       When TTY auditing is enabled, it is inherited by all processes started by
@@ -158,7 +155,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_tty_audit-examples'>
+  <refsect1 xml:id="pam_tty_audit-examples">
     <title>EXAMPLES</title>
     <para>
       Audit all administrative actions.
@@ -168,7 +165,7 @@ session	required pam_tty_audit.so disable=* enable=root
     </para>
   </refsect1>
 
-  <refsect1 id='pam_tty_audit-see_also'>
+  <refsect1 xml:id="pam_tty_audit-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -186,10 +183,10 @@ session	required pam_tty_audit.so disable=* enable=root
     </para>
   </refsect1>
 
-  <refsect1 id='pam_tty_audit-author'>
+  <refsect1 xml:id="pam_tty_audit-author">
     <title>AUTHOR</title>
       <para>
-        pam_tty_audit was written by Miloslav Trma&ccaron;
+        pam_tty_audit was written by Miloslav Trmač
 	&lt;mitr@redhat.com&gt;.
         The log_passwd option was added by Richard Guy Briggs
         &lt;rgb@redhat.com&gt;.

--- a/modules/pam_umask/README.xml
+++ b/modules/pam_umask/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_umask.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_umask.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_umask-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_umask.8.xml" xpointer='xpointer(id("pam_umask-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_umask.8.xml" xpointer='xpointer(id("pam_umask-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_umask.8.xml" xpointer='xpointer(id("pam_umask-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_umask.8.xml" xpointer='xpointer(id("pam_umask-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_umask.8.xml" xpointer='xpointer(//refsect1[@id = "pam_umask-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_umask.8.xml" xpointer='xpointer(id("pam_umask-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_umask/pam_umask.8.xml
+++ b/modules/pam_umask/pam_umask.8.xml
@@ -1,42 +1,39 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_umask">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_umask">
 
   <refmeta>
     <refentrytitle>pam_umask</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_umask-name">
+  <refnamediv xml:id="pam_umask-name">
     <refname>pam_umask</refname>
     <refpurpose>PAM module to set the file mode creation mask</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_umask-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_umask-cmdsynopsis" sepchar=" ">
       <command>pam_umask.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         silent
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         usergroups
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         nousergroups
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         umask=<replaceable>mask</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_umask-description">
+  <refsect1 xml:id="pam_umask-description">
 
     <title>DESCRIPTION</title>
 
@@ -81,7 +78,7 @@
 
   </refsect1>
 
-  <refsect1 id="pam_umask-options">
+  <refsect1 xml:id="pam_umask-options">
 
     <title>OPTIONS</title>
     <para>
@@ -89,7 +86,7 @@
 
         <varlistentry>
           <term>
-            <option>debug</option>
+            debug
           </term>
           <listitem>
             <para>
@@ -100,7 +97,7 @@
 
         <varlistentry>
           <term>
-            <option>silent</option>
+            silent
           </term>
           <listitem>
             <para>
@@ -111,20 +108,20 @@
 
         <varlistentry>
           <term>
-            <option>usergroups</option>
+            usergroups
           </term>
           <listitem>
             <para>
               If the user is not root and the username is the same as
               primary group name, the umask group bits are set to be the
-              same as owner bits (examples: 022 -> 002, 077 -> 007).
+              same as owner bits (examples: 022 -&gt; 002, 077 -&gt; 007).
             </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>
-            <option>nousergroups</option>
+            nousergroups
           </term>
           <listitem>
             <para>
@@ -137,7 +134,7 @@
 
         <varlistentry>
           <term>
-            <option>umask=<replaceable>mask</replaceable></option>
+            umask=mask
           </term>
           <listitem>
             <para>
@@ -153,14 +150,14 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_umask-types">
+  <refsect1 xml:id="pam_umask-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       Only the <option>session</option> type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_umask-return_values'>
+  <refsect1 xml:id="pam_umask-return_values">
     <title>RETURN VALUES</title>
     <para>
       <variablelist>
@@ -225,7 +222,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_umask-examples'>
+  <refsect1 xml:id="pam_umask-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/login</filename> to
@@ -236,7 +233,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_umask-see_also'>
+  <refsect1 xml:id="pam_umask-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -251,7 +248,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_umask-author'>
+  <refsect1 xml:id="pam_umask-author">
     <title>AUTHOR</title>
       <para>
         pam_umask was written by Thorsten Kukuk &lt;kukuk@thkukuk.de&gt;.

--- a/modules/pam_unix/README.xml
+++ b/modules/pam_unix/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_unix.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_unix.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_unix-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_unix.8.xml" xpointer='xpointer(id("pam_unix-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_unix.8.xml" xpointer='xpointer(id("pam_unix-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_unix.8.xml" xpointer='xpointer(id("pam_unix-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_unix.8.xml" xpointer='xpointer(id("pam_unix-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_unix.8.xml" xpointer='xpointer(//refsect1[@id = "pam_unix-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_unix.8.xml" xpointer='xpointer(id("pam_unix-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_unix">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_unix">
 
   <refmeta>
     <refentrytitle>pam_unix</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_unix-name">
+  <refnamediv xml:id="pam_unix-name">
     <refname>pam_unix</refname>
     <refpurpose>Module for traditional password authentication</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_unix-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_unix-cmdsynopsis" sepchar=" ">
       <command>pam_unix.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ...
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_unix-description">
+  <refsect1 xml:id="pam_unix-description">
 
     <title>DESCRIPTION</title>
 
@@ -42,7 +39,7 @@
       <emphasis>shadow</emphasis> elements: expire, last_change, max_change,
       min_change, warn_change. In the case of the latter, it may offer advice
       to the user on changing their password or, through the
-      <emphasis remap='B'>PAM_AUTHTOKEN_REQD</emphasis> return, delay
+      <emphasis remap="B">PAM_AUTHTOKEN_REQD</emphasis> return, delay
       giving service to the user until they have established a new password.
       The entries listed above are documented in the <citerefentry>
       <refentrytitle>shadow</refentrytitle><manvolnum>5</manvolnum>
@@ -89,7 +86,7 @@
     <para>
       The password component of this module performs the task of updating
       the user's password. The default encryption hash is taken from the
-      <emphasis remap='B'>ENCRYPT_METHOD</emphasis> variable from
+      <emphasis remap="B">ENCRYPT_METHOD</emphasis> variable from
       <emphasis>/etc/login.defs</emphasis>
     </para>
 
@@ -107,13 +104,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_unix-options">
+  <refsect1 xml:id="pam_unix-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -127,7 +124,7 @@
 
       <varlistentry>
         <term>
-          <option>audit</option>
+          audit
         </term>
         <listitem>
           <para>
@@ -138,7 +135,7 @@
 
       <varlistentry>
         <term>
-          <option>quiet</option>
+          quiet
         </term>
         <listitem>
           <para>
@@ -153,7 +150,7 @@
 
       <varlistentry>
         <term>
-          <option>nullok</option>
+          nullok
         </term>
         <listitem>
           <para>
@@ -165,7 +162,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nullresetok</option>
+          nullresetok
         </term>
         <listitem>
           <para>
@@ -178,7 +175,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>try_first_pass</option>
+          try_first_pass
         </term>
         <listitem>
           <para>
@@ -190,7 +187,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_first_pass</option>
+          use_first_pass
         </term>
         <listitem>
           <para>
@@ -203,7 +200,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nodelay</option>
+          nodelay
         </term>
         <listitem>
           <para>
@@ -216,7 +213,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_authtok</option>
+          use_authtok
         </term>
         <listitem>
           <para>
@@ -230,7 +227,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>authtok_type=<replaceable>type</replaceable></option>
+          authtok_type=type
         </term>
         <listitem>
           <para>
@@ -242,7 +239,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>nis</option>
+          nis
         </term>
         <listitem>
           <para>
@@ -252,7 +249,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>remember=<replaceable>n</replaceable></option>
+          remember=n
         </term>
         <listitem>
           <para>
@@ -269,7 +266,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>shadow</option>
+          shadow
         </term>
         <listitem>
           <para>
@@ -279,7 +276,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>md5</option>
+          md5
         </term>
         <listitem>
           <para>
@@ -290,7 +287,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>bigcrypt</option>
+          bigcrypt
         </term>
         <listitem>
           <para>
@@ -301,7 +298,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>sha256</option>
+          sha256
         </term>
         <listitem>
           <para>
@@ -315,7 +312,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>sha512</option>
+          sha512
         </term>
         <listitem>
           <para>
@@ -329,7 +326,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>blowfish</option>
+          blowfish
         </term>
         <listitem>
           <para>
@@ -343,7 +340,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>gost_yescrypt</option>
+          gost_yescrypt
         </term>
         <listitem>
           <para>
@@ -357,7 +354,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>yescrypt</option>
+          yescrypt
         </term>
         <listitem>
           <para>
@@ -371,7 +368,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>rounds=<replaceable>n</replaceable></option>
+          rounds=n
         </term>
         <listitem>
           <para>
@@ -384,7 +381,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>broken_shadow</option>
+          broken_shadow
         </term>
         <listitem>
           <para>
@@ -395,7 +392,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>minlen=<replaceable>n</replaceable></option>
+          minlen=n
         </term>
         <listitem>
           <para>
@@ -407,7 +404,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>no_pass_expiry</option>
+          no_pass_expiry
         </term>
         <listitem>
           <para>
@@ -418,9 +415,9 @@
             meaning that other authentication source or method succeeded.
             The example can be public key authentication in
             <emphasis>sshd</emphasis>. The module will return
-            <emphasis remap='B'>PAM_SUCCESS</emphasis> instead of eventual
-            <emphasis remap='B'>PAM_NEW_AUTHTOK_REQD</emphasis> or
-            <emphasis remap='B'>PAM_AUTHTOK_EXPIRED</emphasis>.
+            <emphasis remap="B">PAM_SUCCESS</emphasis> instead of eventual
+            <emphasis remap="B">PAM_NEW_AUTHTOK_REQD</emphasis> or
+            <emphasis remap="B">PAM_AUTHTOK_EXPIRED</emphasis>.
           </para>
         </listitem>
       </varlistentry>
@@ -432,7 +429,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_unix-types">
+  <refsect1 xml:id="pam_unix-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>account</option>, <option>auth</option>,
@@ -440,7 +437,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_unix-return_values'>
+  <refsect1 xml:id="pam_unix-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -454,7 +451,7 @@
     </variablelist>
      </refsect1>
 
-  <refsect1 id='pam_unix-examples'>
+  <refsect1 xml:id="pam_unix-examples">
     <title>EXAMPLES</title>
     <para>
       An example usage for <filename>/etc/pam.d/login</filename>
@@ -473,7 +470,7 @@ session    required   pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_unix-see_also'>
+  <refsect1 xml:id="pam_unix-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -491,7 +488,7 @@ session    required   pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_unix-author'>
+  <refsect1 xml:id="pam_unix-author">
     <title>AUTHOR</title>
       <para>
         pam_unix was written by various people.

--- a/modules/pam_unix/unix_chkpwd.8.xml
+++ b/modules/pam_unix/unix_chkpwd.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="unix_chkpwd">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="unix_chkpwd">
 
   <refmeta>
     <refentrytitle>unix_chkpwd</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="unix_chkpwd-name">
+  <refnamediv xml:id="unix_chkpwd-name">
     <refname>unix_chkpwd</refname>
     <refpurpose>Helper binary that verifies the password of the current user</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="unix_chkpwd-cmdsynopsis">
+    <cmdsynopsis xml:id="unix_chkpwd-cmdsynopsis" sepchar=" ">
       <command>unix_chkpwd</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ...
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="unix_chkpwd-description">
+  <refsect1 xml:id="unix_chkpwd-description">
 
     <title>DESCRIPTION</title>
 
@@ -48,7 +45,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='unix_chkpwd-see_also'>
+  <refsect1 xml:id="unix_chkpwd-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -57,7 +54,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='unix_chkpwd-author'>
+  <refsect1 xml:id="unix_chkpwd-author">
     <title>AUTHOR</title>
       <para>
         Written by Andrew Morgan and other various people.

--- a/modules/pam_unix/unix_update.8.xml
+++ b/modules/pam_unix/unix_update.8.xml
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="unix_update">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="unix_update">
 
   <refmeta>
     <refentrytitle>unix_update</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="unix_update-name">
+  <refnamediv xml:id="unix_update-name">
     <refname>unix_update</refname>
     <refpurpose>Helper binary that updates the password of a given user</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="unix_update-cmdsynopsis">
+    <cmdsynopsis xml:id="unix_update-cmdsynopsis" sepchar=" ">
       <command>unix_update</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         ...
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="unix_update-description">
+  <refsect1 xml:id="unix_update-description">
 
     <title>DESCRIPTION</title>
 
@@ -48,7 +45,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='unix_update-see_also'>
+  <refsect1 xml:id="unix_update-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -57,7 +54,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='unix_update-author'>
+  <refsect1 xml:id="unix_update-author">
     <title>AUTHOR</title>
       <para>
         Written by Tomas Mraz and other various people.

--- a/modules/pam_userdb/README.xml
+++ b/modules/pam_userdb/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_userdb.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_userdb.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_userdb-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_userdb.8.xml" xpointer='xpointer(//refsect1[@id = "pam_userdb-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_userdb.8.xml" xpointer='xpointer(id("pam_userdb-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_userdb/pam_userdb.8.xml
+++ b/modules/pam_userdb/pam_userdb.8.xml
@@ -1,54 +1,51 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_userdb">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_userdb">
 
   <refmeta>
     <refentrytitle>pam_userdb</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_userdb-name">
+  <refnamediv xml:id="pam_userdb-name">
     <refname>pam_userdb</refname>
     <refpurpose>PAM module to authenticate against a db database</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_userdb-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_userdb-cmdsynopsis" sepchar=" ">
       <command>pam_userdb.so</command>
-      <arg choice="plain">
+      <arg choice="plain" rep="norepeat">
 	db=<replaceable>/path/database</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         crypt=[crypt|none]
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         icase
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         dump
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         try_first_pass
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         use_first_pass
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         unknown_ok
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         key_only
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_userdb-description">
+  <refsect1 xml:id="pam_userdb-description">
 
     <title>DESCRIPTION</title>
 
@@ -60,13 +57,13 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_userdb-options">
+  <refsect1 xml:id="pam_userdb-options">
 
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>crypt=[crypt|none]</option>
+          crypt=[crypt|none]
         </term>
         <listitem>
           <para>
@@ -82,13 +79,13 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>db=<replaceable>/path/database</replaceable></option>
+          db=/path/database
         </term>
         <listitem>
           <para>
             Use the <filename>/path/database</filename> database for
             performing lookup. There is no default; the module will
-            return <emphasis remap='B'>PAM_IGNORE</emphasis> if no
+            return <emphasis remap="B">PAM_IGNORE</emphasis> if no
             database is provided. Note that the path to the database file
             should be specified without the <filename>.db</filename> suffix.
           </para>
@@ -96,7 +93,7 @@
       </varlistentry>
        <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -107,7 +104,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>dump</option>
+          dump
         </term>
         <listitem>
           <para>
@@ -118,7 +115,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>icase</option>
+          icase
         </term>
         <listitem>
           <para>
@@ -131,7 +128,7 @@
 
       <varlistentry>
         <term>
-          <option>try_first_pass</option>
+          try_first_pass
         </term>
         <listitem>
           <para>
@@ -146,7 +143,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_first_pass</option>
+          use_first_pass
         </term>
         <listitem>
           <para>
@@ -161,7 +158,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>unknown_ok</option>
+          unknown_ok
         </term>
         <listitem>
           <para>
@@ -174,7 +171,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>key_only</option>
+          key_only
         </term>
         <listitem>
           <para>
@@ -191,7 +188,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_userdb-types">
+  <refsect1 xml:id="pam_userdb-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option> and <option>account</option> module
@@ -199,7 +196,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_userdb-return_values'>
+  <refsect1 xml:id="pam_userdb-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -259,14 +256,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_userdb-examples'>
+  <refsect1 xml:id="pam_userdb-examples">
     <title>EXAMPLES</title>
     <programlisting>
 auth  sufficient pam_userdb.so icase db=/etc/dbtest
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_userdb-see_also'>
+  <refsect1 xml:id="pam_userdb-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -284,7 +281,7 @@ auth  sufficient pam_userdb.so icase db=/etc/dbtest
     </para>
   </refsect1>
 
-  <refsect1 id='pam_userdb-author'>
+  <refsect1 xml:id="pam_userdb-author">
     <title>AUTHOR</title>
       <para>
         pam_userdb was written by Cristian Gafton &gt;gafton@redhat.com&lt;.

--- a/modules/pam_usertype/README.xml
+++ b/modules/pam_usertype/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_usertype.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_usertype.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_usertype-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_usertype.8.xml" xpointer='xpointer(id("pam_usertype-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_usertype.8.xml" xpointer='xpointer(//refsect1[@id = "pam_usertype-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_usertype.8.xml" xpointer='xpointer(id("pam_usertype-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_usertype.8.xml" xpointer='xpointer(//refsect1[@id = "pam_usertype-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_usertype.8.xml" xpointer='xpointer(id("pam_usertype-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_usertype.8.xml" xpointer='xpointer(//refsect1[@id = "pam_usertype-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_usertype.8.xml" xpointer='xpointer(id("pam_usertype-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_usertype.8.xml" xpointer='xpointer(//refsect1[@id = "pam_usertype-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_usertype.8.xml" xpointer='xpointer(id("pam_usertype-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_usertype/pam_usertype.8.xml
+++ b/modules/pam_usertype/pam_usertype.8.xml
@@ -1,31 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-        "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-
-<refentry id='pam_usertype'>
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_usertype">
   <refmeta>
     <refentrytitle>pam_usertype</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class='sectdesc'>Linux-PAM</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id='pam_usertype-name'>
+  <refnamediv xml:id="pam_usertype-name">
     <refname>pam_usertype</refname>
     <refpurpose>check if the authenticated user is a system or regular account</refpurpose>
   </refnamediv>
 
 
   <refsynopsisdiv>
-    <cmdsynopsis id='pam_usertype-cmdsynopsis'>
+    <cmdsynopsis xml:id="pam_usertype-cmdsynopsis" sepchar=" ">
       <command>pam_usertype.so</command>
-      <arg choice='opt' rep='repeat'><replaceable>flag</replaceable></arg>
-      <arg choice='req'><replaceable>condition</replaceable></arg>
+      <arg choice="opt" rep="repeat"><replaceable>flag</replaceable></arg>
+      <arg choice="req" rep="norepeat"><replaceable>condition</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
 
-  <refsect1 id='pam_usertype-description'>
+  <refsect1 xml:id="pam_usertype-description">
     <title>DESCRIPTION</title>
     <para>
       pam_usertype.so is designed to succeed or fail authentication
@@ -42,7 +38,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id="pam_usertype-options">
+  <refsect1 xml:id="pam_usertype-options">
     <title>OPTIONS</title>
     <para>
       The following <emphasis>flag</emphasis>s are supported:
@@ -50,7 +46,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><option>use_uid</option></term>
+        <term>use_uid</term>
         <listitem>
           <para>
             Evaluate conditions using the account of the user whose UID
@@ -60,7 +56,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>audit</option></term>
+        <term>audit</term>
         <listitem>
           <para>
             Log unknown users to the system log.
@@ -75,13 +71,13 @@
 
     <variablelist>
       <varlistentry>
-        <term><option>issystem</option></term>
+        <term>issystem</term>
         <listitem>
           <para>Succeed if the user is a system user.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>isregular</option></term>
+        <term>isregular</term>
         <listitem>
           <para>Succeed if the user is a regular user.</para>
         </listitem>
@@ -89,7 +85,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_usertype-types">
+  <refsect1 xml:id="pam_usertype-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       All module types (<option>account</option>, <option>auth</option>,
@@ -97,7 +93,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_usertype-return_values'>
+  <refsect1 xml:id="pam_usertype-return_values">
     <title>RETURN VALUES</title>
      <variablelist>
 
@@ -170,7 +166,7 @@
   </refsect1>
 
 
-  <refsect1 id='pam_usertype-examples'>
+  <refsect1 xml:id="pam_usertype-examples">
     <title>EXAMPLES</title>
     <para>
       Skip remaining modules if the user is a system user:
@@ -180,7 +176,7 @@ account sufficient pam_usertype.so issystem
     </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_usertype-see_also'>
+  <refsect1 xml:id="pam_usertype-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -192,7 +188,7 @@ account sufficient pam_usertype.so issystem
     </para>
   </refsect1>
 
-  <refsect1 id='pam_usertype-author'>
+  <refsect1 xml:id="pam_usertype-author">
     <title>AUTHOR</title>
     <para>Pavel Březina &lt;pbrezina@redhat.com&gt;</para>
   </refsect1>

--- a/modules/pam_warn/README.xml
+++ b/modules/pam_warn/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_warn.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_warn.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_warn-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_warn.8.xml" xpointer='xpointer(id("pam_warn-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_warn.8.xml" xpointer='xpointer(id("pam_warn-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_warn.8.xml" xpointer='xpointer(id("pam_warn-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_warn.8.xml" xpointer='xpointer(id("pam_warn-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_warn.8.xml" xpointer='xpointer(//refsect1[@id = "pam_warn-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_warn.8.xml" xpointer='xpointer(id("pam_warn-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_warn/pam_warn.8.xml
+++ b/modules/pam_warn/pam_warn.8.xml
@@ -1,25 +1,22 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_warn">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_warn">
 
   <refmeta>
     <refentrytitle>pam_warn</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
-  <refnamediv id="pam_warn-name">
+  <refnamediv xml:id="pam_warn-name">
     <refname>pam_warn</refname>
     <refpurpose>PAM module which logs all PAM items if called</refpurpose>
   </refnamediv>
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_warn-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_warn-cmdsynopsis" sepchar=" ">
       <command>pam_warn.so</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_warn-description">
+  <refsect1 xml:id="pam_warn-description">
     <title>DESCRIPTION</title>
     <para>
       pam_warn is a PAM module that logs the service, terminal, user,
@@ -28,17 +25,17 @@
 	<refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum>
       </citerefentry>. The items are not probed for, but instead obtained
       from the standard PAM items. The module always returns
-      <emphasis remap='B'>PAM_IGNORE</emphasis>, indicating that it
+      <emphasis remap="B">PAM_IGNORE</emphasis>, indicating that it
       does not want to affect the authentication process.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_warn-options">
+  <refsect1 xml:id="pam_warn-options">
     <title>OPTIONS</title>
     <para>This module does not recognise any options.</para>
   </refsect1>
 
-  <refsect1 id="pam_warn-types">
+  <refsect1 xml:id="pam_warn-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
       The <option>auth</option>, <option>account</option>,
@@ -47,7 +44,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='pam_warn-return_values'>
+  <refsect1 xml:id="pam_warn-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -61,7 +58,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_warn-examples'>
+  <refsect1 xml:id="pam_warn-examples">
     <title>EXAMPLES</title>
       <programlisting>
 #%PAM-1.0
@@ -80,7 +77,7 @@ other session  required       pam_deny.so
       </programlisting>
   </refsect1>
 
-  <refsect1 id='pam_warn-see_also'>
+  <refsect1 xml:id="pam_warn-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -95,7 +92,7 @@ other session  required       pam_deny.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_warn-author'>
+  <refsect1 xml:id="pam_warn-author">
     <title>AUTHOR</title>
       <para>
         pam_warn was written by Andrew G. Morgan &lt;morgan@kernel.org&gt;.

--- a/modules/pam_wheel/README.xml
+++ b/modules/pam_wheel/README.xml
@@ -1,41 +1,27 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_wheel.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_wheel.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_wheel-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_wheel.8.xml" xpointer='xpointer(//refsect1[@id = "pam_wheel-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_wheel.8.xml" xpointer='xpointer(id("pam_wheel-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_wheel/pam_wheel.8.xml
+++ b/modules/pam_wheel/pam_wheel.8.xml
@@ -1,45 +1,42 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_wheel">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_wheel">
 
   <refmeta>
     <refentrytitle>pam_wheel</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_wheel-name">
+  <refnamediv xml:id="pam_wheel-name">
     <refname>pam_wheel</refname>
     <refpurpose>Only permit root access to members of group wheel</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_wheel-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_wheel-cmdsynopsis" sepchar=" ">
       <command>pam_wheel.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         deny
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	group=<replaceable>name</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	root_only
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	trust
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	use_uid
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_wheel-description">
+  <refsect1 xml:id="pam_wheel-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_wheel PAM module is used to enforce the so-called
@@ -47,16 +44,16 @@
       access to the target user if the applicant user is a member of the
       <emphasis>wheel</emphasis> group. If no group with this name exist,
       the module is using the group with the group-ID
-      <emphasis remap='B'>0</emphasis>.
+      <emphasis remap="B">0</emphasis>.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_wheel-options">
+  <refsect1 xml:id="pam_wheel-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -66,7 +63,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>deny</option>
+          deny
         </term>
         <listitem>
           <para>
@@ -81,7 +78,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>group=<replaceable>name</replaceable></option>
+          group=name
         </term>
         <listitem>
           <para>
@@ -93,7 +90,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>root_only</option>
+          root_only
         </term>
         <listitem>
           <para>
@@ -104,7 +101,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>trust</option>
+          trust
         </term>
         <listitem>
           <para>
@@ -118,7 +115,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>use_uid</option>
+          use_uid
         </term>
         <listitem>
           <para>
@@ -131,15 +128,15 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_wheel-types">
+  <refsect1 xml:id="pam_wheel-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
-      The <emphasis remap='B'>auth</emphasis> and
-      <emphasis remap='B'>account</emphasis> module types are provided.
+      The <emphasis remap="B">auth</emphasis> and
+      <emphasis remap="B">account</emphasis> module types are provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_wheel-return_values'>
+  <refsect1 xml:id="pam_wheel-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -204,7 +201,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_wheel-examples'>
+  <refsect1 xml:id="pam_wheel-examples">
     <title>EXAMPLES</title>
     <para>
       The root account gains access by default (rootok), only wheel
@@ -218,7 +215,7 @@ su      auth     required       pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_wheel-see_also'>
+  <refsect1 xml:id="pam_wheel-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -233,7 +230,7 @@ su      auth     required       pam_unix.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_wheel-author'>
+  <refsect1 xml:id="pam_wheel-author">
     <title>AUTHOR</title>
       <para>
         pam_wheel was written by Cristian Gafton &lt;gafton@redhat.com&gt;.

--- a/modules/pam_xauth/README.xml
+++ b/modules/pam_xauth/README.xml
@@ -1,46 +1,31 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-"http://www.docbook.org/xml/4.3/docbookx.dtd"
-[
-<!--
-<!ENTITY pamaccess SYSTEM "pam_xauth.8.xml">
--->
-]>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
 
-<article>
-
-  <articleinfo>
+  <info>
 
     <title>
-      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_xauth.8.xml" xpointer='xpointer(//refnamediv[@id = "pam_xauth-name"]/*)'/>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-name")/*)'/>
     </title>
 
-  </articleinfo>
+  </info>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-description"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-description")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-options"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-options")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-examples"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-examples")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-implementation"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-implementation")/*)'/>
   </section>
 
   <section>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
-      href="pam_xauth.8.xml" xpointer='xpointer(//refsect1[@id = "pam_xauth-author"]/*)'/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_xauth.8.xml" xpointer='xpointer(id("pam_xauth-author")/*)'/>
   </section>
 
 </article>

--- a/modules/pam_xauth/pam_xauth.8.xml
+++ b/modules/pam_xauth/pam_xauth.8.xml
@@ -1,39 +1,36 @@
-<?xml version="1.0" encoding='UTF-8'?>
-<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
-	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
-
-<refentry id="pam_xauth">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_xauth">
 
   <refmeta>
     <refentrytitle>pam_xauth</refentrytitle>
     <manvolnum>8</manvolnum>
-    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
   </refmeta>
 
-  <refnamediv id="pam_xauth-name">
+  <refnamediv xml:id="pam_xauth-name">
     <refname>pam_xauth</refname>
     <refpurpose>PAM module to forward xauth keys between users</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis id="pam_xauth-cmdsynopsis">
+    <cmdsynopsis xml:id="pam_xauth-cmdsynopsis" sepchar=" ">
       <command>pam_xauth.so</command>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
 	debug
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         xauthpath=<replaceable>/path/to/xauth</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         systemuser=<replaceable>UID</replaceable>
       </arg>
-      <arg choice="opt">
+      <arg choice="opt" rep="norepeat">
         targetuser=<replaceable>UID</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
-  <refsect1 id="pam_xauth-description">
+  <refsect1 xml:id="pam_xauth-description">
     <title>DESCRIPTION</title>
     <para>
       The pam_xauth PAM module is designed to forward xauth keys
@@ -81,25 +78,25 @@
       If a user has a <filename>.xauth/export</filename> file, the user will
       only forward cookies to users listed in the file. If there is no
       <filename>~/.xauth/export</filename> file, and the invoking user is
-      not <emphasis remap='B'>root</emphasis>, the user will forward cookies
+      not <emphasis remap="B">root</emphasis>, the user will forward cookies
       to any other user. If there is no <filename>~/.xauth/export</filename>
-      file, and the invoking user is <emphasis remap='B'>root</emphasis>,
-      the user will <emphasis remap='I'>not</emphasis> forward cookies to
+      file, and the invoking user is <emphasis remap="B">root</emphasis>,
+      the user will <emphasis remap="I">not</emphasis> forward cookies to
       other users.
     </para>
     <para>
       Both the import and export files support wildcards (such as
-      <emphasis remap='I'>*</emphasis>). Both the import and export files
+      <emphasis remap="I">*</emphasis>). Both the import and export files
       can be empty, signifying that no users are allowed.
     </para>
   </refsect1>
 
-  <refsect1 id="pam_xauth-options">
+  <refsect1 xml:id="pam_xauth-options">
     <title>OPTIONS</title>
     <variablelist>
       <varlistentry>
         <term>
-          <option>debug</option>
+          debug
         </term>
         <listitem>
           <para>
@@ -109,7 +106,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>xauthpath=<replaceable>/path/to/xauth</replaceable></option>
+          xauthpath=/path/to/xauth
         </term>
         <listitem>
           <para>
@@ -122,7 +119,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>systemuser=<replaceable>UID</replaceable></option>
+          systemuser=UID
         </term>
         <listitem>
           <para>
@@ -135,7 +132,7 @@
       </varlistentry>
       <varlistentry>
         <term>
-          <option>targetuser=<replaceable>UID</replaceable></option>
+          targetuser=UID
         </term>
         <listitem>
           <para>
@@ -147,14 +144,14 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id="pam_xauth-types">
+  <refsect1 xml:id="pam_xauth-types">
     <title>MODULE TYPES PROVIDED</title>
     <para>
-      Only the <emphasis remap='B'>session</emphasis> type is provided.
+      Only the <emphasis remap="B">session</emphasis> type is provided.
     </para>
   </refsect1>
 
-  <refsect1 id='pam_xauth-return_values'>
+  <refsect1 xml:id="pam_xauth-return_values">
     <title>RETURN VALUES</title>
     <variablelist>
       <varlistentry>
@@ -205,7 +202,7 @@
     </variablelist>
   </refsect1>
 
-  <refsect1 id='pam_xauth-examples'>
+  <refsect1 xml:id="pam_xauth-examples">
     <title>EXAMPLES</title>
     <para>
       Add the following line to <filename>/etc/pam.d/su</filename> to
@@ -216,10 +213,10 @@ session  optional  pam_xauth.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_xauth-implementation">
+  <refsect1 xml:id="pam_xauth-implementation">
     <title>IMPLEMENTATION DETAILS</title>
     <para>
-      pam_xauth will work <emphasis remap='I'>only</emphasis> if it is
+      pam_xauth will work <emphasis remap="I">only</emphasis> if it is
       used from a setuid application in which the
       <function>getuid</function>() call returns the id of the user
       running the application, and for which PAM can supply the name
@@ -247,17 +244,17 @@ session  optional  pam_xauth.so
     </para>
   </refsect1>
 
-  <refsect1 id="pam_lastlog-files">
+  <refsect1 xml:id="pam_lastlog-files">
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-        <term><filename>~/.xauth/import</filename></term>
+        <term>~/.xauth/import</term>
         <listitem>
           <para>XXX</para>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><filename>~/.xauth/export</filename></term>
+        <term>~/.xauth/export</term>
         <listitem>
           <para>XXX</para>
         </listitem>
@@ -266,7 +263,7 @@ session  optional  pam_xauth.so
   </refsect1>
 
 
-  <refsect1 id='pam_xauth-see_also'>
+  <refsect1 xml:id="pam_xauth-see_also">
     <title>SEE ALSO</title>
     <para>
       <citerefentry>
@@ -281,7 +278,7 @@ session  optional  pam_xauth.so
     </para>
   </refsect1>
 
-  <refsect1 id='pam_xauth-author'>
+  <refsect1 xml:id="pam_xauth-author">
     <title>AUTHOR</title>
       <para>
         pam_xauth was written by Nalin Dahyabhai &lt;nalin@redhat.com&gt;,


### PR DESCRIPTION
Make.xml.rules.in:
- Using RNG file instead of DTD file for checking XML files.
- Taking the correct stylesheet for README files.

doc/sag/Makefile.am, doc/adg/Makefile.am, doc/mwg/Makefile.am:
- Using RNG file instead of DTD file for checking XML files.

configure.ac:
- Adding a new option for selecting RNG check file (-enable-docbook-rng)
- Switching stylesheets to docbook 5
- Checking DocBook 5 environment instead of DocBook 4 environment

*.xml:
Update from DockBook 4 to DocBook 5