### PR TITLE
Fix up formatting of audit messages

### DIFF
--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -248,7 +248,7 @@ check_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 
 				(void)pam_get_item(pamh, PAM_TTY, &tty);
 				(void)pam_get_item(pamh, PAM_RHOST, &rhost);
-				snprintf(buf, sizeof(buf), "pam_faillock uid=%u ", opts->uid);
+				snprintf(buf, sizeof(buf), "op=pam_faillock suid=%u ", opts->uid);
 				audit_log_user_message(audit_fd, AUDIT_RESP_ACCT_UNLOCK_TIMED, buf,
 					rhost, NULL, tty, 1);
 			}
@@ -364,7 +364,7 @@ write_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 			errno == EAFNOSUPPORT))
 			return PAM_SYSTEM_ERR;
 
-		snprintf(buf, sizeof(buf), "pam_faillock uid=%u ", opts->uid);
+		snprintf(buf, sizeof(buf), "op=pam_faillock suid=%u ", opts->uid);
 		audit_log_user_message(audit_fd, AUDIT_ANOM_LOGIN_FAILURES, buf,
 			NULL, NULL, NULL, 1);
 

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -97,7 +97,7 @@ send_audit_message(const pam_handle_t *pamh, int success, const char *default_co
 		pam_syslog(pamh, LOG_ERR, "Error translating selected context '%s'.", selected_context);
 		selected_raw = NULL;
 	}
-	if (asprintf(&msg, "pam: default-context=%s selected-context=%s",
+	if (asprintf(&msg, "op=pam_selinux default-context=%s selected-context=%s",
 		     default_raw ? default_raw : (default_context ? default_context : "?"),
 		     selected_raw ? selected_raw : (selected_context ? selected_context : "?")) < 0) {
 		msg = NULL; /* asprintf leaves msg in undefined state on failure */


### PR DESCRIPTION
Pam_faillock uses audit_log_user_message to write to the audit system. It does not take an op argument, so you have to add one yourself. Otherwise the pam_faillock part of the message is lost because it's not in key=value format.

Also, we can't use uid in that event because the kernel already adds that field. What we normally do is use 'suid' (meaning sender uid) as the field name.