### PR TITLE
pam_shells: Plug econf memory leak

### DIFF
--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -112,6 +112,7 @@ static int perform_check(pam_handle_t *pamh)
         if (!retval)
 	   break;
     }
+    econf_free (keys);
     econf_free (key_file);
 #else
     char shellFileLine[256];


### PR DESCRIPTION
The same leak occurs in shadow and util-linux:
- https://github.com/shadow-maint/shadow/pull/732
- https://github.com/util-linux/util-linux/pull/2239