### PR TITLE
libpam: remove dead code in pam_dynamic.c

### DIFF
--- a/libpam/pam_dynamic.c
+++ b/libpam/pam_dynamic.c
@@ -32,107 +32,25 @@
  */
 
 #include "pam_private.h"
-
-#ifdef PAM_SHL
-# include <dl.h>
-#elif defined(PAM_DYLD)
-# include <mach-o/dyld.h>
-#else /* PAM_SHL */
-# include <dlfcn.h>
-#endif /* PAM_SHL */
-
-#ifndef SHLIB_SYM_PREFIX
-#define SHLIB_SYM_PREFIX "_"
-#endif
+#include <dlfcn.h>
 
 void *_pam_dlopen(const char *mod_path)
 {
-#ifdef PAM_SHL
-	return shl_load(mod_path, BIND_IMMEDIATE, 0L);
-#elif defined(PAM_DYLD)
-	NSObjectFileImage ofile;
-	void *ret = NULL;
-
-	if (NSCreateObjectFileImageFromFile(mod_path, &ofile) !=
-			NSObjectFileImageSuccess )
-		return NULL;
-
-	ret = NSLinkModule(ofile, mod_path, NSLINKMODULE_OPTION_PRIVATE | NSLINKMODULE_OPTION_BINDNOW);
-	NSDestroyObjectFileImage(ofile);
-
-	return ret;
-#else
 	return dlopen(mod_path, RTLD_NOW);
-#endif
 }
 
 servicefn _pam_dlsym(void *handle, const char *symbol)
 {
-#ifdef PAM_SHL
-	char *_symbol = NULL;
-	servicefn ret;
-
-	if( symbol == NULL )
-		return NULL;
-
-	if( shl_findsym(&handle, symbol, (short) TYPE_PROCEDURE, &ret ){
-		_symbol = malloc( strlen(symbol) + sizeof(SHLIB_SYM_PREFIX) + 1 );
-		if( _symbol == NULL )
-			return NULL;
-		strcpy(_symbol, SHLIB_SYM_PREFIX);
-		strcat(_symbol, symbol);
-		if( shl_findsym(&handle, _symbol,
-				(short) TYPE_PROCEDURE, &ret ){
-			free(_symbol);
-			return NULL;
-		}
-		free(_symbol);
-	}
-
-	return ret;
-
-#elif defined(PAM_DYLD)
-	NSSymbol nsSymbol;
-	char *_symbol;
-
-	if( symbol == NULL )
-		return NULL;
-	_symbol = malloc( strlen(symbol) + 2 );
-	if( _symbol == NULL )
-		return NULL;
-	strcpy(_symbol, SHLIB_SYM_PREFIX);
-	strcat(_symbol, symbol);
-
-	nsSymbol = NSLookupSymbolInModule(handle, _symbol);
-	if( nsSymbol == NULL )
-		return NULL;
-	free(_symbol);
-
-	return (servicefn)NSAddressOfSymbol(nsSymbol);
-#else
 	return (servicefn) dlsym(handle, symbol);
-#endif
 }
 
 void _pam_dlclose(void *handle)
 {
-#ifdef PAM_SHL
-	shl_unload(handle);
-#elif defined(PAM_DYLD)
-	NSUnLinkModule((NSModule)handle, NSUNLINKMODULE_OPTION_NONE);
-#else
 	dlclose(handle);
-#endif
-
-	return;
 }
 
 const char *
 _pam_dlerror (void)
 {
-#if defined(PAM_SHL) || defined(PAM_DYLD)
-        return "unknown";
-#else
         return dlerror ();
-#endif
 }


### PR DESCRIPTION
Apparently, the PAM_SHL variant cannot be compiled since the very first commit back in 2005 when it was introduced, and another variant uses PAM_DYLD which is virtually unknown to search engines.

* libpam/pam_dynamic.c [PAM_SHL || PAM_DYLD]: Remove.

Resolves: https://github.com/linux-pam/linux-pam/issues/477