### PR TITLE
pam_timestamp: fix build failure

### DIFF
--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -54,6 +54,7 @@
 #include <security/pam_modutil.h>
 
 #include "hmac_openssl_wrapper.h"
+#include "pam_inline.h"
 
 #define LOGIN_DEFS          "/etc/login.defs"
 #define CRYPTO_KEY          "HMAC_CRYPTO_ALGO"


### PR DESCRIPTION
bcba17939e1b1a568cd4a764534cde74d37078cc started using pam_overwrite_n() without providing the definition to this function, which causes a build failure.

modules/pam_timestamp/hmac_openssl_wrapper.c: include pam_inline.h