### PR TITLE
pam_lastlog: deprecate it and disable by default

### DIFF
--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-DISTCHECK_CONFIGURE_FLAGS='--disable-dependency-tracking --enable-Werror'
+DISTCHECK_CONFIGURE_FLAGS='--disable-dependency-tracking --enable-Werror --enable-lastlog'
 export DISTCHECK_CONFIGURE_FLAGS
 
 case "${TARGET-}" in

--- a/configure.ac
+++ b/configure.ac
@@ -605,10 +605,6 @@ AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
 AC_CHECK_FUNCS(quotactl)
 AC_CHECK_FUNCS(unshare)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
-BACKUP_LIBS=$LIBS
-LIBS="$LIBS -lutil"
-AC_CHECK_FUNCS([logwtmp])
-LIBS=$BACKUP_LIBS
 
 AC_ARG_ENABLE([regenerate-docu],
   AS_HELP_STRING([--disable-regenerate-docu],[Don't re-build documentation from XML sources]),
@@ -694,6 +690,21 @@ AC_ARG_ENABLE([unix],
 case "$enable_unix" in
   yes|no) ;;
   *) AC_MSG_ERROR([bad value $enable_unix for --enable-unix option]) ;;
+esac
+
+AC_ARG_ENABLE([lastlog],
+              [AS_HELP_STRING([--enable-lastlog],
+                              [do build pam_lastlog module])],
+              [], [enable_lastlog=no])
+case "$enable_lastlog" in
+  yes|check)
+    BACKUP_LIBS=$LIBS
+    LIBS="$LIBS -lutil"
+    AC_CHECK_FUNCS([logwtmp])
+    LIBS=$BACKUP_LIBS
+    ;;
+  no) ;;
+  *) AC_MSG_ERROR([bad value $enable_lastlog for --enable-lastlog option]) ;;
 esac
 
 AC_ARG_WITH([misc-conv-bufsize],


### PR DESCRIPTION
pam_lastlog uses utmp, wtmp, btmp and lastlog. None of them is Y2038 safe, even on 64bit architectures. Most 64bit architectures uses 32bit time_t for compat reasons with 32bit userland.
Additional, all relevant tools for which pam_lastlog would make sense have already own support for all four files, so this module will most likely only create duplicate entries.

* configure.ac: don't build pam_lastlog by default.