### PR TITLE
libpam: use close_range() to close file descriptors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -638,6 +638,7 @@ AC_CHECK_FUNCS(quotactl)
 AC_CHECK_FUNCS(unshare)
 AC_CHECK_FUNCS(explicit_bzero memset_explicit)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
+AC_CHECK_FUNCS(close_range)
 
 AC_ARG_ENABLE([regenerate-docu],
   AS_HELP_STRING([--disable-regenerate-docu],[Don't re-build documentation from XML sources]),


### PR DESCRIPTION
* configure.ac: check whether close_range() is available in the system.
* libpam/pam_modutil_sanitize.c: use close_range() to close all file descriptors. If the interface isn't available use the previous approach.

Link: https://github.com/linux-pam/linux-pam/pull/276
Resolves: https://issues.redhat.com/browse/RHEL-5099