### PR TITLE
pam_unix: don't link against yppasswd_xdr if NIS is disabled (#523)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,6 +459,7 @@ AC_SUBST(LIBDB)
 
 AC_ARG_ENABLE([nis],
         AS_HELP_STRING([--disable-nis], [Disable building NIS/YP support in pam_unix]))
+AM_CONDITIONAL([HAVE_NIS], [test "x$enable_nis" != "xno"])
 
 AS_IF([test "x$enable_nis" != "xno"], [
   old_CFLAGS=$CFLAGS

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -5,7 +5,7 @@
 CLEANFILES = *~
 MAINTAINERCLEANFILES = $(MANS) README
 
-EXTRA_DIST = md5.c md5_crypt.c lckpwdf.-c $(XMLS) CHANGELOG
+EXTRA_DIST = md5.c md5_crypt.c lckpwdf.-c yppasswd_xdr.c $(XMLS) CHANGELOG
 
 if HAVE_DOC
 dist_man_MANS = pam_unix.8 unix_chkpwd.8 unix_update.8
@@ -39,7 +39,10 @@ noinst_PROGRAMS = bigcrypt
 
 pam_unix_la_SOURCES = bigcrypt.c pam_unix_acct.c \
 	pam_unix_auth.c pam_unix_passwd.c pam_unix_sess.c support.c \
-	passverify.c yppasswd_xdr.c md5_good.c md5_broken.c
+	passverify.c md5_good.c md5_broken.c
+if HAVE_NIS
+  pam_unix_la_SOURCES += yppasswd_xdr.c
+endif
 
 bigcrypt_SOURCES = bigcrypt.c bigcrypt_main.c
 bigcrypt_CFLAGS = $(AM_CFLAGS)

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -72,10 +72,6 @@
 #include "passverify.h"
 #include "bigcrypt.h"
 
-#if (defined(HAVE_YP_GET_DEFAULT_DOMAIN) || defined(HAVE_GETDOMAINNAME)) && defined(HAVE_YP_MASTER)
-# define HAVE_NIS
-#endif
-
 #ifdef HAVE_NIS
 # include <rpc/rpc.h>
 


### PR DESCRIPTION
The yppasswd_xdr functions are not used if NIS is disabled, so don't link against that object file.

* configure.ac: define HAVE_NIS if NIS is enabled
* modules/pam_unix/Makefile.am: don't link against yppasswd_xdr.c if NIS is disabled
* modules/pam_unix/pam_unix_passwd.c: don't redefine HAVE_NIS