### PR TITLE
Using <vendordir>/etc/security directory for installation if it has been set.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     env:
       CC: clang-14
       TARGET: x86_64
-      VENDORDIR: /usr/etc
+      VENDORDIR: ${prefix}/share/etc
     steps:
     - uses: actions/checkout@v3
       with:

--- a/configure.ac
+++ b/configure.ac
@@ -549,10 +549,13 @@ if test -n "$enable_vendordir"; then
   else
     STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir;with_vendordir_and_without_econf"
   fi
+  VENDOR_SCONFIGDIR="$enable_vendordir/security"
 else
   STRINGPARAM_VENDORDIR="--stringparam profile.condition 'without_vendordir'"
 fi
 AC_SUBST([STRINGPARAM_VENDORDIR])
+AC_SUBST(VENDOR_SCONFIGDIR)
+AM_CONDITIONAL([HAVE_VENDORDIR], [test -n "$enable_vendordir"])
 
 AC_ARG_ENABLE([openssl],
   AS_HELP_STRING([--enable-openssl],[use OpenSSL crypto libraries]),

--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_access
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	    $(WARN_CFLAGS)

--- a/modules/pam_debug/Makefile.am
+++ b/modules/pam_debug/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_debug
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_deny/Makefile.am
+++ b/modules/pam_deny/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_deny
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_echo/Makefile.am
+++ b/modules/pam_echo/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_echo
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_env
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	    $(WARN_CFLAGS) -DSYSCONFDIR=\"$(sysconfdir)\" $(ECONF_CFLAGS)

--- a/modules/pam_exec/Makefile.am
+++ b/modules/pam_exec/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_exec
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_faildelay/Makefile.am
+++ b/modules/pam_faildelay/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_faildelay
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_faillock/Makefile.am
+++ b/modules/pam_faillock/Makefile.am
@@ -18,7 +18,11 @@ dist_check_SCRIPTS = tst-pam_faillock
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 noinst_HEADERS = faillock.h faillock_config.h
 

--- a/modules/pam_filter/Makefile.am
+++ b/modules/pam_filter/Makefile.am
@@ -17,7 +17,11 @@ dist_check_SCRIPTS = tst-pam_filter
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_ftp/Makefile.am
+++ b/modules/pam_ftp/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_ftp
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_group
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	    $(WARN_CFLAGS)

--- a/modules/pam_issue/Makefile.am
+++ b/modules/pam_issue/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_issue
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_keyinit/Makefile.am
+++ b/modules/pam_keyinit/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_keyinit
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_lastlog/Makefile.am
+++ b/modules/pam_lastlog/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_lastlog
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_limits
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 limits_conf_dir = $(SCONFIGDIR)/limits.d
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \

--- a/modules/pam_listfile/Makefile.am
+++ b/modules/pam_listfile/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_listfile
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_localuser/Makefile.am
+++ b/modules/pam_localuser/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_localuser
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_loginuid/Makefile.am
+++ b/modules/pam_loginuid/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_loginuid
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_mail/Makefile.am
+++ b/modules/pam_mail/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_mail
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_mkhomedir/Makefile.am
+++ b/modules/pam_mkhomedir/Makefile.am
@@ -16,7 +16,11 @@ dist_check_SCRIPTS = tst-pam_mkhomedir
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	-DMKHOMEDIR_HELPER=\"$(sbindir)/mkhomedir_helper\" $(WARN_CFLAGS)

--- a/modules/pam_motd/Makefile.am
+++ b/modules/pam_motd/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_motd
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -16,7 +16,11 @@ dist_check_SCRIPTS = tst-pam_namespace
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 namespaceddir = $(SCONFIGDIR)/namespace.d
 servicedir = $(systemdunitdir)
 

--- a/modules/pam_nologin/Makefile.am
+++ b/modules/pam_nologin/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_nologin
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_permit/Makefile.am
+++ b/modules/pam_permit/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_permit
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -17,7 +17,11 @@ dist_check_SCRIPTS = tst-pam_pwhistory
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS) -DPWHISTORY_HELPER=\"$(sbindir)/pwhistory_helper\"

--- a/modules/pam_rhosts/Makefile.am
+++ b/modules/pam_rhosts/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_rhosts
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_rootok/Makefile.am
+++ b/modules/pam_rootok/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_rootok
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_securetty/Makefile.am
+++ b/modules/pam_securetty/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_securetty
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_selinux/Makefile.am
+++ b/modules/pam_selinux/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_selinux
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	-I$(top_srcdir)/libpam_misc/include $(WARN_CFLAGS)

--- a/modules/pam_sepermit/Makefile.am
+++ b/modules/pam_sepermit/Makefile.am
@@ -16,7 +16,11 @@ dist_check_SCRIPTS = tst-pam_sepermit
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 sepermitlockdir = ${localstatedir}/run/sepermit
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \

--- a/modules/pam_setquota/Makefile.am
+++ b/modules/pam_setquota/Makefile.am
@@ -11,7 +11,11 @@ dist_check_SCRIPTS = tst-pam_setquota
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	    $(WARN_CFLAGS)

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_shells
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS) $(ECONF_CFLAGS)

--- a/modules/pam_stress/Makefile.am
+++ b/modules/pam_stress/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_stress
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_succeed_if/Makefile.am
+++ b/modules/pam_succeed_if/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_succeed_if
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_time
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	    $(WARN_CFLAGS)

--- a/modules/pam_timestamp/Makefile.am
+++ b/modules/pam_timestamp/Makefile.am
@@ -16,7 +16,11 @@ dist_check_SCRIPTS = tst-pam_timestamp
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 noinst_HEADERS = hmacsha1.h sha1.h hmac_openssl_wrapper.h
 

--- a/modules/pam_umask/Makefile.am
+++ b/modules/pam_umask/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_umask
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_unix
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	-DCHKPWD_HELPER=\"$(sbindir)/unix_chkpwd\" \

--- a/modules/pam_userdb/Makefile.am
+++ b/modules/pam_userdb/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_userdb
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_usertype/Makefile.am
+++ b/modules/pam_usertype/Makefile.am
@@ -16,7 +16,11 @@ dist_check_SCRIPTS = tst-pam_usertype
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_warn/Makefile.am
+++ b/modules/pam_warn/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_warn
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_wheel/Makefile.am
+++ b/modules/pam_wheel/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_wheel
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)

--- a/modules/pam_xauth/Makefile.am
+++ b/modules/pam_xauth/Makefile.am
@@ -15,7 +15,11 @@ dist_check_SCRIPTS = tst-pam_xauth
 TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
 secureconfdir = $(SCONFIGDIR)
+endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
 	$(WARN_CFLAGS)


### PR DESCRIPTION
Otherwise the corresponding files are still installed in /etc/security.

- configure.ac: Set global variables VENDOR_SCONFIGDIR and HAVE_VENDORDIR.
- modules/*/Makefile.am: Set secureconfdir to VENDOR_SCONFIGDIR if HAVE_VENDORDIR  has been set. Otherwise to SCONFIGDIR.
