### PR TITLE
documentation: document usage of $DISPLAY and PAM_TTY

### DIFF
--- a/doc/man/pam_item_types_std.inc.xml
+++ b/doc/man/pam_item_types_std.inc.xml
@@ -40,10 +40,12 @@
         <term>PAM_TTY</term>
         <listitem>
           <para>
-            The terminal name: prefixed by <filename>/dev/</filename> if
-            it is a device file; for graphical, X-based, applications the
-            value for this item should be the
-            <emphasis>$DISPLAY</emphasis> variable.
+            The terminal name prefixed by <filename>/dev/</filename> for
+            device files.
+            In the past, graphical X-based applications used to store the
+            <emphasis>$DISPLAY</emphasis> variable here, but with the
+            introduction of <emphasis>PAM_XDISPLAY</emphasis> this usage
+            is deprecated.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
man/pam_item_types_std.inc.xml: in the past PAM_TTY was used for tty devices and $DISPLAY variables for X-based applications. With the introduction of PAM_DISPLAY PAM_TTY should only be used for devices.