### PR TITLE
pam_env: _parse_line: fix quoteflg handled

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -293,7 +293,8 @@ _parse_line(const pam_handle_t *pamh, const char *buffer, VAR *var)
       }
       (void)strncpy(*valptr,ptr,length);
       (*valptr)[length]='\0';
-    } else if (quoteflg--) {
+    } else if (quoteflg) {
+      quoteflg--;
       *valptr = &quote;      /* a quick hack to handle the empty string */
     }
     ptr = tmpptr;         /* Start the search where we stopped */


### PR DESCRIPTION
The quoteflg can become negative, creating an inconsistent behavior for quoted and unquoted empty string as explained in the issue #10. 
It shows an use case where length=0 and quoteflg=0, the condition `else if(quoteflg--){}` will not be validate but still decrement the flag to become <0. As a result, the condition at the next step will be validate.

Fix: #10 

Signed-off-by: Valentin Lefebvre <valentin.lefebvre@suse.com>