### PR TITLE
pam_shells: return PAM_USER_UNKNOWN if getpwnam fails

### DIFF
--- a/modules/pam_shells/pam_shells.8.xml
+++ b/modules/pam_shells/pam_shells.8.xml
@@ -75,6 +75,14 @@
         </listitem>
       </varlistentry>
       <varlistentry>
+        <term>PAM_USER_UNKNOWN</term>
+        <listitem>
+          <para>
+            The user does not exist or the user's login shell could not be determined.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term>PAM_SERVICE_ERR</term>
         <listitem>
           <para>

--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -61,8 +61,16 @@ static int perform_check(pam_handle_t *pamh)
     }
 
     pw = pam_modutil_getpwnam(pamh, userName);
-    if (pw == NULL || pw->pw_shell == NULL) {
-	return PAM_AUTH_ERR;		/* user doesn't exist */
+    if (pw == NULL) {
+	return PAM_USER_UNKNOWN;
+    }
+    if (pw->pw_shell == NULL) {
+	/* TODO: when does this happen? I would join it with
+	 * the case userShell[0] == '\0' below.
+	 *
+	 * For now, keep the existing stricter behaviour
+	 */
+	return PAM_AUTH_ERR;
     }
     userShell = pw->pw_shell;
     if (userShell[0] == '\0')


### PR DESCRIPTION
Until before, in this case PAM_AUTH_ERR was returned. This leads to unknown users being logged with the unknown username.
Now it resembles the behavior of other modules like pam_unix in this case.

see #483 