### PR TITLE
pam_listfile: fix pointer misuse leading to data corruption

### DIFF
--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -53,17 +53,16 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
     const char *citemp;
     char *ifname=NULL;
     char aline[256];
-    char mybuf[256],myval[256];
+    char mybuf[256],myval[256],apply_val[256];
     struct stat fileinfo;
     FILE *inf;
-    const char *apply_val;
     int apply_type;
 
     /* Stuff for "extended" items */
     struct passwd *userinfo;
 
     apply_type=APPLY_TYPE_NULL;
-    apply_val="";
+    apply_val[0] = '\0';
 
     for(i=0; i < argc; i++) {
 	{
@@ -133,10 +132,10 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 		apply_type=APPLY_TYPE_NONE;
 		if (myval[0]=='@') {
 		    apply_type=APPLY_TYPE_GROUP;
-		    apply_val=myval+1;
+		    memcpy(apply_val,myval+1,sizeof(myval)-1);
 		} else {
 		    apply_type=APPLY_TYPE_USER;
-		    apply_val=myval;
+		    memcpy(apply_val,myval,sizeof(myval));
 		}
 	    } else {
 		free(ifname);


### PR DESCRIPTION
pam module listfile assume the group being tested will be written at the end of the argument list by carrying only a pointer to the value being examined in `myval` to `apply_val`

Therefore example
```
auth    required       pam_listfile.so \
        onerr=succeed apply=ftp item=user sense=deny file=/etc/ftpusers
```

modified from https://linux.die.net/man/8/pam_listfile is not working because `apply_val` will point to the latest value of `myval` which in this case will be `/etc/ftpusers` instead of `ftp`

This PR fixes this issue by copying the value of `myval` to `apply_val` instead of just taking a reference pointer