### PR TITLE
examples/tty_conv: fix build failure on musl

### DIFF
--- a/examples/tty_conv.c
+++ b/examples/tty_conv.c
@@ -6,8 +6,9 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <termio.h>
+#include <termios.h>
 #include <security/pam_appl.h>
+#include <sys/ioctl.h>
 
 /***************************************
  * @brief echo off/on
@@ -16,7 +17,7 @@
  ***************************************/
 static void echoOff(int fd, int off)
 {
-    struct termio tty;
+    struct termios tty;
     if (ioctl(fd, TCGETA, &tty) < 0)
     {
         fprintf(stderr, "TCGETA failed: %s\n", strerror(errno));


### PR DESCRIPTION
termio.h is the old System V version of the interface header, and is only provided in glibc and dietlibc as far as I can tell. This fixes it to instead use the POSIX termios.h.