### PR TITLE
pam_nologin: explicitly fail when nologin path is a directory

### DIFF
--- a/modules/pam_nologin/pam_nologin.c
+++ b/modules/pam_nologin/pam_nologin.c
@@ -98,6 +98,16 @@ static int perform_check(pam_handle_t *pamh, struct opt_s *opts)
 	    goto clean_up_fd;
 	}
 
+	/*
+	 * on some OSes (e.g. Hurd) reading a directory succeeds,
+	 * instead of failing with EISDIR; hence, work as if
+	 * pam_modutil_read later on would fail
+	 */
+	if (S_ISDIR(st.st_mode)) {
+	    retval = PAM_SYSTEM_ERR;
+	    goto clean_up_fd;
+	}
+
 	/* Don't print anything if the message is empty, will only
 	   disturb the output with empty lines */
 	if (st.st_size > 0) {


### PR DESCRIPTION
On some systems (e.g. GNU/Hurd), `read()` succeeds on the fd of a directory; since the module assumes that `read()` fails (and thus `pam_modutil_read()` as well), manually fail in case the open fd refers to a directory.