### PR TITLE
pam_succeed_if: do not use the result of keyword substitution for keyword match

### DIFF
--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -294,13 +294,6 @@ evaluate(pam_handle_t *pamh, int debug,
 {
 	char buf[LINE_MAX] = "";
 	const char *attribute = left;
-	/* Figure out what we're evaluating here, and convert it to a string.*/
-	if ((strcasecmp(left, "login") == 0) ||
-	    (strcasecmp(left, "name") == 0) ||
-	    (strcasecmp(left, "user") == 0)) {
-		snprintf(buf, sizeof(buf), "%s", user);
-		left = buf;
-	}
 	/* Get information about the user if needed. */
 	if ((*pwd == NULL) &&
 	    ((strcasecmp(left, "uid") == 0) ||
@@ -314,33 +307,34 @@ evaluate(pam_handle_t *pamh, int debug,
 			return PAM_USER_UNKNOWN;
 		}
 	}
-	if (strcasecmp(left, "uid") == 0) {
+	/* Figure out what we're evaluating here, and convert it to a string.*/
+	if ((strcasecmp(left, "login") == 0) ||
+	    (strcasecmp(left, "name") == 0) ||
+	    (strcasecmp(left, "user") == 0)) {
+		snprintf(buf, sizeof(buf), "%s", user);
+		left = buf;
+	} else if (strcasecmp(left, "uid") == 0) {
 		snprintf(buf, sizeof(buf), "%lu", (unsigned long) (*pwd)->pw_uid);
 		left = buf;
-	}
-	if (strcasecmp(left, "gid") == 0) {
+	} else if (strcasecmp(left, "gid") == 0) {
 		snprintf(buf, sizeof(buf), "%lu", (unsigned long) (*pwd)->pw_gid);
 		left = buf;
-	}
-	if (strcasecmp(left, "shell") == 0) {
+	} else if (strcasecmp(left, "shell") == 0) {
 		snprintf(buf, sizeof(buf), "%s", (*pwd)->pw_shell);
 		left = buf;
-	}
-	if ((strcasecmp(left, "home") == 0) ||
+	} else if ((strcasecmp(left, "home") == 0) ||
 	    (strcasecmp(left, "dir") == 0) ||
 	    (strcasecmp(left, "homedir") == 0)) {
 		snprintf(buf, sizeof(buf), "%s", (*pwd)->pw_dir);
 		left = buf;
-	}
-	if (strcasecmp(left, "service") == 0) {
+	} else if (strcasecmp(left, "service") == 0) {
 		const void *svc;
 		if (pam_get_item(pamh, PAM_SERVICE, &svc) != PAM_SUCCESS ||
 			svc == NULL)
 			svc = "";
 		snprintf(buf, sizeof(buf), "%s", (const char *)svc);
 		left = buf;
-	}
-	if (strcasecmp(left, "ruser") == 0) {
+	} else if (strcasecmp(left, "ruser") == 0) {
 		const void *ruser;
 		if (pam_get_item(pamh, PAM_RUSER, &ruser) != PAM_SUCCESS ||
 			ruser == NULL)
@@ -348,16 +342,14 @@ evaluate(pam_handle_t *pamh, int debug,
 		snprintf(buf, sizeof(buf), "%s", (const char *)ruser);
 		left = buf;
 		user = buf;
-	}
-	if (strcasecmp(left, "rhost") == 0) {
+	} else if (strcasecmp(left, "rhost") == 0) {
 		const void *rhost;
 		if (pam_get_item(pamh, PAM_RHOST, &rhost) != PAM_SUCCESS ||
 			rhost == NULL)
 			rhost = "";
 		snprintf(buf, sizeof(buf), "%s", (const char *)rhost);
 		left = buf;
-	}
-	if (strcasecmp(left, "tty") == 0) {
+	} else if (strcasecmp(left, "tty") == 0) {
 		const void *tty;
 		if (pam_get_item(pamh, PAM_TTY, &tty) != PAM_SUCCESS ||
 			tty == NULL)


### PR DESCRIPTION
* modules/pam_succeed_if/pam_succeed_if.c (evaluate): Do not use the result of keyword substitution for keyword match.

Resolves: https://github.com/linux-pam/linux-pam/issues/560