### PR TITLE
libpam: avoid endless loop on long config line

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -575,7 +575,7 @@ static int _pam_assemble_line(FILE *f, char *buffer, int buf_len)
 
     D(("called."));
     for (;;) {
-	if (p >= endp) {
+	if (p >= endp - 1) {
 	    /* Overflow */
 	    D(("_pam_assemble_line: overflow"));
 	    return -1;


### PR DESCRIPTION
An endless loop with fgets can be triggered if exactly one free byte is left in buffer, because fgets will fill this byte with \0 without reading any further data from file.

This requires an invalid system configuration.

Proof of Concept:

1. Create a configuration file with excessively long line
`python -c 'print("a" + " " * 1021 + "\\ suffix")' > /tmp/poc`

2. Run proof of concept
```
#include <security/pam_appl.h>

#include <err.h>
#include <limits.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>

static int
test_conv (int num_msg, const struct pam_message **msgm,
           struct pam_response **response, void *appdata_ptr) {
  return 0;
}

static struct pam_conv conv = {
  test_conv,
  NULL
};

int main(void) {
  pam_handle_t *pamh;
  pam_start_confdir("poc", "nobody", &conv, "/tmp", &pamh);
  return 0;
}
```