### PR TITLE
overhaul pam_overwrite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -615,6 +615,7 @@ AC_CHECK_FUNCS(getgrouplist getline getdelim)
 AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
 AC_CHECK_FUNCS(quotactl)
 AC_CHECK_FUNCS(unshare)
+AC_CHECK_FUNCS(explicit_bzero memset_explicit)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
 
 AC_ARG_ENABLE([regenerate-docu],

--- a/libpam/include/pam_inline.h
+++ b/libpam/include/pam_inline.h
@@ -161,7 +161,7 @@ pam_read_passwords(int fd, int npass, char **passwords)
 				if (npass > 0) {
 					memcpy(passwords[i], pptr, rbytes);
 				}
-				memset(pptr, '\0', rbytes);
+				pam_overwrite_n(pptr, rbytes);
 			}
 		}
 		offset += rbytes;
@@ -169,7 +169,7 @@ pam_read_passwords(int fd, int npass, char **passwords)
 
 	/* clear up */
 	if (offset > 0 && npass > 0) {
-		memset(passwords[i], '\0', offset);
+		pam_overwrite_n(passwords[i], offset);
 	}
 
 	return i;

--- a/libpam/include/security/_pam_macros.h
+++ b/libpam/include/security/_pam_macros.h
@@ -7,6 +7,8 @@
  * Organized by Cristian Gafton <gafton@redhat.com>
  */
 
+#include "_pam_types.h"
+
 /* a 'safe' version of strdup */
 
 #include <stdlib.h>
@@ -14,20 +16,22 @@
 
 #define  x_strdup(s)  ( (s) ? strdup(s):NULL )
 
-/* Good policy to strike out passwords with some characters not just
-   free the memory */
+/*
+ * WARNING: Do NOT use these overwrite macros, as they do not reliable
+ * override the memory.
+ */
 
