### PR TITLE
Various PATH_MAX fixes

### DIFF
--- a/libpam/include/test_assert.h
+++ b/libpam/include/test_assert.h
@@ -11,6 +11,7 @@
 #  include <config.h>
 # endif
 
+# include <limits.h>
 # include <stdio.h>
 # include <stdlib.h>
 
@@ -51,5 +52,9 @@
 # define ASSERT_GE(expected_, seen_)						\
 	ASSERT_((expected_), #expected_, >=, (seen_), #seen_)			\
 /* End of ASSERT_LT definition.  */
+
+# ifndef PATH_MAX
+#  define PATH_MAX 4096
+# endif
 
 #endif /* TEST_ASSERT_H */

--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -82,7 +82,9 @@
 
 /* Various buffers we use need to be at least as large as either PATH_MAX or
  * LINE_MAX, so choose the larger of the two. */
-#if (LINE_MAX > PATH_MAX)
+#ifndef PATH_MAX
+#define BUFLEN LINE_MAX
+#elif (LINE_MAX > PATH_MAX)
 #define BUFLEN LINE_MAX
 #else
 #define BUFLEN PATH_MAX

--- a/tests/tst-dlopen.c
+++ b/tests/tst-dlopen.c
@@ -16,6 +16,10 @@
 #include <limits.h>
 #include <sys/stat.h>
 
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
+
 /* Simple program to see if dlopen() would succeed. */
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
`PATH_MAX` is optional in POSIX, and not defined on GNU/Hurd; hence, do some changes to be able to build PAM more on Hurd:
- pam_timestamp: check for its existence before trying to check it
- pam_pwhistory: use `asprintf()` to allocate buffers
- tests: define a fallback `PATH_MAX` if not available