### PR TITLE
cast to unsigned char for character handling function

### DIFF
--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -72,7 +72,7 @@ line
 
     /* make sure we have lower case */
     for (i=0; $1[i]; ++i) {
-	$1[i] = tolower($1[i]);
+	$1[i] = tolower((unsigned char)$1[i]);
     }
 
     /* $1 = service-name */

--- a/libpam/pam_item.c
+++ b/libpam/pam_item.c
@@ -46,7 +46,7 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
 	{
 	    char *tmp;
 	    for (tmp=pamh->service_name; *tmp; ++tmp)
-		*tmp = tolower(*tmp);                 /* require lower case */
+		*tmp = tolower((unsigned char)*tmp);                 /* require lower case */
 	}
 	break;
 

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -273,7 +273,7 @@ void _pam_parse_control(int *control_array, char *tok)
 	int act, len;
 
 	/* skip leading space */
-	while (isspace((int)*tok) && *++tok);
+	while (isspace((unsigned char)*tok) && *++tok);
 	if (!*tok)
 	    break;
 
@@ -290,14 +290,14 @@ void _pam_parse_control(int *control_array, char *tok)
 	}
 
 	/* observe '=' */
-	while (isspace((int)*tok) && *++tok);
+	while (isspace((unsigned char)*tok) && *++tok);
 	if (!*tok || *tok++ != '=') {
 	    error = "expecting '='";
 	    goto parse_error;
 	}
 
 	/* skip leading space */