-#define _pam_overwrite(x)        \
-do {                             \
-     register char *__xx__;      \
-     if ((__xx__=(x)))           \
-          while (*__xx__)        \
-               *__xx__++ = '\0'; \
+#define _pam_overwrite(x)                  \
+do {                                       \
+     PAM_DEPRECATED register char *__xx__; \
+     if ((__xx__=(x)))                     \
+          while (*__xx__)                  \
+               *__xx__++ = '\0';           \
 } while (0)
 
 #define _pam_overwrite_n(x,n)   \
 do {                             \
-     register char *__xx__;      \
+     PAM_DEPRECATED register char *__xx__; \
      register unsigned int __i__ = 0;    \
      if ((__xx__=(x)))           \
         for (;__i__<n; __i__++) \
@@ -46,9 +50,13 @@ do {                 \
     }                \
 } while (0)
 
+/*
+ * WARNING: Do NOT use this macro, as it does not reliable override the memory.
+ */
+
 #define _pam_drop_reply(/* struct pam_response * */ reply, /* int */ replies) \
 do {                                              \
-    int reply_i;                                  \
+    PAM_DEPRECATED int reply_i;                   \
                                                   \
     for (reply_i=0; reply_i<replies; ++reply_i) { \
 	if (reply[reply_i].resp) {                \

--- a/libpam/include/security/_pam_types.h
+++ b/libpam/include/security/_pam_types.h
@@ -160,6 +160,12 @@ typedef struct pam_handle pam_handle_t;
 # define PAM_FORMAT(params)
 #endif
 
+#if PAM_GNUC_PREREQ(3,1)
+# define PAM_DEPRECATED __attribute__((__deprecated__))
+#else
+# define PAM_DEPRECATED
+#endif
+
 #if PAM_GNUC_PREREQ(3,3) && !defined(LIBPAM_COMPILE)
 # define PAM_NONNULL(params) __attribute__((__nonnull__ params))
 #else

--- a/libpam/pam_end.c
+++ b/libpam/pam_end.c
@@ -5,6 +5,7 @@
  */
 
 #include "pam_private.h"
+#include "pam_inline.h"
 
 #include <stdlib.h>
 
@@ -41,34 +42,34 @@ int pam_end(pam_handle_t *pamh, int pam_status)
 
     _pam_drop_env(pamh);                      /* purge the environment */
 
-    _pam_overwrite(pamh->authtok);            /* blank out old token */
+    pam_overwrite_string(pamh->authtok);      /* blank out old token */
     _pam_drop(pamh->authtok);
 
-    _pam_overwrite(pamh->oldauthtok);         /* blank out old token */
+    pam_overwrite_string(pamh->oldauthtok);   /* blank out old token */
     _pam_drop(pamh->oldauthtok);
 
-    _pam_overwrite(pamh->former.prompt);
+    pam_overwrite_string(pamh->former.prompt);
     _pam_drop(pamh->former.prompt);           /* drop saved prompt */
 
-    _pam_overwrite(pamh->service_name);
+    pam_overwrite_string(pamh->service_name);
     _pam_drop(pamh->service_name);
 
-    _pam_overwrite(pamh->user);
+    pam_overwrite_string(pamh->user);
     _pam_drop(pamh->user);
 
-    _pam_overwrite(pamh->confdir);
+    pam_overwrite_string(pamh->confdir);
     _pam_drop(pamh->confdir);
 
-    _pam_overwrite(pamh->prompt);
+    pam_overwrite_string(pamh->prompt);
     _pam_drop(pamh->prompt);                  /* prompt for pam_get_user() */
 
-    _pam_overwrite(pamh->tty);
+    pam_overwrite_string(pamh->tty);
     _pam_drop(pamh->tty);
 
-    _pam_overwrite(pamh->rhost);
+    pam_overwrite_string(pamh->rhost);
     _pam_drop(pamh->rhost);
 
-    _pam_overwrite(pamh->ruser);
+    pam_overwrite_string(pamh->ruser);
     _pam_drop(pamh->ruser);
 
     _pam_drop(pamh->pam_conversation);
@@ -76,16 +77,16 @@ int pam_end(pam_handle_t *pamh, int pam_status)
 
     _pam_drop(pamh->former.substates);
 
-    _pam_overwrite(pamh->xdisplay);
+    pam_overwrite_string(pamh->xdisplay);
     _pam_drop(pamh->xdisplay);
 
-    _pam_overwrite(pamh->xauth.name);
+    pam_overwrite_string(pamh->xauth.name);
     _pam_drop(pamh->xauth.name);
-    _pam_overwrite_n(pamh->xauth.data, (unsigned int)pamh->xauth.datalen);
+    pam_overwrite_n(pamh->xauth.data, (unsigned int)pamh->xauth.datalen);
     _pam_drop(pamh->xauth.data);
-    _pam_overwrite_n((char *)&pamh->xauth, sizeof(pamh->xauth));
+    pam_overwrite_object(&pamh->xauth);
 
-    _pam_overwrite(pamh->authtok_type);
+    pam_overwrite_string(pamh->authtok_type);
     _pam_drop(pamh->authtok_type);
 
     /* and finally liberate the memory for the pam_handle structure */

--- a/libpam/pam_env.c
+++ b/libpam/pam_env.c
@@ -11,6 +11,7 @@
  */
 
 #include "pam_private.h"
+#include "pam_inline.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -100,7 +101,7 @@ void _pam_drop_env(pam_handle_t *pamh)
 
 	for (i=pamh->env->requested-1; i-- > 0; ) {
 	    D(("dropping #%3d>%s<", i, pamh->env->list[i]));
-	    _pam_overwrite(pamh->env->list[i]);          /* clean */
+	    pam_overwrite_string(pamh->env->list[i]);   /* clean */
 	    _pam_drop(pamh->env->list[i]);              /* forget */
 	}
 	pamh->env->requested = 0;
@@ -227,7 +228,7 @@ int pam_putenv(pam_handle_t *pamh, const char *name_value)
 	} else {                                /* replace old */
 	    D(("replacing item: %s\n          with: %s"
 	       , pamh->env->list[item], name_value));
-	    _pam_overwrite(pamh->env->list[item]);
+	    pam_overwrite_string(pamh->env->list[item]);
 	    _pam_drop(pamh->env->list[item]);
 	}
 
@@ -261,7 +262,7 @@ int pam_putenv(pam_handle_t *pamh, const char *name_value)
      */
 
     D(("deleting: env#%3d:[%s]", item, pamh->env->list[item]));
-    _pam_overwrite(pamh->env->list[item]);
+    pam_overwrite_string(pamh->env->list[item]);
     _pam_drop(pamh->env->list[item]);
     --(pamh->env->requested);
     D(("mmove: item[%d]+%d -> item[%d]"
@@ -341,7 +342,7 @@ static char **_copy_env(pam_handle_t *pamh)
 	    /* out of memory */
 
 	    while (dump[++i]) {
-		_pam_overwrite(dump[i]);
+		pam_overwrite_string(dump[i]);
 		_pam_drop(dump[i]);
 	    }
 	    _pam_drop(dump);

--- a/libpam/pam_get_authtok.c
+++ b/libpam/pam_get_authtok.c
@@ -33,6 +33,7 @@
 
 #include "config.h"
 #include "pam_private.h"
+#include "pam_inline.h"
 
 #include <security/pam_ext.h>
 
@@ -174,6 +175,10 @@ pam_get_authtok_internal (pam_handle_t *pamh, int item,
       (chpass > 1 && resp[1] == NULL))
     {
       /* We want to abort */
+      pam_overwrite_string (resp[0]);
+      _pam_drop (resp[0]);
+      pam_overwrite_string (resp[1]);
+      _pam_drop (resp[1]);
       if (chpass)
         pam_error (pamh, _("Password change has been aborted."));
       return PAM_AUTHTOK_ERR;
@@ -182,18 +187,18 @@ pam_get_authtok_internal (pam_handle_t *pamh, int item,
   if (chpass > 1 && strcmp (resp[0], resp[1]) != 0)
     {
       pam_error (pamh, MISTYPED_PASS);
-      _pam_overwrite (resp[0]);
+      pam_overwrite_string (resp[0]);
       _pam_drop (resp[0]);
-      _pam_overwrite (resp[1]);
+      pam_overwrite_string (resp[1]);
       _pam_drop (resp[1]);
       return PAM_TRY_AGAIN;
     }
 
-  _pam_overwrite (resp[1]);
+  pam_overwrite_string (resp[1]);
   _pam_drop (resp[1]);
 
   retval = pam_set_item (pamh, item, resp[0]);
-  _pam_overwrite (resp[0]);
+  pam_overwrite_string (resp[0]);
   _pam_drop (resp[0]);
   if (retval != PAM_SUCCESS)
     return retval;
@@ -263,13 +268,13 @@ pam_get_authtok_verify (pam_handle_t *pamh, const char **authtok,
     {
       pam_set_item (pamh, PAM_AUTHTOK, NULL);
       pam_error (pamh, MISTYPED_PASS);
-      _pam_overwrite (resp);
+      pam_overwrite_string (resp);
       _pam_drop (resp);
       return PAM_TRY_AGAIN;
     }
 
   retval = pam_set_item (pamh, PAM_AUTHTOK, resp);
-  _pam_overwrite (resp);
+  pam_overwrite_string (resp);
   _pam_drop (resp);
   if (retval != PAM_SUCCESS)
     return retval;

--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -1033,7 +1033,7 @@ void _pam_free_handlers_aux(struct handler **hp)
 	_pam_drop(h->argv);  /* This is all allocated in a single chunk */
 	_pam_drop(h->mod_name);
 	h = h->next;
-	memset(last, 0, sizeof(*last));
+	pam_overwrite_object(last);
 	free(last);
     }
 

--- a/libpam/pam_item.c
+++ b/libpam/pam_item.c
@@ -5,6 +5,7 @@
  */
 
 #include "pam_private.h"
+#include "pam_inline.h"
 
 #include <ctype.h>
 #include <stdlib.h>
@@ -79,7 +80,7 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
 	 */
 	if (__PAM_FROM_MODULE(pamh)) {
 	    if (pamh->authtok != item) {
-		_pam_overwrite(pamh->authtok);
+		pam_overwrite_string(pamh->authtok);
 		TRY_SET(pamh->authtok, item);
 	    }
 	} else {
@@ -95,7 +96,7 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
 	 */
 	if (__PAM_FROM_MODULE(pamh)) {
 	    if (pamh->oldauthtok != item) {
-		_pam_overwrite(pamh->oldauthtok);
+		pam_overwrite_string(pamh->oldauthtok);
 		TRY_SET(pamh->oldauthtok, item);
 	    }
 	} else {
@@ -139,24 +140,23 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
 	if (&pamh->xauth == item)
 	    break;
 	if (pamh->xauth.namelen) {
-	    _pam_overwrite(pamh->xauth.name);
+	    pam_overwrite_string(pamh->xauth.name);
 	    free(pamh->xauth.name);
 	}
 	if (pamh->xauth.datalen) {
-	    _pam_overwrite_n(pamh->xauth.data,
-			   (unsigned int) pamh->xauth.datalen);
+	    pam_overwrite_n(pamh->xauth.data, (unsigned int) pamh->xauth.datalen);
 	    free(pamh->xauth.data);
 	}
 	pamh->xauth = *((const struct pam_xauth_data *) item);
 	if ((pamh->xauth.name=_pam_strdup(pamh->xauth.name)) == NULL) {
-	    memset(&pamh->xauth, '\0', sizeof(pamh->xauth));
+	    pam_overwrite_object(&pamh->xauth);
 	    return PAM_BUF_ERR;
 	}
 	if ((pamh->xauth.data=_pam_memdup(pamh->xauth.data,
 	    pamh->xauth.datalen)) == NULL) {
-	    _pam_overwrite(pamh->xauth.name);
+	    pam_overwrite_string(pamh->xauth.name);
 	    free(pamh->xauth.name);
-	    memset(&pamh->xauth, '\0', sizeof(pamh->xauth));
+	    pam_overwrite_object(&pamh->xauth);
 	    return PAM_BUF_ERR;
 	}
 	break;
@@ -330,7 +330,7 @@ int pam_get_user(pam_handle_t *pamh, const char **user, const char *prompt)
 
 	/* ok, we can resume where we left off last time */
 	pamh->former.want_user = PAM_FALSE;
-	_pam_overwrite(pamh->former.prompt);
+	pam_overwrite_string(pamh->former.prompt);
 	_pam_drop(pamh->former.prompt);
     }
 
@@ -388,7 +388,7 @@ int pam_get_user(pam_handle_t *pamh, const char **user, const char *prompt)
 	 * note 'resp' is allocated by the application and is
          * correctly free()'d here
 	 */
-	_pam_drop_reply(resp, 1);
+	pam_drop_response(resp, 1);
     }
 
     D(("completed"));

--- a/libpam/pam_vprompt.c
+++ b/libpam/pam_vprompt.c
@@ -40,10 +40,10 @@
 #include <errno.h>
 
 #include <security/pam_modules.h>
-#include <security/_pam_macros.h>
 #include <security/pam_ext.h>
 
 #include "pam_private.h"
+#include "pam_inline.h"
 
 int
 pam_vprompt (pam_handle_t *pamh, int style, char **response,
@@ -88,10 +88,10 @@ pam_vprompt (pam_handle_t *pamh, int style, char **response,
     *response = pam_resp == NULL ? NULL : pam_resp->resp;
   else if (pam_resp && pam_resp->resp)
     {
-      _pam_overwrite (pam_resp->resp);
+      pam_overwrite_string (pam_resp->resp);
       _pam_drop (pam_resp->resp);
     }
-  _pam_overwrite (msgbuf);
+  pam_overwrite_string (msgbuf);
   _pam_drop (pam_resp);
   free (msgbuf);
   if (retval != PAM_SUCCESS)

--- a/libpam_misc/help_env.c
+++ b/libpam_misc/help_env.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <security/pam_misc.h>
+#include "pam_inline.h"
 
 /*
  * This function should be used to carefully dispose of the copied
@@ -25,7 +26,7 @@ char **pam_misc_drop_env(char **dump)
 
     for (i=0; dump[i] != NULL; ++i) {
 	D(("dump[%d]=`%s'", i, dump[i]));
-	_pam_overwrite(dump[i]);
+	pam_overwrite_string(dump[i]);
 	_pam_drop(dump[i]);
     }
     _pam_drop(dump);
@@ -77,7 +78,7 @@ int pam_misc_setenv(pam_handle_t *pamh, const char *name
     if (asprintf(&tmp, "%s=%s", name, value) >= 0) {
 	D(("pam_putt()ing: %s", tmp));
 	retval = pam_putenv(pamh, tmp);
-	_pam_overwrite(tmp);                 /* purge */
+	pam_overwrite_string(tmp);           /* purge */
 	_pam_drop(tmp);                      /* forget */
     } else {
 	D(("malloc failure"));

--- a/libpam_misc/misc_conv.c
+++ b/libpam_misc/misc_conv.c
@@ -17,6 +17,7 @@
 
 #include <security/pam_appl.h>
 #include <security/pam_misc.h>
+#include "pam_inline.h"
 
 #define INPUTSIZE PAM_MISC_CONV_BUFSIZE      /* maximum length of input+1 */
 #define CONV_ECHO_ON  1                            /* types of echo state */
@@ -185,7 +186,7 @@ static int read_string(int echo, const char *prompt, char **retstr)
 		    int rv;
 		    if ((rv=read(STDIN_FILENO, line+nc, 1)) != 1) {
 			if (rv < 0) {
-			    _pam_overwrite_n(line, (unsigned int) nc);
+			    pam_overwrite_n(line, (unsigned int) nc);
 			    nc = rv;
 			}
 			break;
@@ -213,7 +214,7 @@ static int read_string(int echo, const char *prompt, char **retstr)
 		    line[nc] = '\0';
 		}
 		*retstr = strdup(line);
-		_pam_overwrite(line);
+		pam_overwrite_array(line);
 		if (!*retstr) {
 		    D(("no memory for response string"));
 		    nc = -1;
@@ -246,7 +247,7 @@ static int read_string(int echo, const char *prompt, char **retstr)
     D(("the timer appears to have expired"));
 
     *retstr = NULL;
-    _pam_overwrite_n(line, sizeof(line));
+    pam_overwrite_array(line);
 
  cleanexit:
 
@@ -376,7 +377,7 @@ failed_conversation:
 	    switch (msgm[count]->msg_style) {
 	    case PAM_PROMPT_ECHO_ON:
 	    case PAM_PROMPT_ECHO_OFF:
-		_pam_overwrite(reply[count].resp);
+		pam_overwrite_string(reply[count].resp);
 		free(reply[count].resp);
 		break;
 	    case PAM_BINARY_PROMPT:

--- a/libpamc/pamc_client.c
+++ b/libpamc/pamc_client.c
@@ -7,6 +7,7 @@
  */
 
 #include "libpamc.h"
+#include "pam_inline.h"
 
 /*
  * liberate path list
@@ -145,7 +146,7 @@ static int __pamc_shutdown_agents(pamc_handle_t pch)
 	}
 	pid = this->pid = 0;
 
-	memset(this->id, 0, this->id_length);
+	pam_overwrite_n(this->id, this->id_length);
 	free(this->id);
 	this->id = NULL;
 	this->id_length = 0;

--- a/libpamc/pamc_converse.c
+++ b/libpamc/pamc_converse.c
@@ -7,6 +7,7 @@
  */
 
 #include "libpamc.h"
+#include "pam_inline.h"
 
 /*
  * select agent
@@ -157,7 +158,7 @@ int pamc_converse(pamc_handle_t pch, pamc_bp_t *prompt_p)
 
     size = PAM_BP_SIZE(raw);
     control = PAM_BP_RCONTROL(raw);
-    memset(raw, 0, sizeof(raw));
+    pam_overwrite_array(raw);
 
     D(("agent replied with prompt of size %d and control %u",
        size, control));

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -7,6 +7,7 @@
  */
 
 #include "libpamc.h"
+#include "pam_inline.h"
 
 static int __pamc_exec_agent(pamc_handle_t pch, pamc_agent_t *agent)
 {
@@ -143,7 +144,7 @@ close_the_agent:
     close(to_agent[1]);
 
 free_and_return:
-    memset(full_path, 0, reset_length);
+    pam_overwrite_n(full_path, reset_length);
     free(full_path);
 
     D(("returning %d", return_code));
@@ -301,10 +302,10 @@ int pamc_load(pamc_handle_t pch, const char *agent_id)
 
 fail_free_agent_id:
 
-    memset(agent->id, 0, agent->id_length);
+    pam_overwrite_n(agent->id, agent->id_length);
     free(agent->id);
 
-    memset(agent, 0, sizeof(*agent));
+    pam_overwrite_object(agent);
 
 fail_free_agent:
 

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -663,7 +663,7 @@ static int
 group_match (pam_handle_t *pamh, const char *tok, const char* usr,
     int debug)
 {
-    char grptok[BUFSIZ];
+    char grptok[BUFSIZ] = {};
 
     if (debug)
         pam_syslog (pamh, LOG_DEBUG,
@@ -673,7 +673,6 @@ group_match (pam_handle_t *pamh, const char *tok, const char* usr,
         return NO;
 
     /* token is received under the format '(...)' */
-    memset(grptok, 0, BUFSIZ);
     strncpy(grptok, tok + 1, strlen(tok) - 2);
 
     if (pam_modutil_user_in_group_nam_nam(pamh, usr, grptok))

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -70,6 +70,7 @@ static void free_string_array(char **array)
     if (array == NULL)
       return;
     for (char **entry = array; *entry != NULL; ++entry) {
+      pam_overwrite_string(*entry);
       free(*entry);
     }
     free(array);
@@ -402,6 +403,7 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
 	pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
 	(void) fclose(conf);
 	free_string_array(*lines);
+	pam_overwrite_array(buffer);
 	return PAM_BUF_ERR;
       }
       *lines = tmp;
@@ -410,12 +412,14 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
         pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
         (void) fclose(conf);
         free_string_array(*lines);
+        pam_overwrite_array(buffer);
         return PAM_BUF_ERR;
       }
       (*lines)[i] = 0;
     }
 
     (void) fclose(conf);
+    pam_overwrite_array(buffer);
     return PAM_SUCCESS;
 }
 #endif
@@ -580,12 +584,8 @@ _expand_arg(pam_handle_t *pamh, char **value)
   char type, tmpval[BUF_SIZE];
 
   /* I know this shouldn't be hard-coded but it's so much easier this way */
-  char tmp[MAX_ENV];
-  size_t idx;
-
-  D(("Remember to initialize tmp!"));
-  memset(tmp, 0, MAX_ENV);
-  idx = 0;
+  char tmp[MAX_ENV] = {};
+  size_t idx = 0;
 
   /*
    * (possibly non-existent) environment variables can be used as values
@@ -610,7 +610,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	D(("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr));
 	pam_syslog (pamh, LOG_ERR, "Variable buffer overflow: <%s> + <%s>",
 		 tmp, tmpptr);
-	return PAM_BUF_ERR;
+	goto buf_err;
       }
       continue;
     }
@@ -635,7 +635,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	  D(("Unterminated expandable variable: <%s>", orig-2));
 	  pam_syslog(pamh, LOG_ERR,
 		     "Unterminated expandable variable: <%s>", orig-2);
-	  return PAM_ABORT;
+	  goto abort_err;
 	}
 	strncpy(tmpval, orig, sizeof(tmpval));
 	tmpval[sizeof(tmpval)-1] = '\0';
@@ -661,7 +661,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	default:
 	  D(("Impossible error, type == <%c>", type));
 	  pam_syslog(pamh, LOG_CRIT, "Impossible error, type == <%c>", type);
-	  return PAM_ABORT;
+	  goto abort_err;
 	}         /* switch */
 
 	if (tmpptr) {
@@ -674,7 +674,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	    D(("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr));
 	    pam_syslog (pamh, LOG_ERR,
 			"Variable buffer overflow: <%s> + <%s>", tmp, tmpptr);
-	    return PAM_BUF_ERR;
+	    goto buf_err;
 	  }
 	}
       }           /* if ('{' != *orig++) */
@@ -686,7 +686,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	D(("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr));
 	pam_syslog(pamh, LOG_ERR,
 		   "Variable buffer overflow: <%s> + <%s>", tmp, tmpptr);
-	return PAM_BUF_ERR;
+	goto buf_err;
       }
     }
   }              /* for (;*orig;) */
@@ -697,14 +697,23 @@ _expand_arg(pam_handle_t *pamh, char **value)
       D(("Couldn't malloc %d bytes for expanded var", idx + 1));
       pam_syslog (pamh, LOG_CRIT, "Couldn't malloc %lu bytes for expanded var",
 	       (unsigned long)idx+1);
-      return PAM_BUF_ERR;
+      goto buf_err;
     }
   }
   strcpy(*value, tmp);
-  memset(tmp, '\0', sizeof(tmp));
+  pam_overwrite_array(tmp);
+  pam_overwrite_array(tmpval);
   D(("Exit."));
 
   return PAM_SUCCESS;
+buf_err:
+  pam_overwrite_array(tmp);
+  pam_overwrite_array(tmpval);
+  return PAM_BUF_ERR;
+abort_err:
+  pam_overwrite_array(tmp);
+  pam_overwrite_array(tmpval);
+  return PAM_ABORT;
 }
 
 static int
@@ -780,12 +789,15 @@ static void
 _clean_var(VAR *var)
 {
     if (var->name) {
+      pam_overwrite_string(var->name);
       free(var->name);
     }
     if (var->defval && (&quote != var->defval)) {
+      pam_overwrite_string(var->defval);
       free(var->defval);
     }
     if (var->override && (&quote != var->override)) {
+      pam_overwrite_string(var->override);
       free(var->override);
     }
     var->name = NULL;

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -265,6 +265,7 @@ econf_read_file(const pam_handle_t *pamh, const char *filename, const char *deli
 	  pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
           econf_free(keys);
           econf_freeFile(key_file);
+	  (*lines)[i] = NULL;
 	  free_string_array(*lines);
 	  free (val);
 	  return PAM_BUF_ERR;

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -992,11 +992,10 @@ _parse_env_file(pam_handle_t *pamh, int ctrl, const char *file)
 	    pam_syslog(pamh, LOG_DEBUG,
 		       "pam_putenv(\"%s\")", key);
 	}
-	free(*env);
     }
 
     /* tidy up */
-    free(env_list);
+    free_string_array(env_list);
     D(("Exit."));
     return retval;
 }

--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -184,6 +184,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
 	      if (retval != PAM_SUCCESS)
 		{
+		  pam_overwrite_string (resp);
 		  _pam_drop (resp);
 		  if (retval == PAM_CONV_AGAIN)
 		    retval = PAM_INCOMPLETE;
@@ -194,6 +195,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 		{
 		  pam_set_item (pamh, PAM_AUTHTOK, resp);
 		  strncpy (authtok, resp, sizeof(authtok) - 1);
+		  pam_overwrite_string (resp);
 		  _pam_drop (resp);
 		}
 	    }
@@ -202,6 +204,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
 	  if (pipe(fds) != 0)
 	    {
+	      pam_overwrite_array(authtok);
 	      pam_syslog (pamh, LOG_ERR, "Could not create pipe: %m");
 	      return PAM_SYSTEM_ERR;
 	    }
@@ -212,18 +215,21 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
     {
       if (pipe(stdout_fds) != 0)
 	{
+	  pam_overwrite_array(authtok);
 	  pam_syslog (pamh, LOG_ERR, "Could not create pipe: %m");
 	  return PAM_SYSTEM_ERR;
 	}
       stdout_file = fdopen(stdout_fds[0], "r");
       if (!stdout_file)
 	{
+	  pam_overwrite_array(authtok);
 	  pam_syslog (pamh, LOG_ERR, "Could not fdopen pipe: %m");
 	  return PAM_SYSTEM_ERR;
 	}
     }
 
   if (optargc >= argc) {
+    pam_overwrite_array(authtok);
     pam_syslog (pamh, LOG_ERR, "No path given as argument");
     return PAM_SERVICE_ERR;
   }
@@ -231,13 +237,16 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
   memset(&newsa, '\0', sizeof(newsa));
   newsa.sa_handler = SIG_DFL;
   if (sigaction(SIGCHLD, &newsa, &oldsa) == -1) {
+    pam_overwrite_array(authtok);
     pam_syslog(pamh, LOG_ERR, "failed to reset SIGCHLD handler: %m");
     return PAM_SYSTEM_ERR;
   }
 
   pid = fork();
-  if (pid == -1)
+  if (pid == -1) {
+    pam_overwrite_array(authtok);
     return PAM_SYSTEM_ERR;
+  }
   if (pid > 0) /* parent */
     {
       int status = 0;
@@ -254,6 +263,8 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
           close(fds[0]);       /* close here to avoid possible SIGPIPE above */
           close(fds[1]);
 	}
+
+      pam_overwrite_array(authtok);
 
       if (use_stdout)
 	{
@@ -324,6 +335,8 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 	      expose_authtok ? PAM_MODUTIL_IGNORE_FD : PAM_MODUTIL_PIPE_FD;
       enum pam_modutil_redirect_fd redirect_stdout =
 	      (use_stdout || logfile) ? PAM_MODUTIL_IGNORE_FD : PAM_MODUTIL_NULL_FD;
+
+      pam_overwrite_array(authtok);
 
       /* First, move all the pipes off of stdin, stdout, and stderr, to ensure
        * that calls to dup2 won't close them. */

--- a/modules/pam_ftp/pam_ftp.c
+++ b/modules/pam_ftp/pam_ftp.c
@@ -157,7 +157,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 			       GUEST_LOGIN_PROMPT);
 
 	if (retval != PAM_SUCCESS) {
-	    _pam_overwrite (resp);
+	    pam_overwrite_string (resp);
 	    _pam_drop (resp);
 	    return ((retval == PAM_CONV_AGAIN)
 		    ? PAM_INCOMPLETE:PAM_AUTHINFO_UNAVAIL);
@@ -196,7 +196,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	}
 
 	/* clean up */
-	_pam_overwrite(resp);
+	pam_overwrite_string(resp);
 	_pam_drop(resp);
 
 	/* success or failure */

--- a/modules/pam_group/pam_group.c
+++ b/modules/pam_group/pam_group.c
@@ -44,6 +44,7 @@ typedef enum { AND, OR } operator;
 #include <security/_pam_macros.h>
 #include <security/pam_modutil.h>
 #include <security/pam_ext.h>
+#include "pam_inline.h"
 
 /* --- static functions for checking whether the user should be let in --- */
 
@@ -53,7 +54,7 @@ shift_buf(char *mem, int from)
     char *start = mem;
     while ((*mem = mem[from]) != '\0')
 	++mem;
-    memset(mem, '\0', PAM_GROUP_BUFLEN - (mem - start));
+    pam_overwrite_n(mem, PAM_GROUP_BUFLEN - (mem - start));
     return mem;
 }
 
@@ -114,7 +115,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state,
 	if (i < 0) {
 	    pam_syslog(pamh, LOG_ERR, "error reading %s: %m", conf_filename);
 	    close(fd);
-	    memset(*buf, 0, PAM_GROUP_BUFLEN);
+	    pam_overwrite_n(*buf, PAM_GROUP_BUFLEN);
 	    _pam_drop(*buf);
 	    *state = STATE_EOF;
 	    return -1;
@@ -133,7 +134,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state,
 	return -1;
     }
 
-    memset(to, '\0', PAM_GROUP_BUFLEN - (to - *buf));
+    pam_overwrite_n(to, PAM_GROUP_BUFLEN - (to - *buf));
 
     to = *buf;
     onspace = 1; /* delete any leading spaces */
@@ -744,7 +745,7 @@ static int check_account(pam_handle_t *pamh, const char *service,
     }
 
     if (grps) {                                          /* tidy up */
-	memset(grps, 0, sizeof(gid_t) * blk_size(no_grps));
+	pam_overwrite_n(grps, sizeof(gid_t) * blk_size(no_grps));
 	_pam_drop(grps);
 	no_grps = 0;
     }

--- a/modules/pam_lastlog/pam_lastlog.c
+++ b/modules/pam_lastlog/pam_lastlog.c
@@ -366,11 +366,11 @@ last_login_read(pam_handle_t *pamh, int announce, int last_fd, uid_t uid, time_t
 
     /* cleanup */
  cleanup:
-    memset(&last_login, 0, sizeof(last_login));
-    _pam_overwrite(date);
-    _pam_overwrite(host);
+    pam_overwrite_object(&last_login);
+    pam_overwrite_string(date);
+    pam_overwrite_string(host);
     _pam_drop(host);
-    _pam_overwrite(line);
+    pam_overwrite_string(line);
     _pam_drop(line);
 
     return retval;
@@ -502,7 +502,7 @@ last_login_write(pam_handle_t *pamh, int announce, int last_fd,
     }
 
     /* cleanup */
-    memset(&last_login, 0, sizeof(last_login));
+    pam_overwrite_object(&last_login);
 
     return retval;
 }

--- a/modules/pam_mail/pam_mail.c
+++ b/modules/pam_mail/pam_mail.c
@@ -169,7 +169,7 @@ get_folder(pam_handle_t *pamh, int ctrl,
 	hash[2 * i] = '\0';
 
 	rc = asprintf(&folder, MAIL_FILE_FORMAT, path, hash, pwd->pw_name);
-	_pam_overwrite(hash);
+	pam_overwrite_string(hash);
 	_pam_drop(hash);
 	if (rc < 0)
 	    goto get_folder_cleanup;
@@ -211,7 +211,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
 	}
 	i = scandir(dir, &namelist, 0, alphasort);
 	save_errno = errno;
-	_pam_overwrite(dir);
+	pam_overwrite_string(dir);
 	_pam_drop(dir);
 	if (i < 0) {
 	    type = 0;
@@ -232,7 +232,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
 	    }
 	    i = scandir(dir, &namelist, 0, alphasort);
 	    save_errno = errno;
-	    _pam_overwrite(dir);
+	    pam_overwrite_string(dir);
 	    _pam_drop(dir);
 	    if (i < 0) {
 		type = 0;
@@ -264,7 +264,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
     }
 
   get_mail_status_cleanup:
-    memset(&mail_st, 0, sizeof(mail_st));
+    pam_overwrite_object(&mail_st);
     D(("user has %d mail in %s folder", type, folder));
     return type;
 }
@@ -415,7 +415,7 @@ static int _do_mail(pam_handle_t *pamh, int flags, int argc,
 	}
 	D(("setting env: %s", tmp));
 	retval = pam_putenv(pamh, tmp);
-	_pam_overwrite(tmp);
+	pam_overwrite_string(tmp);
 	_pam_drop(tmp);
 	if (retval != PAM_SUCCESS) {
 	    pam_syslog(pamh, LOG_CRIT,
@@ -457,7 +457,7 @@ static int _do_mail(pam_handle_t *pamh, int flags, int argc,
 	(void) pam_putenv(pamh, MAIL_ENV_NAME);
 
   do_mail_cleanup:
-    _pam_overwrite(folder);
+    pam_overwrite_string(folder);
     _pam_drop(folder);
 
     /* indicate success or failure */

--- a/modules/pam_mkhomedir/mkhomedir_helper.c
+++ b/modules/pam_mkhomedir/mkhomedir_helper.c
@@ -184,8 +184,7 @@ create_homedir(const struct passwd *pwd,
 	   else
 		   pointed[pointedlen] = 0;
 #else
-         char pointed[PATH_MAX];
-         memset(pointed, 0, sizeof(pointed));
+         char pointed[PATH_MAX] = {};
 
          pointedlen = readlink(newsource, pointed, sizeof(pointed) - 1);
 #endif

--- a/modules/pam_namespace/md5.c
+++ b/modules/pam_namespace/md5.c
@@ -21,6 +21,8 @@
 #include "md5.h"
 #include <string.h>
 
+#include "pam_inline.h"
+
 #define MD5Name(x) x
 
 #ifdef WORDS_BIGENDIAN
@@ -149,7 +151,7 @@ void MD5Name(MD5Final)(unsigned char digest[16], struct MD5Context *ctx)
 	MD5Name(MD5Transform)(ctx->buf.i, ctx->in.i);
 	byteReverse(ctx->buf.c, 4);
 	memcpy(digest, ctx->buf.c, 16);
-	memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
+	pam_overwrite_object(ctx);	/* In case it's sensitive */
 }
 
 /* The four core functions - F1 is optimized somewhat */

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -68,6 +68,7 @@
 #include <security/pam_ext.h>
 #endif
 #include <security/pam_modules.h>
+#include "pam_inline.h"
 
 #include "opasswd.h"
 
@@ -129,6 +130,7 @@ compare_password(const char *newpass, const char *oldpass)
   char *outval;
 #ifdef HAVE_CRYPT_R
   struct crypt_data output;
+  int retval;
 
   output.initialized = 0;
 
@@ -137,7 +139,9 @@ compare_password(const char *newpass, const char *oldpass)
   outval = crypt (newpass, oldpass);
 #endif
 
-  return outval != NULL && strcmp(outval, oldpass) == 0;
+  retval = outval != NULL && strcmp(outval, oldpass) == 0;
+  pam_overwrite_string(outval);
+  return retval;
 }
 
 /* Check, if the new password is already in the opasswd file.  */
@@ -238,8 +242,8 @@ check_old_pass, const char *user, const char *newpass, const char *filename, int
       } while (oldpass != NULL);
     }
 
-  if (buf)
-    free (buf);
+  pam_overwrite_n(buf, buflen);
+  free (buf);
 
   return retval;
 }
@@ -519,6 +523,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 	}
       if (fputs (out, newpf) < 0)
 	{
+	  pam_overwrite_string(out);
 	  free (out);
 	  retval = PAM_AUTHTOK_ERR;
 	  if (oldpf)
@@ -526,6 +531,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 	  fclose (newpf);
 	  goto error_opasswd;
 	}
+      pam_overwrite_string(out);
       free (out);
     }
 
@@ -571,6 +577,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
   rename (opasswd_tmp, opasswd_file);
  error_opasswd:
   unlink (opasswd_tmp);
+  pam_overwrite_n(buf, buflen);
   free (buf);
 
   return retval;

--- a/modules/pam_pwhistory/pwhistory_helper.c
+++ b/modules/pam_pwhistory/pwhistory_helper.c
@@ -70,7 +70,7 @@ check_history(const char *user, const char *filename, const char *debug)
 
   retval = check_old_pass(user, pass, filename, dbg);
 
-  memset(pass, '\0', PAM_MAX_RESP_SIZE);	/* clear memory of the password */
+  pam_overwrite_array(pass);	/* clear memory of the password */
 
   return retval;
 }

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -393,7 +393,6 @@ free_module_data(module_data_t *data)
   freecon(data->prev_exec_context);
   if (data->exec_context != data->default_user_context)
     freecon(data->exec_context);
