### PR TITLE
libpam: improve debug output

### DIFF
--- a/libpam/pam_env.c
+++ b/libpam/pam_env.c
@@ -14,6 +14,7 @@
 #include "pam_inline.h"
 
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #ifdef sunos
@@ -33,7 +34,12 @@ static void _pam_dump_env(pam_handle_t *pamh)
        , pamh->env->requested, pamh->env->entries));
 
     for (i=0; i<pamh->env->requested; ++i) {
-	_pam_output_debug(">%-3d [%9p]:[%s]"
+	_pam_output_debug(
+#if UINTPTR_MAX == UINT32_MAX
+			  ">%-3d [%10p]:[%s]"
+#else
+			  ">%-3d [%18p]:[%s]"
+#endif
 			  , i, pamh->env->list[i], pamh->env->list[i]);
     }
     _pam_output_debug("*NOTE* the last item should be (nil)");


### PR DESCRIPTION
The debug output of environment variables tries to properly format pointers in a right-aligned way. 9 characters are not enough for 32 bit pointers though due to prepended 0x. Also, it takes 18 for 64 bit systems.

Adjust the formatter properly for architectures.

32 bit before:
```
[../../libpam/pam_env.c:_pam_dump_env(32)] environment entries used = 2 [of 10 allocated]
>0   [0xf55005d0]:[a=b]
>1   [    (nil)]:[(null)]
*NOTE* the last item should be (nil)
```

32 bit after:
```
[../../libpam/pam_env.c:_pam_dump_env(33)] environment entries used = 2 [of 10 allocated]
>0   [0xf54005d0]:[a=b]
>1   [     (nil)]:[(null)]
*NOTE* the last item should be (nil)
```

64 bit before:
```
[../../libpam/pam_env.c:_pam_dump_env(32)] environment entries used = 2 [of 10 allocated]
>0   [0x6020000001d0]:[a=b]
>1   [    (nil)]:[(null)]
*NOTE* the last item should be (nil)
```

64 bit after:
```
[../../libpam/pam_env.c:_pam_dump_env(33)] environment entries used = 2 [of 10 allocated]
>0   [    0x6020000001d0]:[a=b]
>1   [             (nil)]:[(null)]
*NOTE* the last item should be (nil)
```
