### PR TITLE
pam_shells: Use the vendor directory as fallback for a distribution provided default config if there is no one in /etc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -520,8 +520,7 @@ AC_ARG_ENABLE([econf],
   AS_HELP_STRING([--disable-econf], [do not use libeconf]),
   [WITH_ECONF=$enableval], WITH_ECONF=yes)
 if test "$WITH_ECONF" = "yes" ; then
-  PKG_CHECK_MODULES([ECONF], [libeconf], [],
-  [AC_CHECK_LIB([econf],[econf_readDirs],[ECONF_LIBS="-leconf"],[ECONF_LIBS=""])])
+  AC_CHECK_LIB([econf],[econf_readDirsWithCallback],[ECONF_LIBS="-leconf"],[ECONF_LIBS=""])
   if test -n "$ECONF_LIBS" ; then
     ECONF_CFLAGS="-DUSE_ECONF=1 $ECONF_CFLAGS"
   fi
@@ -535,7 +534,11 @@ if test -n "$enable_vendordir"; then
 		     [Directory for distribution provided configuration files])
   AC_DEFINE_UNQUOTED([VENDOR_SCONFIGDIR], ["$enable_vendordir/security"],
 		     [Directory for PAM modules distribution provided configuration files])
-  STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir'"
+  if test "$WITH_ECONF" = "yes" ; then
+    STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir;with_vendordir_and_with_econf'"
+  else
+    STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir;with_vendordir_and_without_econf"
+  fi
 else
   STRINGPARAM_VENDORDIR="--stringparam profile.condition 'without_vendordir'"
 fi

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -18,14 +18,14 @@ securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+	$(WARN_CFLAGS) $(ECONF_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
 
 securelib_LTLIBRARIES = pam_shells.la
-pam_shells_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_shells_la_LIBADD = $(top_builddir)/libpam/libpam.la $(ECONF_LIBS)
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_shells/pam_shells.8.xml
+++ b/modules/pam_shells/pam_shells.8.xml
@@ -29,9 +29,17 @@
       pam_shells is a PAM module that only allows access to the
       system if the user's shell is listed in <filename>/etc/shells</filename>.
     </para>
+
+    <para condition="with_vendordir_and_with_econf">
+      If this file does not exist, entries are taken from files
+      <filename>%vendordir%/shells</filename>,
+      <filename>%vendordir%/shells.d/*</filename> and
+      <filename>/etc/shells.d/*</filename> in that order.
+    </para>
+
     <para>
-      It also checks if <filename>/etc/shells</filename> is a plain
-      file and not world writable.
+      It also checks if needed files (e.g. <filename>/etc/shells</filename>) are plain
+      files and not world writable.
     </para>
   </refsect1>
 


### PR DESCRIPTION
Use the vendor directory as fallback for a distribution provided default config if there is no one in /etc.

If pam will be compiled with the option --enable-vendordir=<vendor_dir> and NOT defined 
--disable-econf, the files which define valid login shells will be parsed in following order:

- <vendor_dir>/shells
- <vendor_dir>/shells.d/*
- /etc/shells.d/shells

But all files in <vendor_dir> will be ingnored if the user has defined his
own file /etc/shells.

This PR should solve: https://github.com/linux-pam/linux-pam/issues/498

- Makefile.am: Add libeconf setting.
- pam_shells.c: Take care about the fallback configuration in the vendor directory.
- pam_shells.8.xml: Added description for the vendor directory.
- configure.ac: Added ECONF settings for building man pages.