### PR TITLE
Fix build if crypt_r isn't available

### DIFF
--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -128,9 +128,9 @@ static int
 compare_password(const char *newpass, const char *oldpass)
 {
   char *outval;
+  int retval;
 #ifdef HAVE_CRYPT_R
   struct crypt_data output;
-  int retval;
 
   output.initialized = 0;
 


### PR DESCRIPTION
retval was being defined only in #ifdef HAVE_CRYPT_R, but used unconditionally.