### PR TITLE
pam_access: document IPv6 link-local addresses (#582)

### DIFF
--- a/modules/pam_access/access.conf
+++ b/modules/pam_access/access.conf
@@ -115,6 +115,9 @@
 # User "john" should get access from ipv6 host address (same as above)
 #+:john:2001:4ca0:0:101:0:0:0:1
 #
+# User "john" should get access from ipv6 local link host address
+#+:john:fe80::de95:818c:1b55:7e42%eth0
+#
 # User "john" should get access from ipv6 net/mask
 #+:john:2001:4ca0:0:101::/64
 #

--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -189,6 +189,12 @@
     <para>+:john foo:2001:db8:0:101::1</para>
 
     <para>
+      User <emphasis>john</emphasis> and <emphasis>foo</emphasis>
+      should get access from IPv6 link local host address.
+    </para>
+    <para>+:john foo:fe80::de95:818c:1b55:7e42%eth1</para>
+
+    <para>
       User <emphasis>john</emphasis> should get access from IPv6 net/mask.
     </para>
     <para>+:john:2001:db8:0:101::/64</para>
@@ -221,6 +227,10 @@
       <emphasis>listsep</emphasis> option, the spaces will become part of the actual
       item and the line will be most probably ignored. For this reason, it is not
       recommended to put spaces around the ':' characters.
+    </para>
+    <para>
+      An IPv6 link local host address must contain the interface
+      identifier. IPv6 link local network/netmask is not supported.
     </para>
   </refsect1>
 


### PR DESCRIPTION
* modules/pam_access/access.conf.5.xml: Add example and note for IPv6 link-local addresses
* modules/pam_access/access.conf: Add example for IPv6 link-local addresses