### PR TITLE
modules: update Linux detection

### DIFF
--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -13,7 +13,7 @@
  * See end for Copyright information
  */
 
-#if !defined(linux) && !defined(__linux)
+#ifndef __linux__
 #warning THIS CODE IS KNOWN TO WORK ONLY ON LINUX !!!
 #endif
 

--- a/modules/pam_namespace/pam_namespace.h
+++ b/modules/pam_namespace/pam_namespace.h
@@ -30,7 +30,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#if !(defined(linux))
+#ifndef __linux__
 #error THIS CODE IS KNOWN TO WORK ONLY ON LINUX !!!
 #endif
 


### PR DESCRIPTION
GCC and Clang only define the macro `linux` when using the GNU dialect of C (e.g. -std=gnu11 instead of -std=c11).  Since `linux` is also not in a reserved namespace it might be target of collisions. Use the canonical macro `__linux__` instead (already used in pam_limits.c).