### PR TITLE
examples/tty_conv: fix build on musl

### DIFF
--- a/examples/tty_conv.c
+++ b/examples/tty_conv.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <termios.h>
+#include <asm/termios.h>
 #include <security/pam_appl.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
Using__ GLIBC__ This macro distinguishes between calling different termios.h for compiling with Musl