-	while (isspace((int)*tok) && *++tok);
+	while (isspace((unsigned char)*tok) && *++tok);
 	if (!*tok) {
 	    error = "expecting action";
 	    goto parse_error;
@@ -322,7 +322,7 @@ void _pam_parse_control(int *control_array, char *tok)
 	     * cause looping problems.  So, for now, we will just
 	     * allow forward jumps.  (AGM 1998/1/7)
 	     */
-	    if (!isdigit((int)*tok)) {
+	    if (!isdigit((unsigned char)*tok)) {
 		error = "expecting jump number";
 		goto parse_error;
 	    }
@@ -331,7 +331,7 @@ void _pam_parse_control(int *control_array, char *tok)
 	    do {
 		act *= 10;
 		act += *tok - '0';      /* XXX - this assumes ascii behavior */
-	    } while (*++tok && isdigit((int)*tok));
+	    } while (*++tok && isdigit((unsigned char)*tok));
 	    if (! act) {
 		/* we do not allow 0 jumps.  There is a token ('ignore')
                    for that */

--- a/libpam/pam_modutil_searchkey.c
+++ b/libpam/pam_modutil_searchkey.c
@@ -103,14 +103,14 @@ pam_modutil_search_key(pam_handle_t *pamh UNUSED,
 		tmp = strchr(cp, '#');  /* remove comments */
 		if (tmp)
 			*tmp = '\0';
-		while (isspace((int)*cp))    /* remove spaces and tabs */
+		while (isspace((unsigned char)*cp))    /* remove spaces and tabs */
 			++cp;
 		if (*cp == '\0')        /* ignore empty lines */
 			continue;
 
 		tmp = strsep (&cp, " \t=");
 		if (cp != NULL)
-			while (isspace((int)*cp) || *cp == '=')
+			while (isspace((unsigned char)*cp) || *cp == '=')
 				++cp;
 		else
 			cp = buf + n;   /* empty string */

--- a/libpam/pam_start.c
+++ b/libpam/pam_start.c
@@ -67,7 +67,7 @@ static int _pam_start_internal (
 	char *tmp;
 
 	for (tmp=(*pamh)->service_name; *tmp; ++tmp)
-	    *tmp = tolower(*tmp);                   /* require lower case */
+	    *tmp = tolower((unsigned char)*tmp);                   /* require lower case */
     }
 
     if (user) {

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -324,7 +324,7 @@ int __pamc_valid_agent_id(int id_length, const char *id)
     for (i=post=0 ; i < id_length; ++i) {
 	int ch = id[i++];
 
-	if (isalpha(ch) || isdigit(ch) || (ch == '_')) {
+	if (isalpha((unsigned char)ch) || isdigit((unsigned char)ch) || (ch == '_')) {
 	    continue;
 	} else if (post && (ch == '.')) {
 	    continue;

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -456,7 +456,7 @@ login_access (pam_handle_t *pamh, struct login_info *item)
 	    }
 	    if (line[0] == '#')
 		continue;			/* comment line */
-	    while (end > 0 && isspace(line[end - 1]))
+	    while (end > 0 && isspace((unsigned char)line[end - 1]))
 		end--;
 	    line[end] = 0;			/* strip trailing whitespace */
 	    if (line[0] == 0)			/* skip blank lines */

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -965,7 +965,7 @@ _parse_env_file(pam_handle_t *pamh, int ctrl, const char *file)
 	}
 
 	for ( i = 0 ; key[i] != '=' && key[i] != '\0' ; i++ )
-	    if (!isalnum(key[i]) && key[i] != '_') {
+	    if (!isalnum((unsigned char)key[i]) && key[i] != '_') {
 		pam_syslog(pamh, LOG_ERR,
 		           "non-alphanumeric key '%s' in %s', ignoring",
 		           key, file);

--- a/modules/pam_faillock/faillock_config.c
+++ b/modules/pam_faillock/faillock_config.c
@@ -121,7 +121,7 @@ read_config_file(pam_handle_t *pamh, struct options *opts, const char *cfgfile)
 
 		/* drop terminating whitespace including the \n */
 		while (ptr > linebuf) {
-			if (!isspace(*(ptr-1))) {
+			if (!isspace((unsigned char)*(ptr-1))) {
 				*ptr = '\0';
 				break;
 			}
@@ -129,7 +129,7 @@ read_config_file(pam_handle_t *pamh, struct options *opts, const char *cfgfile)
 		}
 
 		/* skip initial whitespace */
-		for (ptr = linebuf; isspace(*ptr); ptr++);
+		for (ptr = linebuf; isspace((unsigned char)*ptr); ptr++);
 		if (*ptr == '\0')
 			continue;
 
@@ -137,7 +137,7 @@ read_config_file(pam_handle_t *pamh, struct options *opts, const char *cfgfile)
 		eq = 0;
 		name = ptr;
 		while (*ptr != '\0') {
-			if (isspace(*ptr) || *ptr == '=') {
+			if (isspace((unsigned char)*ptr) || *ptr == '=') {
 				eq = *ptr == '=';
 				*ptr = '\0';
 				++ptr;
@@ -149,7 +149,7 @@ read_config_file(pam_handle_t *pamh, struct options *opts, const char *cfgfile)
 		/* grab the key value */
 		while (*ptr != '\0') {
 			if (*ptr != '=' || eq) {
-				if (!isspace(*ptr)) {
+				if (!isspace((unsigned char)*ptr)) {
 					break;
 				}
 			} else {

--- a/modules/pam_filter/upperLOWER/upperLOWER.c
+++ b/modules/pam_filter/upperLOWER/upperLOWER.c
@@ -24,10 +24,10 @@ static void do_transpose(char *buffer,int len)
 {
      int i;
      for (i=0; i<len; ++i) {
-	  if (islower(buffer[i])) {
-	       buffer[i] = toupper(buffer[i]);
+	  if (islower((unsigned char)buffer[i])) {
+	       buffer[i] = toupper((unsigned char)buffer[i]);
 	  } else {
-	       buffer[i] = tolower(buffer[i]);
+	       buffer[i] = tolower((unsigned char)buffer[i]);
 	  }
      }
 }

--- a/modules/pam_group/pam_group.c
+++ b/modules/pam_group/pam_group.c
@@ -232,7 +232,7 @@ static int logic_member(const char *string, int *at)
 	       break;
 
 	  default:
-	       if (isalpha(c) || c == '*' || isdigit(c) || c == '_'
+	       if (isalpha((unsigned char)c) || c == '*' || isdigit((unsigned char)c) || c == '_'
 		    || c == '-' || c == '.' || c == '/' || c == ':') {
 		    token = 1;
 	       } else if (token) {
@@ -266,7 +266,7 @@ logic_field (const pam_handle_t *pamh, const void *me,
 	  if (next == VAL) {
 	       if (c == '!')
 		    not = !not;
-	       else if (isalpha(c) || c == '*' || isdigit(c) || c == '_'
+	       else if (isalpha((unsigned char)c) || c == '*' || isdigit((unsigned char)c) || c == '_'
                     || c == '-' || c == '.' || c == '/' || c == ':') {
 		    right = not ^ agrees(pamh, me, x+at, l, rule);
 		    if (oper == AND)
@@ -394,13 +394,13 @@ check_time (const pam_handle_t *pamh, const void *AT,
 	  not = FALSE;
      }
 
-     for (marked_day = 0; len > 0 && isalpha(times[j]); --len) {
+     for (marked_day = 0; len > 0 && isalpha((unsigned char)times[j]); --len) {
 	  int this_day=-1;
 
 	  D(("%c%c ?", times[j], times[j+1]));
 	  for (i=0; days[i].d != NULL; ++i) {
-	       if (tolower(times[j]) == days[i].d[0]
-		   && tolower(times[j+1]) == days[i].d[1] ) {
+	       if (tolower((unsigned char)times[j]) == days[i].d[0]
+		   && tolower((unsigned char)times[j+1]) == days[i].d[1] ) {
 		    this_day = days[i].bit;
 		    break;
 	       }
@@ -419,7 +419,7 @@ check_time (const pam_handle_t *pamh, const void *AT,
      D(("day range = 0%o", marked_day));
 
      time_start = 0;
-     for (i=0; len > 0 && i < 4 && isdigit(times[i+j]); ++i, --len) {
+     for (i=0; len > 0 && i < 4 && isdigit((unsigned char)times[i+j]); ++i, --len) {
 	  time_start *= 10;
 	  time_start += times[i+j]-'0';       /* is this portable? */
      }
@@ -427,7 +427,7 @@ check_time (const pam_handle_t *pamh, const void *AT,
 
      if (times[j] == '-') {
 	  time_end = 0;
-	  for (i=1; len > 0 && i < 5 && isdigit(times[i+j]); ++i, --len) {
+	  for (i=1; len > 0 && i < 5 && isdigit((unsigned char)times[i+j]); ++i, --len) {
 	       time_end *= 10;
 	       time_end += times[i+j]-'0';    /* is this portable? */
 	  }
@@ -497,7 +497,7 @@ static int find_member(const char *string, int *at)
                break;
 
           default:
-               if (isalpha(c) || isdigit(c) || c == '_' || c == '*'
+               if (isalpha((unsigned char)c) || isdigit((unsigned char)c) || c == '_' || c == '*'
                     || c == '-') {
                     token = 1;
                } else if (token) {

--- a/modules/pam_lastlog/pam_lastlog.c
+++ b/modules/pam_lastlog/pam_lastlog.c
@@ -205,7 +205,7 @@ get_lastlog_uid_max(pam_handle_t *pamh)
 	return uid_max;
 
     ep = s + strlen(s);
-    while (ep > s && isspace(*(--ep))) {
+    while (ep > s && isspace((unsigned char)*(--ep))) {
 	*ep = '\0';
     }
     errno = 0;

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -852,7 +852,7 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
 
         line = buf;
         /* skip the leading white space */
-        while (*line && isspace(*line))
+        while (*line && isspace((unsigned char)*line))
             line++;
 
         /* Rip off the comments */
@@ -874,7 +874,7 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
 	   i, domain, ltype, item, value));
 
         for(j=0; j < strlen(ltype); j++)
-            ltype[j]=tolower(ltype[j]);
+            ltype[j]=tolower((unsigned char)ltype[j]);
 
 	if ((rngtype=parse_uid_range(pamh, domain, &min_uid, &max_uid)) < 0) {
 	    pam_syslog(pamh, LOG_WARNING, "invalid uid range '%s' - skipped", domain);
@@ -883,9 +883,9 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
 
         if (i == 4) { /* a complete line */
 	    for(j=0; j < strlen(item); j++)
-		item[j]=tolower(item[j]);
+		item[j]=tolower((unsigned char)item[j]);
 	    for(j=0; j < strlen(value); j++)
-		value[j]=tolower(value[j]);
+		value[j]=tolower((unsigned char)value[j]);
 
             if (strcmp(uname, domain) == 0) /* this user have a limit */
                 process_limit(pamh, LIMITS_DEF_USER, ltype, item, value, ctrl, pl);

--- a/modules/pam_namespace/argv_parse.c
+++ b/modules/pam_namespace/argv_parse.c
@@ -56,7 +56,7 @@ int argv_parse(const char *in_buf, int *ret_argc, char ***ret_argv)
 	outcp = buf;
 	for (cp = in_buf; (ch = *cp); cp++) {
 		if (state == STATE_WHITESPACE) {
-			if (isspace((int) ch))
+			if (isspace((unsigned char)ch))
 				continue;
 			/* Not whitespace, so start a new token */
 			state = STATE_TOKEN;
@@ -81,7 +81,7 @@ int argv_parse(const char *in_buf, int *ret_argc, char ***ret_argv)
 			continue;
 		}
 		/* Must be processing characters in a word */
-		if (isspace((int) ch)) {
+		if (isspace((unsigned char)ch)) {
 			/*
 			 * Terminate the current word and start
 			 * looking for the beginning of the next word.

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -485,7 +485,7 @@ static int process_line(char *line, const char *home, const char *rhome,
     /*
      * skip the leading white space
      */
-    while (*line && isspace(*line))
+    while (*line && isspace((unsigned char)*line))
         line++;
 
     /*

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -199,7 +199,7 @@ check_old_pass, const char *user, const char *newpass, const char *filename, int
       tmp = strchr (cp, '#');  /* remove comments */
       if (tmp)
         *tmp = '\0';
-      while (isspace ((int)*cp))    /* remove spaces and tabs */
+      while (isspace ((unsigned char)*cp))    /* remove spaces and tabs */
         ++cp;
       if (*cp == '\0')        /* ignore empty lines */
         continue;
@@ -420,7 +420,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 	tmp = strchr (cp, '#');  /* remove comments */
 	if (tmp)
 	  *tmp = '\0';
-	while (isspace ((int)*cp))    /* remove spaces and tabs */
+	while (isspace ((unsigned char)*cp))    /* remove spaces and tabs */
 	  ++cp;
 	if (*cp == '\0')        /* ignore empty lines */
 	  goto write_old_data;

--- a/modules/pam_securetty/pam_securetty.c
+++ b/modules/pam_securetty/pam_securetty.c
@@ -148,7 +148,7 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
 	return PAM_SERVICE_ERR;
     }
 
-    if (isdigit(uttyname[0])) {
+    if (isdigit((unsigned char)uttyname[0])) {
 	snprintf(ptname, sizeof(ptname), "pts/%s", uttyname);
     } else {
 	ptname[0] = '\0';

--- a/modules/pam_sepermit/pam_sepermit.c
+++ b/modules/pam_sepermit/pam_sepermit.c
@@ -299,10 +299,10 @@ sepermit_match(pam_handle_t *pamh, const char *cfgfile, const char *user,
 			continue;
 
 		start = line;
-		while (isspace(*start))
+		while (isspace((unsigned char)*start))
 			++start;
 		n = strlen(start);
-		while (n > 0 && isspace(start[n-1])) {
+		while (n > 0 && isspace((unsigned char)start[n-1])) {
 			--n;
 		}
 		if (n == 0)

--- a/modules/pam_time/pam_time.c
+++ b/modules/pam_time/pam_time.c
@@ -286,7 +286,7 @@ logic_member(const char *string, int *at)
 	       break;
 
 	  default:
-	       if (isalpha(c) || c == '*' || isdigit(c) || c == '_'
+	       if (isalpha((unsigned char)c) || c == '*' || isdigit((unsigned char)c) || c == '_'
 		    || c == '-' || c == '.' || c == '/' || c == ':') {
 		    token = 1;
 	       } else if (token) {
@@ -319,7 +319,7 @@ logic_field(pam_handle_t *pamh, const void *me, const char *x, int rule,
 	  if (next == VAL) {
 	       if (c == '!')
 		    not = !not;
-	       else if (isalpha(c) || c == '*' || isdigit(c) || c == '_'
+	       else if (isalpha((unsigned char)c) || c == '*' || isdigit((unsigned char)c) || c == '_'
                     || c == '-' || c == '.' || c == '/' || c == ':') {
 		    right = not ^ agrees(pamh, me, x+at, l, rule);
 		    if (oper == AND)
@@ -449,13 +449,13 @@ check_time(pam_handle_t *pamh, const void *AT, const char *times,
 	  not = FALSE;
      }
 
-     for (marked_day = 0; len > 0 && isalpha(times[j]); --len) {
+     for (marked_day = 0; len > 0 && isalpha((unsigned char)times[j]); --len) {
 	  int this_day=-1;
 
 	  D(("%c%c ?", times[j], times[j+1]));
 	  for (i=0; days[i].d != NULL; ++i) {
-	       if (tolower(times[j]) == days[i].d[0]
-		   && tolower(times[j+1]) == days[i].d[1] ) {
+	       if (tolower((unsigned char)times[j]) == days[i].d[0]
+		   && tolower((unsigned char)times[j+1]) == days[i].d[1] ) {
 		    this_day = days[i].bit;
 		    break;
 	       }
@@ -474,7 +474,7 @@ check_time(pam_handle_t *pamh, const void *AT, const char *times,
      D(("day range = 0%o", marked_day));
 
      time_start = 0;
-     for (i=0; len > 0 && i < 4 && isdigit(times[i+j]); ++i, --len) {
+     for (i=0; len > 0 && i < 4 && isdigit((unsigned char)times[i+j]); ++i, --len) {
 	  time_start *= 10;
 	  time_start += times[i+j]-'0';        /* is this portable? */
      }
@@ -482,7 +482,7 @@ check_time(pam_handle_t *pamh, const void *AT, const char *times,
 
      if (times[j] == '-') {
 	  time_end = 0;
-	  for (i=1; len > 0 && i < 5 && isdigit(times[i+j]); ++i, --len) {
+	  for (i=1; len > 0 && i < 5 && isdigit((unsigned char)times[i+j]); ++i, --len) {
 	       time_end *= 10;
 	       time_end += times[i+j]-'0';    /* is this portable */
 	  }

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -327,7 +327,7 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 				if ((buf[userlen] == ':') &&
 				    (strncmp(name, buf, userlen) == 0)) {
 					p = buf + strlen(buf) - 1;
-					while (isspace(*p) && (p >= buf)) {
+					while (isspace((unsigned char)*p) && (p >= buf)) {
 						*p-- = '\0';
 					}
 					matched = 1;

--- a/modules/pam_usertype/pam_usertype.c
+++ b/modules/pam_usertype/pam_usertype.c
@@ -169,7 +169,7 @@ pam_usertype_get_id(pam_handle_t *pamh,
 
     /* taken from get_lastlog_uid_max() */
     ep = value + strlen(value);
-    while (ep > value && isspace(*(--ep))) {
+    while (ep > value && isspace((unsigned char)*(--ep))) {
         *ep = '\0';
     }
 


### PR DESCRIPTION
Character handling functions, like isspace(3), expect a value representable as unsigned char or equal to EOF.
Otherwise the behavior is undefined.

See https://wiki.sei.cmu.edu/confluence/display/c/STR37-C.+Arguments+to+character-handling+functions+must+be+representable+as+an+unsigned+char