-  memset(data, 0, sizeof(*data));
   free(data);
 }
 

--- a/modules/pam_stress/pam_stress.c
+++ b/modules/pam_stress/pam_stress.c
@@ -18,6 +18,7 @@
 #include <security/pam_modules.h>
 #include <security/_pam_macros.h>
 #include <security/pam_ext.h>
+#include "pam_inline.h"
 
 /* ---------- */
 
@@ -240,7 +241,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags,
      /* try to set password item */
 
      retval = pam_set_item(pamh,PAM_AUTHTOK,pass);
-     _pam_overwrite(pass); /* clean up local copy of password */
+     pam_overwrite_string(pass); /* clean up local copy of password */
      free(pass);
      pass = NULL;
      if (retval != PAM_SUCCESS) {
@@ -432,7 +433,7 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 		    return retval;
 	       }
 	       retval = pam_set_item(pamh, PAM_OLDAUTHTOK, pass);
-	       _pam_overwrite(pass);
+	       pam_overwrite_string(pass);
 	       free(pass);
 	       pass = NULL;
 	       if (retval != PAM_SUCCESS) {
@@ -495,7 +496,7 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 	       if (strcmp(resp[i-2].resp,resp[i-1].resp)) {
 		    /* passwords are not the same; forget and return error */
 
-		    _pam_drop_reply(resp, i);
+		    pam_drop_response(resp, i);
 
 		    if (!(flags & PAM_SILENT) && !(ctrl & PAM_ST_NO_WARN)) {
 			 pmsg[0] = &msg[0];
@@ -505,7 +506,7 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 			 resp = NULL;
 			 (void) converse(pamh,1,pmsg,&resp);
 			 if (resp) {
-			     _pam_drop_reply(resp, 1);
+			     pam_drop_response(resp, 1);
 			 }
 		    }
 		    return PAM_AUTHTOK_ERR;
@@ -523,7 +524,7 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 	       retval = PAM_SYSTEM_ERR;
 	  }
 
-	  _pam_drop_reply(resp, i);      /* clean up the passwords */
+	  pam_drop_response(resp, i);      /* clean up the passwords */
      } else {
 	  pam_syslog(pamh, LOG_ERR,
 		     "pam_sm_chauthtok: this must be a Linux-PAM error");

--- a/modules/pam_time/pam_time.c
+++ b/modules/pam_time/pam_time.c
@@ -107,7 +107,7 @@ shift_buf(char *mem, int from)
     char *start = mem;
     while ((*mem = mem[from]) != '\0')
 	++mem;
-    memset(mem, '\0', PAM_TIME_BUFLEN - (mem - start));
+    pam_overwrite_n(mem, PAM_TIME_BUFLEN - (mem - start));
     return mem;
 }
 
