### PR TITLE
pam_env: fix handling of huge strings

### DIFF
--- a/libpam/pam_env.c
+++ b/libpam/pam_env.c
@@ -120,7 +120,7 @@ void _pam_drop_env(pam_handle_t *pamh)
  */
 
 static int _pam_search_env(const struct pam_environ *env
-			   , const char *name_value, int length)
+			   , const char *name_value, size_t length)
 {
     int i;
 
@@ -152,7 +152,8 @@ static int _pam_search_env(const struct pam_environ *env
 
 int pam_putenv(pam_handle_t *pamh, const char *name_value)
 {
-    int l2eq, item, retval;
+    size_t l2eq;
+    int item, retval;
 
     D(("called."));
     IF_NO_PAMH("pam_putenv", pamh, PAM_ABORT);
@@ -167,7 +168,7 @@ int pam_putenv(pam_handle_t *pamh, const char *name_value)
      */
 
     for (l2eq=0; name_value[l2eq] && name_value[l2eq] != '='; ++l2eq);
-    if (l2eq <= 0) {
+    if (l2eq == 0) {
 	pam_syslog(pamh, LOG_ERR, "pam_putenv: bad variable");
 	return PAM_BAD_ITEM;
     }


### PR DESCRIPTION
pam_putenv and pam_getenv do not properly handle strings which are longer than 2 GB (INT_MAX).

In pam_putenv the l2eq variable could overflow and turn negative, leading to out of boundary access (after the fact that signed integer overflow is undefined behavior).

In pam_getenv a very long string could lead to a small int value so other environment variables could match.

The easiest fix for both is to use size_t.

Proof of Concept (compile with `-fsanitize=address`):

```
#include <security/pam_appl.h>
#include <security/pam_misc.h>

#include <err.h>
#include <limits.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

static struct pam_conv conv = {
        misc_conv,
        NULL
};

int main(void) {
        pam_handle_t *pamh = NULL;
        int ret;
        char *val;

        ret = pam_start("poc", "poc", &conv, &pamh);
        if (ret != PAM_SUCCESS)
                errx(1, "pam_start: %s", pam_strerror(pamh, ret));

        val = malloc((size_t)INT_MAX + 2);
        if (val == NULL)
                err(1, NULL);

        memset(val, 'A', (size_t)INT_MAX + 1);
        val[(size_t)INT_MAX + 1] = '\0';

        ret = pam_putenv(pamh, val);
        if (ret != PAM_SUCCESS)
                errx(1, "pam_putenv: %s", pam_strerror(pamh, ret));

        pam_end(pamh, ret);
        return 0;
}
```

Output on amd64 with sufficient RAM is:
```
./main
AddressSanitizer:DEADLYSIGNAL
=================================================================
==80459==ERROR: AddressSanitizer: SEGV on unknown address
```