### PR TITLE
pam_pwhistory: fix passing NULL filename argument to pwhistory helper

### DIFF
--- a/modules/pam_pwhistory/pam_pwhistory.c
+++ b/modules/pam_pwhistory/pam_pwhistory.c
@@ -141,7 +141,7 @@ run_save_helper(pam_handle_t *pamh, const char *user,
       args[0] = (char *)PWHISTORY_HELPER;
       args[1] = (char *)"save";
       args[2] = (char *)user;
-      args[3] = (char *)filename;
+      args[3] = (char *)((filename != NULL) ? filename : "");
       DIAG_POP_IGNORE_CAST_QUAL;
       if (asprintf(&args[4], "%d", howmany) < 0 ||
           asprintf(&args[5], "%d", debug) < 0)
@@ -228,7 +228,7 @@ run_check_helper(pam_handle_t *pamh, const char *user,
       args[0] = (char *)PWHISTORY_HELPER;
       args[1] = (char *)"check";
       args[2] = (char *)user;
-      args[3] = (char *)filename;
+      args[3] = (char *)((filename != NULL) ? filename : "");
       DIAG_POP_IGNORE_CAST_QUAL;
       if (asprintf(&args[4], "%d", debug) < 0)
         {

--- a/modules/pam_pwhistory/pwhistory_helper.c
+++ b/modules/pam_pwhistory/pwhistory_helper.c
@@ -108,7 +108,7 @@ main(int argc, char *argv[])
 
   option = argv[1];
   user = argv[2];
-  filename = argv[3];
+  filename = (argv[3][0] != '\0') ? argv[3] : NULL;
 
   if (strcmp(option, "check") == 0 && argc == 5)
     return check_history(user, filename, argv[4]);


### PR DESCRIPTION
This bug was observed in an environment where SELinux was enabled and no file override was passed to `pam_pwhistory.so` in pam config. That causes a `NULL` value to be passed as an argument when calling `pwhistory_helper` binary, short-circuiting the arguments to just three.

The changes introduced handle the default case when the file is not overridden and passed as an empty string rather than a `NULL` value so that `pwhistory_helper` binary when called via `execve` can read all the arguments passed.