### PR TITLE
pam_access: Support UID and GID in access.conf

### DIFF
--- a/libpam/include/pam_inline.h
+++ b/libpam/include/pam_inline.h
@@ -45,6 +45,26 @@
 #define PAM_ARRAY_SIZE(a_)		(sizeof(a_) / sizeof((a_)[0]) + PAM_MUST_BE_ARRAY(a_))
 
 /*
+ * Zero-extend a signed integer type to unsigned long long.
+ */
+# define zero_extend_signed_to_ull(v_) \
+	(sizeof(v_) == sizeof(char) ? (unsigned long long) (unsigned char) (v_) : \
+	 sizeof(v_) == sizeof(short) ? (unsigned long long) (unsigned short) (v_) : \
+	 sizeof(v_) == sizeof(int) ? (unsigned long long) (unsigned int) (v_) : \
+	 sizeof(v_) == sizeof(long) ? (unsigned long long) (unsigned long) (v_) : \
+	 (unsigned long long) (v_))
+
+/*
+ * Sign-extend an unsigned integer type to long long.
+ */
+# define sign_extend_unsigned_to_ll(v_) \
+	(sizeof(v_) == sizeof(char) ? (long long) (signed char) (v_) : \
+	 sizeof(v_) == sizeof(short) ? (long long) (signed short) (v_) : \
+	 sizeof(v_) == sizeof(int) ? (long long) (signed int) (v_) : \
+	 sizeof(v_) == sizeof(long) ? (long long) (signed long) (v_) : \
+	 (long long) (v_))
+
+/*
  * Returns NULL if STR does not start with PREFIX,
  * or a pointer to the first char in STR after PREFIX.
  * The length of PREFIX is specified by PREFIX_LEN.

--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -63,10 +63,10 @@
     <para>
       The second field, the
       <replaceable>users</replaceable>/<replaceable>group</replaceable>
-      field, should be a list of one or more login names, group names, or
+      field, should be a list of one or more login names, group names, uid, gid, or
       <emphasis>ALL</emphasis> (which always matches). To differentiate
       user entries from group entries, group entries should be written
-      with brackets, e.g. <emphasis>(group)</emphasis>.
+      with brackets, e.g. <emphasis>(group)</emphasis> or <emphasis>(gid)</emphasis>.
     </para>
 
     <para>
@@ -175,6 +175,12 @@
     </para>
     <para>-:root:ALL</para>
 
+    <para>
+      A user with uid <emphasis>1003</emphasis> and a group with gid
+      <emphasis>1000</emphasis> should be allowed to get access
+      from all other sources.
+    </para>
+    <para>+:(1000) 1003:ALL</para>
     <para>
       User <emphasis>foo</emphasis> and members of netgroup
       <emphasis>admins</emphasis> should be allowed to get access


### PR DESCRIPTION
Following up on #114 and #186.  It appears that the original author, @blueskycs2c, has been inactive for several years.  The change has been [rebased as requested](https://github.com/linux-pam/linux-pam/pull/186#issuecomment-1650565201) by @t8m.