### PR TITLE
pam_canonicalize_user: new module to canonicalize user name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -768,7 +768,8 @@ AC_CONFIG_FILES([Makefile libpam/Makefile libpamc/Makefile libpamc/test/Makefile
 	Make.xml.rules \
 	modules/Makefile \
 	modules/pam_access/Makefile \
-        modules/pam_debug/Makefile modules/pam_deny/Makefile \
+	modules/pam_canonicalize_user/Makefile \
+	modules/pam_debug/Makefile modules/pam_deny/Makefile \
 	modules/pam_echo/Makefile modules/pam_env/Makefile \
 	modules/pam_faildelay/Makefile modules/pam_faillock/Makefile \
 	modules/pam_filter/Makefile modules/pam_filter/upperLOWER/Makefile \

--- a/doc/sag/Linux-PAM_SAG.xml
+++ b/doc/sag/Linux-PAM_SAG.xml
@@ -378,6 +378,7 @@ session   required   pam_warn.so
       coming with Linux-PAM.
     </para>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_access.xml"/>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_canonicalize_user.xml"/>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_debug.xml"/>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_deny.xml"/>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_echo.xml"/>

--- a/doc/sag/pam_canonicalize_user.xml
+++ b/doc/sag/pam_canonicalize_user.xml
@@ -1,0 +1,24 @@
+<section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="sag-pam_canonicalize_user">
+  <title>pam_canonicalize_user - get user name and canonicalize it</title>
+  <cmdsynopsis sepchar=" ">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-cmdsynopsis")/*)'/>
+  </cmdsynopsis>
+  <section xml:id="sag-pam_canonicalize_user-description">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-description")/*)'/>
+  </section>
+  <section xml:id="sag-pam_canonicalize_user-options">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-options")/*)'/>
+  </section>
+  <section xml:id="sag-pam_canonicalize_user-types">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-types")/*)'/>
+  </section>
+  <section xml:id="sag-pam_canonicalize_user-return_values">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-return_values")/*)'/>
+  </section>
+  <section xml:id="sag-pam_canonicalize_user-examples">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-examples")/*)'/>
+  </section>
+  <section xml:id="sag-pam_canonicalize_user-author">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../../modules/pam_canonicalize_user/pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-author")/*)'/>
+  </section>
+</section>

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -44,6 +44,7 @@ endif
 
 SUBDIRS := \
 	pam_access \
+	pam_canonicalize_user \
 	pam_debug \
 	pam_deny \
 	pam_echo \

--- a/modules/pam_canonicalize_user/Makefile.am
+++ b/modules/pam_canonicalize_user/Makefile.am
@@ -27,6 +27,9 @@ endif
 securelib_LTLIBRARIES = pam_canonicalize_user.la
 pam_canonicalize_user_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
+check_PROGRAMS = tst-pam_canonicalize_user-retval
+tst_pam_canonicalize_user_retval_LDADD = $(top_builddir)/libpam/libpam.la
+
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
 -include $(top_srcdir)/Make.xml.rules

--- a/modules/pam_canonicalize_user/Makefile.am
+++ b/modules/pam_canonicalize_user/Makefile.am
@@ -1,0 +1,33 @@
+CLEANFILES = *~
+MAINTAINERCLEANFILES = $(MANS) README
+
+EXTRA_DIST = $(XMLS)
+
+if HAVE_DOC
+dist_man_MANS = pam_canonicalize_user.8
+endif
+XMLS = README.xml pam_canonicalize_user.8.xml
+dist_check_SCRIPTS = tst-pam_canonicalize_user
+TESTS = $(dist_check_SCRIPTS)
+
+securelibdir = $(SECUREDIR)
+if HAVE_VENDORDIR
+secureconfdir = $(VENDOR_SCONFIGDIR)
+else
+secureconfdir = $(SCONFIGDIR)
+endif
+
+AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
+	    $(WARN_CFLAGS)
+AM_LDFLAGS = -no-undefined -avoid-version -module
+if HAVE_VERSIONING
+  AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
+endif
+
+securelib_LTLIBRARIES = pam_canonicalize_user.la
+pam_canonicalize_user_la_LIBADD = $(top_builddir)/libpam/libpam.la
+
+if ENABLE_REGENERATE_MAN
+dist_noinst_DATA = README
+-include $(top_srcdir)/Make.xml.rules
+endif

--- a/modules/pam_canonicalize_user/README.xml
+++ b/modules/pam_canonicalize_user/README.xml
@@ -1,0 +1,27 @@
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+
+  <info>
+
+    <title>
+      <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-name")/*)'/>
+    </title>
+
+  </info>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-description")/*)'/>
+  </section>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-options")/*)'/>
+  </section>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-examples")/*)'/>
+  </section>
+
+  <section>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pam_canonicalize_user.8.xml" xpointer='xpointer(id("pam_canonicalize_user-author")/*)'/>
+  </section>
+
+</article>

--- a/modules/pam_canonicalize_user/pam_canonicalize_user.8.xml
+++ b/modules/pam_canonicalize_user/pam_canonicalize_user.8.xml
@@ -1,0 +1,137 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="pam_canonicalize_user">
+
+  <refmeta>
+    <refentrytitle>pam_canonicalize_user</refentrytitle>
+    <manvolnum>8</manvolnum>
+    <refmiscinfo class="source">Linux-PAM</refmiscinfo>
+    <refmiscinfo class="manual">Linux-PAM Manual</refmiscinfo>
+  </refmeta>
+
+  <refnamediv xml:id="pam_canonicalize_user-name">
+    <refname>pam_canonicalize_user</refname>
+    <refpurpose>Get user name and canonicalize it</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis xml:id="pam_canonicalize_user-cmdsynopsis" sepchar=" ">
+      <command>pam_canonicalize_user.so</command>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1 xml:id="pam_canonicalize_user-description">
+  <title>DESCRIPTION</title>
+  <para>
+    This PAM module uses the name of the user obtained via
+    <citerefentry>
+      <refentrytitle>pam_get_user</refentrytitle><manvolnum>3</manvolnum>
+    </citerefentry>
+    as a key to query the password database, and replaces
+    <emphasis>PAM_USER</emphasis> with the <emphasis>pw_name</emphasis> value
+    that has been returned.
+  </para>
+  </refsect1>
+
+  <refsect1 xml:id="pam_canonicalize_user-options">
+    <title>OPTIONS</title>
+    <para>This module does not recognise any options.</para>
+  </refsect1>
+
+  <refsect1 xml:id="pam_canonicalize_user-types">
+    <title>MODULE TYPES PROVIDED</title>
+    <para>Only the <option>auth</option> module type is provided.</para>
+  </refsect1>
+
+  <refsect1 xml:id="pam_canonicalize_user-return_values">
+    <title>RETURN VALUES</title>
+    <variablelist>
+      <varlistentry>
+        <term>PAM_IGNORE</term>
+        <listitem>
+          <para>The user name was set successfully.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_USER_UNKNOWN</term>
+        <listitem>
+          <para>The user was not found.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_SYSTEM_ERR</term>
+        <listitem>
+          <para>The application did not supply neither a user name nor a conversation method.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_INCOMPLETE</term>
+        <listitem>
+          <para>The conversation method supplied by the application is waiting for an event.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_CONV_ERR</term>
+        <listitem>
+          <para>The conversation method supplied by the application failed to obtain the user name.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_ABORT</term>
+        <listitem>
+          <para>Error resuming an old conversation.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_BUF_ERR</term>
+        <listitem>
+          <para>Memory buffer error.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1 xml:id="pam_canonicalize_user-examples">
+    <title>EXAMPLES</title>
+    <para>
+      Prepend the PAM auth stack with the following line to canonicalize
+      the user name before the authentication:
+      <programlisting>
+        auth required pam_canonicalize_user.so
+      </programlisting>
+    </para>
+  </refsect1>
+
+  <refsect1 xml:id="pam_get_user-see_also">
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+        <refentrytitle>pam_get_user</refentrytitle><manvolnum>3</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam_get_item</refentrytitle><manvolnum>3</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam_set_item</refentrytitle><manvolnum>3</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>getpwnam</refentrytitle><manvolnum>3</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam.conf</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam.d</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>pam</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+
+  <refsect1 xml:id="pam_canonicalize_user-author">
+    <title>AUTHOR</title>
+    <para>
+      pam_canonicalize_user was written by Dmitry V. Levin &lt;ldv@strace.io&gt;.
+    </para>
+  </refsect1>
+
+</refentry>

--- a/modules/pam_canonicalize_user/pam_canonicalize_user.c
+++ b/modules/pam_canonicalize_user/pam_canonicalize_user.c
@@ -1,0 +1,76 @@
+/*
+ * pam_canonicalize_user - get user name and canonicalize it
+ *
+ * Copyright (c) 2023 Dmitry V. Levin <ldv@strace.io>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * ALTERNATIVELY, this product may be distributed under the terms of
+ * the GNU Public License, in which case the provisions of the GPL
+ * are required INSTEAD OF the above restrictions.  (This clause is
+ * necessary due to a potential bad interaction between the GPL and
+ * the restrictions contained in a BSD-style copyright.)
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <string.h>
+#include <syslog.h>
+
+#include <security/pam_modules.h>
+#include <security/pam_modutil.h>
+#include <security/pam_ext.h>
+
+int
+pam_sm_authenticate(pam_handle_t *pamh UNUSED, int flags UNUSED,
+		    int argc UNUSED, const char **argv UNUSED)
+{
+	const char *user;
+	int rc = pam_get_user(pamh, &user, 0);
+	if (rc != PAM_SUCCESS) {
+		pam_syslog(pamh, LOG_NOTICE, "cannot determine user name: %s",
+			   pam_strerror(pamh, rc));
+		return rc == PAM_CONV_AGAIN ? PAM_INCOMPLETE : rc;
+	}
+
+	struct passwd *pw = pam_modutil_getpwnam(pamh, user);
+	if (!pw) {
+		pam_syslog(pamh, LOG_NOTICE, "user unknown");
+		return PAM_USER_UNKNOWN;
+	}
+
+	if (strcmp(user, pw->pw_name) == 0)
+		return PAM_IGNORE;
+
+	rc = pam_set_item(pamh, PAM_USER, pw->pw_name);
+	return rc == PAM_SUCCESS ? PAM_IGNORE : rc;
+}
+
+int
+pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
+	       int argc UNUSED, const char **argv UNUSED)
+{
+	return PAM_IGNORE;
+}

--- a/modules/pam_canonicalize_user/tst-pam_canonicalize_user
+++ b/modules/pam_canonicalize_user/tst-pam_canonicalize_user
@@ -1,0 +1,2 @@
+#!/bin/sh
+../../tests/tst-dlopen .libs/pam_canonicalize_user.so

--- a/modules/pam_canonicalize_user/tst-pam_canonicalize_user-retval.c
+++ b/modules/pam_canonicalize_user/tst-pam_canonicalize_user-retval.c
@@ -1,0 +1,197 @@
+/*
+ * Check pam_canonicalize_user return values.
+ *
+ * Copyright (c) 2023 Dmitry V. Levin <ldv@strace.io>
+ */
+
+#include "test_assert.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <security/pam_appl.h>
+
+#define MODULE_NAME "pam_canonicalize_user"
+#define TEST_NAME "tst-" MODULE_NAME "-retval"
+
+static const char service_file[] = TEST_NAME ".service";
+static struct pam_conv null_conv;
+
+static int
+again_conv_func(int num_msg UNUSED, const struct pam_message **msg UNUSED,
+		struct pam_response **resp UNUSED, void *appdata_ptr UNUSED)
+{
+	return PAM_CONV_AGAIN;
+}
+
+static struct pam_conv again_conv = { .conv = again_conv_func };
+
+#ifdef HAVE_GETPWNAM_R
+
+int
+getpwnam_r(const char *name, struct passwd *pwd, char *buf, size_t buflen, struct passwd **result)
+{
+	if (strcmp(name, "root") == 0 ||
+	    strcmp(name, "ROOT") == 0)
+		return getpwuid_r(0, pwd, buf, buflen, result);
+
+	*result = NULL;
+	return 0;
+}
+
+#else /* !HAVE_GETPWNAM_R */
+
+struct passwd *
+getpwnam(const char *name)
+{
+	if (strcmp(name, "root") == 0 ||
+	    strcmp(name, "ROOT") == 0)
+		return getpwuid(0);
+
+	errno = 0;
+	return NULL;
+}
+
+#endif /* !HAVE_GETPWNAM_R */
+
+int
+main(void)
+{
+	pam_handle_t *pamh = NULL;
+	FILE *fp;
+
+	char cwd[PATH_MAX];
+	ASSERT_NE(NULL, getcwd(cwd, sizeof(cwd)));
+
+	struct passwd *pw;
+	ASSERT_NE(NULL, (pw = getpwuid(0)));
+	ASSERT_EQ(0, strcmp("root", pw->pw_name));
+
+	/* PAM_USER_UNKNOWN */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "#%%PAM-1.0\n"
+			     "auth required %s/.libs/%s.so\n"
+			     "account required %s/.libs/%s.so\n"
+			     "password required %s/.libs/%s.so\n"
+			     "session required %s/.libs/%s.so\n",
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, ":", &null_conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_USER_UNKNOWN, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_USER_UNKNOWN, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	/* PAM_IGNORE -> PAM_PERM_DENIED */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "#%%PAM-1.0\n"
+			     "auth required %s/.libs/%s.so\n"
+			     "account required %s/.libs/%s.so\n"
+			     "password required %s/.libs/%s.so\n"
+			     "session required %s/.libs/%s.so\n",
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "root", &null_conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_PERM_DENIED, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_PERM_DENIED, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	/* PAM_IGNORE -> PAM_SUCCESS */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "#%%PAM-1.0\n"
+			     "auth required %s/.libs/%s.so\n"
+			     "auth required %s/../pam_permit/.libs/pam_permit.so\n"
+			     "account required %s/.libs/%s.so\n"
+			     "account required %s/../pam_permit/.libs/pam_permit.so\n"
+			     "password required %s/.libs/%s.so\n"
+			     "password required %s/../pam_permit/.libs/pam_permit.so\n"
+			     "session required %s/.libs/%s.so\n"
+			     "session required %s/../pam_permit/.libs/pam_permit.so\n",
+			     cwd, MODULE_NAME, cwd,
+			     cwd, MODULE_NAME, cwd,
+			     cwd, MODULE_NAME, cwd,
+			     cwd, MODULE_NAME, cwd));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "root", &null_conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_SUCCESS, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	/* PAM_INCOMPLETE */
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, NULL, &again_conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_INCOMPLETE, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_INCOMPLETE, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	/* PAM_IGNORE -> PAM_SUCCESS, "ROOT" -> "root" */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "#%%PAM-1.0\n"
+			     "auth required %s/.libs/%s.so\n"
+			     "auth required %s/../pam_succseed_if/.libs/pam_succseed_if.so user = root\n"
+			     "account required %s/.libs/%s.so\n"
+			     "account required %s/../pam_succseed_if/.libs/pam_succseed_if.so user = root\n"
+			     "password required %s/.libs/%s.so\n"
+			     "password required %s/../pam_succseed_if/.libs/pam_succseed_if.so user = root\n"
+			     "session required %s/.libs/%s.so\n"
+			     "session required %s/../pam_succseed_if/.libs/pam_succseed_if.so user = root\n",
+			     cwd, MODULE_NAME, cwd,
+			     cwd, MODULE_NAME, cwd,
+			     cwd, MODULE_NAME, cwd,
+			     cwd, MODULE_NAME, cwd));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, "ROOT", &null_conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_SUCCESS, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_setcred(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_MODULE_UNKNOWN, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	ASSERT_EQ(0, unlink(service_file));
+
+	return 0;
+}


### PR DESCRIPTION
This module uses the name of the user obtained via pam_get_user(3)
as a key to query the password database, and replaces PAM_USER
with the pw_name value that has been returned.

The main usage scenario is systems where a user name is used in several
distinct authentication systems, some of them being case sensitive while
others are not.

The issue this module deals with pops up from time to time.
For example, 9 years ago a similar user name canonicalization was implemented in pam_selinux:
https://bugzilla.redhat.com/show_bug.cgi?id=1071010
https://github.com/linux-pam/linux-pam/commit/da695db7a453b1e2a5ef63fcca21d59a2ed75dda
https://lists.fedorahosted.org/pipermail/pam-developers/2014-March/thread.html