### PR TITLE
configure.ac: add `--enable-examples` option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,10 +4,13 @@
 
 AUTOMAKE_OPTIONS = 1.9 gnu dist-xz no-dist-gzip check-news
 
-SUBDIRS = libpam tests libpamc libpam_misc modules po conf examples xtests
+SUBDIRS = libpam tests libpamc libpam_misc modules po conf xtests
 
 if HAVE_DOC
 SUBDIRS += doc
+endif
+if HAVE_EXAMPLES
+SUBDIRS += examples
 endif
 
 CLEANFILES = *~

--- a/configure.ac
+++ b/configure.ac
@@ -224,6 +224,11 @@ AC_ARG_ENABLE([doc],
         WITH_DOC=$enableval, WITH_DOC=yes)
 AM_CONDITIONAL([HAVE_DOC], [test "x$WITH_DOC" = "xyes"])
 
+AC_ARG_ENABLE([examples],
+        AS_HELP_STRING([--disable-examples],[Do not build the examples]),
+        WITH_EXAMPLES=$enableval, WITH_EXAMPLES=yes)
+AM_CONDITIONAL([HAVE_EXAMPLES], [test "x$WITH_EXAMPLES" = "xyes"])
+
 AC_ARG_ENABLE([prelude],
 	AS_HELP_STRING([--disable-prelude],[do not use prelude]),
 	WITH_PRELUDE=$enableval, WITH_PRELUDE=yes)


### PR DESCRIPTION
Allow the user to not build the examples through `--disable-examples` (enabled by default); this can be useful:
- when cross-compiling, as the examples are not useful
- in distribution builds, not building stuff that is not used in any way