### PR TITLE
treewide: fix unnecessary $ on arithmetic variables

### DIFF
--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -48,7 +48,7 @@ autoconf --version |head -1
 automake --version |head -1
 libtoolize --version |head -1
 kver="$(printf '%s\n%s\n' '#include <linux/version.h>' 'LINUX_VERSION_CODE' | $CC $CPPFLAGS -E -P -)"
-printf 'kernel-headers %s.%s.%s\n' $(($kver/65536)) $(($kver/256%256)) $(($kver%256))
+printf 'kernel-headers %s.%s.%s\n' $((kver/65536)) $((kver/256%256)) $((kver%256))
 echo 'END OF BUILD ENVIRONMENT INFORMATION'
 
 export CC_FOR_BUILD="$CC"

--- a/modules/pam_namespace/namespace.init
+++ b/modules/pam_namespace/namespace.init
@@ -16,7 +16,7 @@ if [ "$3" = 1 ]; then
                 cp -rT /etc/skel "$homedir"
                 chown -R "$user":"$gid" "$homedir"
                 mask=$(awk '/^UMASK/{gsub("#.*$", "", $2); print $2; exit}' /etc/login.defs)
-                mode=$(printf "%o" $((0777 & ~$mask)))
+                mode=$(printf "%o" $((0777 & ~mask)))
                 chmod ${mode:-700} "$homedir"
                 [ -x /sbin/restorecon ] && /sbin/restorecon -R "$homedir"
         fi


### PR DESCRIPTION
This should fix shellcheck warning SC2004.