### PR TITLE
build: fix --enable-openssl support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,21 @@ jobs:
     - name: build check
       run: ci/run-build-and-tests.sh
 
+  gcc12-x86_64-openssl:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-12
+      TARGET: x86_64
+      USE_OPENSSL: yes
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
   gcc11-x86_64:
     runs-on: ubuntu-latest
     env:
@@ -90,6 +105,21 @@ jobs:
       CC: clang-14
       TARGET: x86_64
       VENDORDIR: ${prefix}/share/etc
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang14-x86_64-openssl:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-14
+      TARGET: x86_64
+      USE_OPENSSL: yes
     steps:
     - uses: actions/checkout@v3
       with:

--- a/Make.xml.rules.in
+++ b/Make.xml.rules.in
@@ -5,22 +5,22 @@
 README: $(XMLS)
 
 README: README.xml
-	$(XSLTPROC) --path $(srcdir) --xinclude --stringparam generate.toc "none" @STRINGPARAM_VENDORDIR@ --nonet $(TXT_STYLESHEET) $< | $(BROWSER) > $(srcdir)/$@
+	$(XSLTPROC) --path $(srcdir) --xinclude --stringparam generate.toc "none" @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(TXT_STYLESHEET) $< | $(BROWSER) > $(srcdir)/$@
 
 %.1: %.1.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.3: %.3.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.5: %.5.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 %.8: %.8.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_HMAC@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
 
 #CLEANFILES += $(man_MANS) README

--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -38,6 +38,12 @@ case "${VENDORDIR-}" in
 		;;
 esac
 
+case "${USE_OPENSSL-}" in
+	yes)
+		DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --enable-openssl"
+		;;
+esac
+
 echo 'BEGIN OF BUILD ENVIRONMENT INFORMATION'
 uname -a |head -1
 libc="$(ldd /bin/sh |sed -n 's|^[^/]*\(/[^ ]*/libc\.so[^ ]*\).*|\1|p' |head -1)"

--- a/configure.ac
+++ b/configure.ac
@@ -562,13 +562,15 @@ if test -n "$enable_vendordir"; then
   AC_DEFINE_UNQUOTED([VENDOR_SCONFIGDIR], ["$enable_vendordir/security"],
 		     [Directory for PAM modules distribution provided configuration files])
   if test "$WITH_ECONF" = "yes" ; then
-    STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir;with_vendordir_and_with_econf'"
+    STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir'"
+    profileconditions="with_vendordir;with_vendordir_and_with_econf"
   else
-    STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir' --stringparam profile.condition 'with_vendordir;with_vendordir_and_without_econf"
+    STRINGPARAM_VENDORDIR="--stringparam vendordir '$enable_vendordir'"
+    profileconditions="with_vendordir;with_vendordir_and_without_econf"
   fi
   VENDOR_SCONFIGDIR="$enable_vendordir/security"
 else
-  STRINGPARAM_VENDORDIR="--stringparam profile.condition 'without_vendordir'"
+  profileconditions="without_vendordir"
 fi
 AC_SUBST([STRINGPARAM_VENDORDIR])
 AC_SUBST(VENDOR_SCONFIGDIR)
@@ -582,13 +584,15 @@ if test "$OPENSSL_ENABLED" = "yes" ; then
   [CRYPTO_LIBS="-lcrypto"
    use_openssl=yes
    AC_DEFINE([WITH_OPENSSL], 1, [OpenSSL provides crypto algorithm for hmac])
-   STRINGPARAM_HMAC="--stringparam profile.condition 'openssl_hmac'"],
+   profileconditions+=";openssl_hmac"],
   [CRYPTO_LIBS=""
-   STRINGPARAM_HMAC="--stringparam profile.condition 'no_openssl_hmac'"])
+   profileconditions+=";no_openssl_hmac"])
 fi
 AC_SUBST([CRYPTO_LIBS])
-AC_SUBST([STRINGPARAM_HMAC])
 AM_CONDITIONAL([COND_USE_OPENSSL], [test "x$use_openssl" = "xyes"])
+
+STRINGPARAM_PROFILECONDITIONS="--stringparam profile.condition '$profileconditions'"
+AC_SUBST([STRINGPARAM_PROFILECONDITIONS])
 
 dnl Checks for header files.
 AC_HEADER_DIRENT

--- a/modules/pam_timestamp/Makefile.am
+++ b/modules/pam_timestamp/Makefile.am
@@ -49,14 +49,11 @@ pam_timestamp_check_CFLAGS = $(AM_CFLAGS) @EXE_CFLAGS@
 pam_timestamp_check_LDADD = $(top_builddir)/libpam/libpam.la $(SYSTEMD_LIBS)
 pam_timestamp_check_LDFLAGS = @EXE_LDFLAGS@
 
-if COND_USE_OPENSSL
-hmacfile_SOURCES = hmac_openssl_wrapper.c
-else
+if !COND_USE_OPENSSL
 hmacfile_SOURCES = hmacfile.c hmacsha1.c sha1.c
-endif
 hmacfile_LDADD = $(top_builddir)/libpam/libpam.la
-
 check_PROGRAMS = hmacfile
+endif
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README


### PR DESCRIPTION
Added --enable-openssl build and fixed regarding issues around --stringparam profile.condition settings.

.github/workflows/ci.yml: added openssl builds
Make.xml.rules.in: fixed double profile.condition settings
configure.ac: fixed double profile.condition settings
ci/run-build-and-tests.sh: added openssl builds

This should solve issue:
https://github.com/linux-pam/linux-pam/issues/553