### PR TITLE
pam_selinux: treat getenforce failures as enforcing

### DIFF
--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -553,7 +553,7 @@ compute_tty_context(const pam_handle_t *pamh, module_data_t *data)
     }
     pam_syslog(pamh, LOG_ERR, "Failed to get current context for %s: %m",
 	       data->tty_path);
-    return (security_getenforce() == 1) ? PAM_SESSION_ERR : PAM_SUCCESS;
+    return (security_getenforce() != 0) ? PAM_SESSION_ERR : PAM_SUCCESS;
   }
 
   tclass = string_to_security_class("chr_file");
@@ -563,7 +563,7 @@ compute_tty_context(const pam_handle_t *pamh, module_data_t *data)
     data->prev_tty_context = NULL;
     free(data->tty_path);
     data->tty_path = NULL;
-    return (security_getenforce() == 1) ? PAM_SESSION_ERR : PAM_SUCCESS;
+    return (security_getenforce() != 0) ? PAM_SESSION_ERR : PAM_SUCCESS;
   }
 
   if (security_compute_relabel(data->exec_context, data->prev_tty_context,
@@ -575,7 +575,7 @@ compute_tty_context(const pam_handle_t *pamh, module_data_t *data)
     data->prev_tty_context = NULL;
     free(data->tty_path);
     data->tty_path = NULL;
-    return (security_getenforce() == 1) ? PAM_SESSION_ERR : PAM_SUCCESS;
+    return (security_getenforce() != 0) ? PAM_SESSION_ERR : PAM_SUCCESS;
   }
 
   return PAM_SUCCESS;
@@ -606,7 +606,7 @@ restore_context(const pam_handle_t *pamh, const module_data_t *data, int debug)
 	       data->prev_exec_context ? data->prev_exec_context : "");
   err |= set_exec_context(pamh, data->prev_exec_context);
 
-  if (err && security_getenforce() == 1)
+  if (err && security_getenforce() != 0)
     return PAM_SESSION_ERR;
 
   return PAM_SUCCESS;
@@ -658,7 +658,7 @@ set_context(pam_handle_t *pamh, const module_data_t *data,
   }
 #endif
 
-  if (err && security_getenforce() == 1)
+  if (err && security_getenforce() != 0)
     return PAM_SESSION_ERR;
 
   return PAM_SUCCESS;
@@ -717,7 +717,7 @@ create_context(pam_handle_t *pamh, int argc, const char **argv,
 
   if (!data->exec_context) {
     free_module_data(data);
-    return (security_getenforce() == 1) ? PAM_SESSION_ERR : PAM_SUCCESS;
+    return (security_getenforce() != 0) ? PAM_SESSION_ERR : PAM_SUCCESS;
   }
 
   if (ttys && (i = compute_tty_context(pamh, data)) != PAM_SUCCESS) {


### PR DESCRIPTION
security_getenforce(3) can return -1 on error; either because the selinuxfs is not mounted or reading from /sys/fs/selinux/enforce failed.

Since security_getenforce(3) is either called after an approving call to is_selinux_enabled(3) in create_context() or with populated module data in restore_context(), which requires a previous pass of create_context(), the selinuxfs should be mounted. Reading from /sys/fs/selinux/enforce should never fail (except being prohibited by the SElinux policy itself) since it is a public interface.

In the unlikely case of security_getenforce(3) nevertheless failing continue execution as if the result was enforcing (likewise to pam_sepermit and pam_rootok).