### PR TITLE
Update for gcc-12 and clang-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,26 @@ jobs:
     - name: check
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
-  gcc11-x86_64-vendordir:
+  gcc12-x86_64-vendordir:
     runs-on: ubuntu-latest
     env:
-      CC: gcc-11
+      CC: gcc-12
       TARGET: x86_64
       VENDORDIR: /usr/etc
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  gcc12-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-12
+      TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
       with:
@@ -70,12 +84,40 @@ jobs:
     - name: build check
       run: ci/run-build-and-tests.sh
 
-  clang12-x86_64-vendordir:
+  clang14-x86_64-vendordir:
     runs-on: ubuntu-latest
     env:
-      CC: clang-12
+      CC: clang-14
       TARGET: x86_64
       VENDORDIR: /usr/etc
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang14-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-14
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang13-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-13
+      TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
   gcc11-x86_64-vendordir:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-11
       TARGET: x86_64
@@ -29,7 +29,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc11-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-11
       TARGET: x86_64
@@ -43,7 +43,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc10-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-10
       TARGET: x86_64
@@ -57,7 +57,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc9-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc
       TARGET: x86_64
@@ -70,22 +70,8 @@ jobs:
     - name: build check
       run: ci/run-build-and-tests.sh
 
-  gcc8-x86_64:
-    runs-on: ubuntu-20.04
-    env:
-      CC: gcc-8
-      TARGET: x86_64
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: install dependencies
-      run: ci/install-dependencies.sh
-    - name: build check
-      run: ci/run-build-and-tests.sh
-
   clang12-x86_64-vendordir:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-12
       TARGET: x86_64
@@ -100,7 +86,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang12-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-12
       TARGET: x86_64
@@ -114,51 +100,9 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang11-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-11
-      TARGET: x86_64
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: install dependencies
-      run: ci/install-dependencies.sh
-    - name: build check
-      run: ci/run-build-and-tests.sh
-
-  clang10-x86_64:
-    runs-on: ubuntu-20.04
-    env:
-      CC: clang
-      TARGET: x86_64
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: install dependencies
-      run: ci/install-dependencies.sh
-    - name: build check
-      run: ci/run-build-and-tests.sh
-
-  clang9-x86_64:
-    runs-on: ubuntu-20.04
-    env:
-      CC: clang-9
-      TARGET: x86_64
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: install dependencies
-      run: ci/install-dependencies.sh
-    - name: build check
-      run: ci/run-build-and-tests.sh
-
-  clang8-x86_64:
-    runs-on: ubuntu-20.04
-    env:
-      CC: clang-8
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3

--- a/libpamc/include/security/pam_client.h
+++ b/libpamc/include/security/pam_client.h
@@ -24,7 +24,8 @@ extern "C" {
 typedef struct pamc_handle_s *pamc_handle_t;
 
 /* binary prompt structure pointer */
-typedef struct { uint32_t length; uint8_t control; } *pamc_bp_t;
+typedef struct { uint32_t length; uint8_t control; }
+	__attribute__ ((__packed__)) *pamc_bp_t;
 
 /*
  * functions provided by libpamc

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -283,8 +283,8 @@ check_logins (pam_handle_t *pamh, const char *name, int limit, int ctrl,
 	}
         if (!pl->flag_numsyslogins) {
 	    char user[sizeof(ut->UT_USER) + 1];
-	    user[0] = '\0';
-	    strncat(user, ut->UT_USER, sizeof(ut->UT_USER));
+	    memcpy(user, ut->UT_USER, sizeof(ut->UT_USER));
+	    user[sizeof(ut->UT_USER)] = '\0';
 
 	    if (((pl->login_limit_def == LIMITS_DEF_USER)
 	         || (pl->login_limit_def == LIMITS_DEF_GROUP)


### PR DESCRIPTION
This also silences all warnings reported by gcc-12 and clang-14.