### PR TITLE
libpam: stop processing excessively long lines

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -590,6 +590,12 @@ static int _pam_assemble_line(FILE *f, char *buffer, int buf_len)
 	    }
 	}
 
+	if (strchr(p, '\n') == NULL && !feof(f)) {
+	    /* Incomplete */
+	    D(("_pam_assemble_line: incomplete"));
+	    return -1;
+	}
+
 	/* skip leading spaces --- line may be blank */
 
 	s = p + strspn(p, " \n\t");


### PR DESCRIPTION
If a configuration file contains lines which are longer than 1024 characters, _pam_assemble_line splits them into multiple ones.

This may lead to comments being interpreted as actual configuration lines.

Proof of Concept:
1. Create a configuration line with a very long comment
`python -c 'print("a" + " " * 1030 + "just a comment")' > /tmp/poc`

2. Run Proof of Concept with --enable-debug compiled libpam
```
#include <security/pam_appl.h>

#include <err.h>
#include <limits.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>

static int
test_conv (int num_msg, const struct pam_message **msgm,
           struct pam_response **response, void *appdata_ptr) {
  return 0;
}

static struct pam_conv conv = {
  test_conv,
  NULL
};

int main(void) {
        pam_handle_t *pamh;
        pam_start_confdir("poc", "nobody", &conv, "/tmp", &pamh);
        return 0;
}
```
3. Observe DEBUG output
`[../../libpam/pam_handlers.c:_pam_parse_conf_file(79)] _pam_init_handler: LINE:         just a comment`