@@ -168,7 +168,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state, 
 	if (i < 0) {
 	    pam_syslog(pamh, LOG_ERR, "error reading %s: %m", file);
 	    close(fd);
-	    memset(*buf, 0, PAM_TIME_BUFLEN);
+	    pam_overwrite_n(*buf, PAM_TIME_BUFLEN);
 	    _pam_drop(*buf);
 	    *state = STATE_EOF;
 	    return -1;
@@ -187,7 +187,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state, 
 	return -1;
     }
 
-    memset(to, '\0', PAM_TIME_BUFLEN - (to - *buf));
+    pam_overwrite_n(to, PAM_TIME_BUFLEN - (to - *buf));
 
     to = *buf;
     onspace = 1; /* delete any leading spaces */

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -144,7 +144,7 @@ read_file(pam_handle_t *pamh, int fd, char **text, size_t *text_length)
 
     if (bytes_read < (size_t)st.st_size) {
         pam_syslog(pamh, LOG_ERR, "Short read on key file");
-        memset(tmp, 0, st.st_size);
+        pam_overwrite_n(tmp, st.st_size);
         free(tmp);
         return PAM_AUTH_ERR;
     }
@@ -167,14 +167,14 @@ write_file(pam_handle_t *pamh, const char *file_name, char *text,
               S_IRUSR | S_IWUSR);
     if (fd == -1) {
         pam_syslog(pamh, LOG_ERR, "Unable to open [%s]: %m", file_name);
-        memset(text, 0, text_length);
+        pam_overwrite_n(text, text_length);
         free(text);
         return PAM_AUTH_ERR;
     }
 
     if (fchown(fd, owner, group) == -1) {
         pam_syslog(pamh, LOG_ERR, "Unable to change ownership [%s]: %m", file_name);
-        memset(text, 0, text_length);
+        pam_overwrite_n(text, text_length);
         free(text);
         close(fd);
         return PAM_AUTH_ERR;
@@ -294,7 +294,7 @@ done:
         free(hmac_message);
     }
     if (key != NULL) {
-        memset(key, 0, key_length);
+        pam_overwrite_n(key, key_length);
         free(key);
     }
     if (ctx != NULL) {

--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -95,7 +95,7 @@
 static int
 check_dir_perms(pam_handle_t *pamh, const char *tdir)
 {
-	char scratch[BUFLEN];
+	char scratch[BUFLEN] = {};
 	struct stat st;
 	int i;
 	/* Check that the directory is "safe". */
@@ -103,7 +103,6 @@ check_dir_perms(pam_handle_t *pamh, const char *tdir)
 		return PAM_AUTH_ERR;
 	}
 	/* Iterate over the path, checking intermediate directories. */
-	memset(scratch, 0, sizeof(scratch));
 	for (i = 0; (tdir[i] != '\0') && (i < (int)sizeof(scratch)); i++) {
 		scratch[i] = tdir[i];
 		if ((scratch[i] == '/') || (tdir[i + 1] == '\0')) {

--- a/modules/pam_unix/md5.c
+++ b/modules/pam_unix/md5.c
@@ -21,6 +21,8 @@
 #include <string.h>
 #include "md5.h"
 
+#include "pam_inline.h"
+
 #ifndef HIGHFIRST
 #define byteReverse(buf, len)	/* Nothing */
 #else
@@ -149,7 +151,7 @@ void MD5Name(MD5Final)(unsigned char digest[16], struct MD5Context *ctx)
 	MD5Name(MD5Transform)(ctx->buf.i, ctx->in.i);
 	byteReverse(ctx->buf.i, 4);
 	memcpy(digest, ctx->buf.c, 16);
-	memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
+	pam_overwrite_object(ctx);	/* In case it's sensitive */
 }
 
 #ifndef ASM_MD5

--- a/modules/pam_unix/md5_crypt.c
+++ b/modules/pam_unix/md5_crypt.c
@@ -87,7 +87,7 @@ char *MD5Name(crypt_md5)(const char *pw, const char *salt)
 		MD5Name(MD5Update)(&ctx,(unsigned const char *)final,pl>16 ? 16 : pl);
 
 	/* Don't leave anything around in vm they could use. */
-	memset(final, 0, sizeof final);
+	pam_overwrite_array(final);
 
 	/* Then something really weird... */
 	for (j = 0, i = strlen(pw); i; i >>= 1)
@@ -151,7 +151,7 @@ char *MD5Name(crypt_md5)(const char *pw, const char *salt)
 	*p = '\0';
 
 	/* Don't leave anything around in vm they could use. */
-	memset(final, 0, sizeof final);
+	pam_overwrite_array(final);
 
 	return passwd;
 }

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -66,6 +66,7 @@
 #include <security/pam_ext.h>
 #include <security/pam_modutil.h>
 
+#include "pam_inline.h"
 #include "pam_cc_compat.h"
 #include "md5.h"
 #include "support.h"

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -805,7 +805,7 @@ int _unix_verify_password(pam_handle_t * pamh, const char *name
 	}
 
 cleanup:
-	memset(pw, 0, sizeof(pw)); /* clear memory of the password */
+	pam_overwrite_array(pw); /* clear memory of the password */
 	if (data_name)
 		_pam_delete(data_name);
 	if (salt)

--- a/modules/pam_unix/support.h
+++ b/modules/pam_unix/support.h
@@ -151,10 +151,10 @@ static const UNIX_Ctrls unix_args[UNIX_CTRLS_] =
 
 /* use this to free strings. ESPECIALLY password strings */
 
-#define _pam_delete(xx)		\
-{				\
-	_pam_overwrite(xx);	\
-	_pam_drop(xx);		\
+#define _pam_delete(xx)			\
+{					\
+	pam_overwrite_string(xx);	\
+	_pam_drop(xx);			\
 }
 
 extern int _make_remark(pam_handle_t * pamh, unsigned long long ctrl,

--- a/modules/pam_unix/unix_chkpwd.c
+++ b/modules/pam_unix/unix_chkpwd.c
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
 
 	retval = helper_verify_password(user, pass, nullok);
 
-	memset(pass, '\0', PAM_MAX_RESP_SIZE);	/* clear memory of the password */
+	pam_overwrite_array(pass);	/* clear memory of the password */
 
 	/* return pass or fail */
 

--- a/modules/pam_unix/unix_update.c
+++ b/modules/pam_unix/unix_update.c
@@ -55,15 +55,18 @@ set_password(const char *forwho, const char *shadow, const char *remember)
     if (npass != 2) {	/* is it a valid password? */
       if (npass == 1) {
         helper_log_err(LOG_DEBUG, "no new password supplied");
-	memset(pass, '\0', PAM_MAX_RESP_SIZE);
+        pam_overwrite_array(pass);
       } else {
         helper_log_err(LOG_DEBUG, "no valid passwords supplied");
       }
       return PAM_AUTHTOK_ERR;
     }
 
-    if (lock_pwdf() != PAM_SUCCESS)
+    if (lock_pwdf() != PAM_SUCCESS) {
+	pam_overwrite_array(pass);
+	pam_overwrite_array(towhat);
 	return PAM_AUTHTOK_LOCK_BUSY;
+    }
 
     pwd = getpwnam(forwho);
 
@@ -98,8 +101,8 @@ set_password(const char *forwho, const char *shadow, const char *remember)
     }
 
 done:
-    memset(pass, '\0', PAM_MAX_RESP_SIZE);
-    memset(towhat, '\0', PAM_MAX_RESP_SIZE);
+    pam_overwrite_array(pass);
+    pam_overwrite_array(towhat);
 
     unlock_pwdf();
 

--- a/modules/pam_userdb/pam_userdb.c
+++ b/modules/pam_userdb/pam_userdb.c
@@ -62,7 +62,7 @@ obtain_authtok(pam_handle_t *pamh)
     retval = pam_set_item(pamh, PAM_AUTHTOK, resp);
 
     /* clean it up */
-    _pam_overwrite(resp);
+    pam_overwrite_string(resp);
     _pam_drop(resp);
 
     if ( (retval != PAM_SUCCESS) ||
@@ -181,7 +181,7 @@ user_lookup (pam_handle_t *pamh, const char *database, const char *cryptmode,
 
     if (key.dptr) {
 	data = dbm_fetch(dbm, key);
-	memset(key.dptr, 0, key.dsize);
+	pam_overwrite_n(key.dptr, key.dsize);
 	free(key.dptr);
     }
 
@@ -247,8 +247,11 @@ user_lookup (pam_handle_t *pamh, const char *database, const char *cryptmode,
 	      free(cdata);
 #endif
 	    }
+	    pam_overwrite_string(pwhash);
 	    free(pwhash);
 	  }
+
+	  pam_overwrite_string(cryptpw);
 	} else {
 
 	  /* Unknown password encryption method -

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -141,7 +141,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 	if (child == 0) {
 		/* We're the child. */
 		size_t j;
-		const char *args[10];
+		const char *args[10] = {};
 		/* Drop privileges. */
 		if (setgid(gid) == -1)
 		  {
@@ -181,8 +181,6 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 						    PAM_MODUTIL_NULL_FD) < 0) {
 		    _exit(1);
 		}
-		/* Initialize the argument list. */
-		memset(args, 0, sizeof(args));
 		/* Convert the varargs list into a regular array of strings. */
 		va_start(ap, command);
 		args[0] = command;
@@ -564,9 +562,8 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 			}
 			/* Allocate enough space to hold an adjusted name. */
 			tlen = strlen(display) + LINE_MAX + 1;
-			t = malloc(tlen);
+			t = calloc(1, tlen);
 			if (t != NULL) {
-				memset(t, 0, tlen);
 				if (gethostname(t, tlen - 1) != -1) {
 					/* Append the protocol and then the
 					 * screen number. */


### PR DESCRIPTION
Avoid compiler optimizations to elide the memory erasure by using a secure method: either `memset_explicit()` [C23], `bzero_explicit()` [glibc 2.25] or a manual memory barrier.

Also introduce a `_pam_overwrite_array()` convenience wrapper.