### PR TITLE
.github: add gcc-13 and clang-15 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,41 @@ jobs:
     - name: check
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
-  gcc12-x86_64-vendordir:
+  gcc13-x86_64-vendordir:
     runs-on: ubuntu-latest
     env:
-      CC: gcc-12
+      CC: gcc-13
       TARGET: x86_64
       VENDORDIR: ${prefix}/share/etc
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  gcc13-x86_64-openssl:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+      USE_OPENSSL: yes
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  gcc13-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
       with:
@@ -33,21 +62,6 @@ jobs:
     env:
       CC: gcc-12
       TARGET: x86_64
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: install dependencies
-      run: ci/install-dependencies.sh
-    - name: build check
-      run: ci/run-build-and-tests.sh
-
-  gcc12-x86_64-openssl:
-    runs-on: ubuntu-latest
-    env:
-      CC: gcc-12
-      TARGET: x86_64
-      USE_OPENSSL: yes
     steps:
     - uses: actions/checkout@v3
       with:
@@ -99,10 +113,10 @@ jobs:
     - name: build check
       run: ci/run-build-and-tests.sh
 
-  clang14-x86_64-vendordir:
+  clang15-x86_64-vendordir:
     runs-on: ubuntu-latest
     env:
-      CC: clang-14
+      CC: clang-15
       TARGET: x86_64
       VENDORDIR: ${prefix}/share/etc
     steps:
@@ -114,12 +128,26 @@ jobs:
     - name: build check
       run: ci/run-build-and-tests.sh
 
-  clang14-x86_64-openssl:
+  clang15-x86_64-openssl:
     runs-on: ubuntu-latest
     env:
-      CC: clang-14
+      CC: clang-15
       TARGET: x86_64
       USE_OPENSSL: yes
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang15-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-15
+      TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
* .github/workflows/ci.yml (gcc13-x86_64, clang15-x86_64): New jobs.
(gcc12-x86_64-vendordir): Rename to gcc13-x86_64-vendordir, replace gcc-12 with gcc-13.
(gcc12-x86_64-openssl): Rename to gcc13-x86_64-openssl, replace gcc-12 with gcc-13.
(clang14-x86_64-vendordir): Rename to clang15-x86_64-vendordir, replace clang-14 with clang-15.
(clang14-x86_64-openssl): Rename to clang15-x86_64-openssl, replace clang-14 with clang-15.