### PR TITLE
Memory erasure followups

### DIFF
--- a/libpam/include/security/_pam_macros.h
+++ b/libpam/include/security/_pam_macros.h
@@ -21,21 +21,21 @@
  * override the memory.
  */
 
-#define _pam_overwrite(x)                  \
-do {                                       \
-     PAM_DEPRECATED register char *__xx__; \
-     if ((__xx__=(x)))                     \
-          while (*__xx__)                  \
-               *__xx__++ = '\0';           \
+#define _pam_overwrite(x)               \
+do {                                    \
+     PAM_DEPRECATED register char *xx_; \
+     if ((xx_=(x)))                     \
+          while (*xx_)                  \
+               *xx_++ = '\0';           \
 } while (0)
 
-#define _pam_overwrite_n(x,n)   \
-do {                             \
-     PAM_DEPRECATED register char *__xx__; \
-     register unsigned int __i__ = 0;    \
-     if ((__xx__=(x)))           \
-        for (;__i__<n; __i__++) \
-            __xx__[__i__] = 0; \
+#define _pam_overwrite_n(x,n)           \
+do {                                    \
+     PAM_DEPRECATED register char *xx_; \
+     register unsigned int i_ = 0;      \
+     if ((xx_=(x)))                     \
+        for (;i_<n; i_++)               \
+            xx_[i_] = 0;                \
 } while (0)
 
 /*

--- a/modules/pam_timestamp/sha1.c
+++ b/modules/pam_timestamp/sha1.c
@@ -48,7 +48,7 @@
 #include <unistd.h>
 #include "sha1.h"
 
-static unsigned char
+static const unsigned char
 padding[SHA1_BLOCK_SIZE] = {
 	0x80, 0, 0, 0, 0, 0, 0, 0,     0, 0, 0, 0, 0, 0, 0, 0,
 	   0, 0, 0, 0, 0, 0, 0, 0,     0, 0, 0, 0, 0, 0, 0, 0,

--- a/modules/pam_timestamp/sha1.c
+++ b/modules/pam_timestamp/sha1.c
@@ -47,6 +47,7 @@
 #include <endian.h>
 #include <unistd.h>
 #include "sha1.h"
+#include "pam_inline.h"
 
 static const unsigned char
 padding[SHA1_BLOCK_SIZE] = {
@@ -142,8 +143,8 @@ sha1_process(struct sha1_context *ctx, uint32_t buffer[SHA1_BLOCK_SIZE / 4])
 	ctx->d += d;
 	ctx->e += e;
 
-	memset(buffer, 0, sizeof(buffer[0]) * SHA1_BLOCK_SIZE / 4);
-	memset(data, 0, sizeof(data));
+	pam_overwrite_n(buffer, sizeof(buffer[0]) * SHA1_BLOCK_SIZE / 4);
+	pam_overwrite_array(data);
 }
 
 void


### PR DESCRIPTION
* pam_timestamp: constify sha1 padding block
  The padding block is only read from via memcpy(3).

* pam_timestamp: use secure memory erasure
  Closes: https://github.com/linux-pam/linux-pam/issues/575

* libpam: avoid reserved variable names in macros
  Identifiers staring with an underscores are reserved by the C standard.
  Also avoid double underscore, which are reserved by C++, in header file.