### PR TITLE
Remove memory leaks in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,24 @@ jobs:
     - name: build check
       run: ci/run-build-and-tests.sh
 
+  gcc13-x86_64-sanitizers:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      CFLAGS: '-O1 -g -fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fsanitize=undefined -Wno-error=inline -Wno-error=format-overflow'
+      LDFLAGS: '-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fsanitize=undefined'
+      ASAN_OPTIONS: strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
+      UBSAN_OPTIONS: print_stacktrace=1:print_summary=1:halt_on_error=1
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
   gcc13-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/libpam/pam_start.c
+++ b/libpam/pam_start.c
@@ -143,6 +143,7 @@ static int _pam_start_internal (
 
     if ( _pam_init_handlers(*pamh) != PAM_SUCCESS ) {
 	pam_syslog(*pamh, LOG_ERR, "pam_start: failed to initialize handlers");
+	_pam_free_handlers(*pamh);
 	_pam_drop_env(*pamh);                 /* purge the environment */
 	_pam_drop((*pamh)->pam_conversation);
 	_pam_drop((*pamh)->service_name);

--- a/modules/pam_faillock/tst-pam_faillock-retval.c
+++ b/modules/pam_faillock/tst-pam_faillock-retval.c
@@ -82,6 +82,7 @@ main(void)
 	ASSERT_NE(NULL, pamh);
 	ASSERT_EQ(PAM_PERM_DENIED, pam_authenticate(pamh, 0));
 	ASSERT_EQ(PAM_PERM_DENIED, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
 	pamh = NULL;
 	ASSERT_EQ(0, unlink(service_file));
 

--- a/tests/tst-pam_fail_delay.c
+++ b/tests/tst-pam_fail_delay.c
@@ -67,6 +67,8 @@ main (void)
       return 1;
     }
 
+  pam_end (pamh, retval);
+
   /* 2: use NULL pam handle */
   retval = pam_fail_delay (NULL, 60);
   if (retval == PAM_SUCCESS)

--- a/tests/tst-pam_getenvlist.c
+++ b/tests/tst-pam_getenvlist.c
@@ -130,5 +130,7 @@ main (void)
       free (ptr);
     }
 
+  pam_end (pamh, retval);
+
   return 0;
 }

--- a/tests/tst-pam_mkargv.c
+++ b/tests/tst-pam_mkargv.c
@@ -50,5 +50,7 @@ int main(void)
 	return 1;
     }
 
+  free(myargv);
+
   return 0;
 }

--- a/tests/tst-pam_start.c
+++ b/tests/tst-pam_start.c
@@ -66,6 +66,8 @@ main (void)
       return 1;
     }
 
+  pam_end (pamh, retval);
+
   /* 2: check with NULL for service */
   retval = pam_start (NULL, user, &conv, &pamh);
   if (retval == PAM_SUCCESS)
@@ -83,6 +85,8 @@ main (void)
 	       service, retval);
       return 1;
     }
+
+  pam_end (pamh, retval);
 
 
   /* 4: check with NULL for conv */

--- a/tests/tst-pam_start_confdir.c
+++ b/tests/tst-pam_start_confdir.c
@@ -77,6 +77,8 @@ main (void)
       return 1;
     }
 
+  pam_end (pamh, retval);
+
   /* 2: check with invalid service */
   retval = pam_start_confdir (xservice, user, &conv, confdir, &pamh);
   if (retval == PAM_SUCCESS)
@@ -86,6 +88,8 @@ main (void)
       return 1;
     }
 
+  pam_end (pamh, retval);
+
   /* 3: check with invalid confdir */
   retval = pam_start_confdir (service, user, &conv, xconfdir, &pamh);
   if (retval == PAM_SUCCESS)
@@ -94,6 +98,8 @@ main (void)
 	       service, user, xconfdir);
       return 1;
     }
+
+  pam_end (pamh, retval);
 
   return 0;
 }


### PR DESCRIPTION
* tests: free handles via pam_end()
  Destroy the pam handles via pam_end() to release all associated resources.  This allows to run the test-suite with sanitizers and validates the resource cleanup in pam_end() and callees.

* pam_start: free handlers on handler init failure
  If the pam handlers fail to initialize halfway, clean them up afterwards.  Since we set the handle to NULL callers can't clean them.

* pam_faillock: free handle in test

* ci: add GCC 13 job with sanitzers