### PR TITLE
pam_rootok: call va_end only once

### DIFF
--- a/modules/pam_rootok/pam_rootok.c
+++ b/modules/pam_rootok/pam_rootok.c
@@ -72,7 +72,6 @@ log_callback (int type UNUSED, const char *fmt, ...)
 				   NULL, 0);
 	audit_close(audit_fd);
 	free(buf);
-	va_end(ap);
 	return 0;
     }
 


### PR DESCRIPTION
The amount of va_start and va_end calls should be identical. Since va_end is called right after vasprintf, don't call it later again.