### PR TITLE
pam_pwhistory: use vendor specific pwhistory.conf as fallback

### DIFF
--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -14,7 +14,7 @@ endif
 XMLS = README.xml pam_pwhistory.8.xml pwhistory_helper.8.xml \
   pwhistory.conf.5.xml
 dist_check_SCRIPTS = tst-pam_pwhistory
-TESTS = $(dist_check_SCRIPTS)
+TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
 secureconfdir = $(SCONFIGDIR)
@@ -41,6 +41,9 @@ pwhistory_helper_CFLAGS = $(AM_CFLAGS) -DHELPER_COMPILE=\"pwhistory_helper\" @EX
 pwhistory_helper_SOURCES = pwhistory_helper.c opasswd.c
 pwhistory_helper_LDFLAGS = @EXE_LDFLAGS@
 pwhistory_helper_LDADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@
+
+check_PROGRAMS = tst-pam_pwhistory-retval
+tst_pam_pwhistory_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_pwhistory/pam_pwhistory.8.xml
+++ b/modules/pam_pwhistory/pam_pwhistory.8.xml
@@ -251,6 +251,21 @@ password     required       pam_unix.so        use_authtok
           <para>Default file with password history</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><filename>/etc/security/pwhistory.conf</filename></term>
+        <listitem>
+          <para>Config file for pam_pwhistory options</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry condition="with_vendordir">
+        <term><filename>%vendordir%/security/pwhistory.conf</filename></term>
+        <listitem>
+          <para>
+            Config file for pam_pwhistory options. It will be used if
+            <filename>/etc/security/pwhistory.conf</filename> does not exist.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/modules/pam_pwhistory/tst-pam_pwhistory-retval.c
+++ b/modules/pam_pwhistory/tst-pam_pwhistory-retval.c
@@ -1,0 +1,60 @@
+/*
+ * Check pam_pwhistory return values.
+ *
+ * Copyright (c) 2023 Stefan Schubert <schubi@suse.de>
+ */
+
+#include "test_assert.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <security/pam_appl.h>
+
+#define MODULE_NAME "pam_pwhistory"
+#define TEST_NAME "tst-" MODULE_NAME "-retval"
+
+static const char service_file[] = TEST_NAME ".service";
+static struct pam_conv conv;
+
+int
+main(void)
+{
+	pam_handle_t *pamh = NULL;
+	FILE *fp;
+	char cwd[PATH_MAX];
+
+	ASSERT_NE(NULL, getcwd(cwd, sizeof(cwd)));
+
+	/* PAM_USER_UNKNOWN */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0,
+		  fprintf(fp, "#%%PAM-1.0\n"
+			      "auth required %s/.libs/%s.so\n"
+			      "account required %s/.libs/%s.so\n"
+			      "password required %s/.libs/%s.so\n"
+			      "session required %s/.libs/%s.so\n",
+			  cwd, MODULE_NAME,
+			  cwd, MODULE_NAME,
+			  cwd, MODULE_NAME,
+			  cwd, MODULE_NAME));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "", &conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_USER_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	/* cleanup */
+	ASSERT_EQ(0, unlink(service_file));
+
+	return 0;
+}


### PR DESCRIPTION
Use the vendor directory defined by --enable-vendordir=DIR configure option as fallback for the distribution provided default config file if there is no configuration in /etc.

* modules/pam_pwhistory/pam_pwhistory.8.xml: Describes pwhistory.conf
* modules/pam_pwhistory/pwhistory_config.c: (parse_config_file) [VENDOR_PWHISTORY_DEFAULT_CONF] Try to open
   VENDOR_PWHISTORY_DEFAULT_CONF if PWHISTORY_DEFAULT_CONF file does not exist.
* modules/pam_pwhistory/tst-pam_pwhistory-retval.c: testcase for pam_pwhistory.
* modules/pam_pwhistory/Makefile.am: define testcase