### PR TITLE
libpam: use getlogin() from libc and not utmp

### DIFF
--- a/libpam/pam_modutil_getlogin.c
+++ b/libpam/pam_modutil_getlogin.c
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <utmp.h>
 
 #define _PAMMODUTIL_GETLOGIN "_pammodutil_getlogin"
 
@@ -19,62 +18,33 @@ pam_modutil_getlogin(pam_handle_t *pamh)
 {
     int status;
     const void *logname;
-    const void *void_curr_tty;
-    const char *curr_tty;
     char *curr_user;
-    struct utmp *ut, line;
+    size_t curr_user_len;
 
     status = pam_get_data(pamh, _PAMMODUTIL_GETLOGIN, &logname);
     if (status == PAM_SUCCESS) {
 	return logname;
     }
 
-    status = pam_get_item(pamh, PAM_TTY, &void_curr_tty);
-    if ((status != PAM_SUCCESS) || (void_curr_tty == NULL))
-      curr_tty = ttyname(0);
-    else
-      curr_tty = (const char*)void_curr_tty;
-
-    if (curr_tty == NULL) {
-	return NULL;
+    logname = getlogin();
+    if (logname == NULL) {
+      return NULL;
     }
 
-    if (curr_tty[0] == '/') {   /* full path */
-        const char *t;
-	curr_tty++;
-	if ((t = strchr(curr_tty, '/')) != NULL) {
-	  curr_tty = t + 1;
-	}
-    }
-    logname = NULL;
-
-    setutent();
-    strncpy(line.ut_line, curr_tty, sizeof(line.ut_line));
-
-    if ((ut = getutline(&line)) == NULL) {
-	goto clean_up_and_go_home;
-    }
-
-    curr_user = calloc(sizeof(line.ut_user)+1, 1);
+    curr_user_len = strlen(logname)+1;
+    curr_user = calloc(curr_user_len, 1);
     if (curr_user == NULL) {
-	goto clean_up_and_go_home;
+      return NULL;
     }
 
-    strncpy(curr_user, ut->ut_user, sizeof(ut->ut_user));
-    /* calloc already zeroed the memory */
+    memcpy(curr_user, logname, curr_user_len);
 
     status = pam_set_data(pamh, _PAMMODUTIL_GETLOGIN, curr_user,
 			  pam_modutil_cleanup);
     if (status != PAM_SUCCESS) {
-	free(curr_user);
-	goto clean_up_and_go_home;
+      free(curr_user);
+      return NULL;
     }
 
-    logname = curr_user;
-
-clean_up_and_go_home:
-
-    endutent();
-
-    return logname;
+    return curr_user;
 }


### PR DESCRIPTION
 utmp uses 32bit time_t for compatibility with 32bit userland on some
 64bit systems and is thus not Y2038 safe. Use getlogin() from libc
 which avoids using utmp.

 * libpam/pam_modutil_getlogin.c: Use getlogin() instead of parsing utmp