### PR TITLE
libpam: simplify IF_NO_PAMH

### DIFF
--- a/libpam/pam_account.c
+++ b/libpam/pam_account.c
@@ -10,7 +10,7 @@ int pam_acct_mgmt(pam_handle_t *pamh, int flags)
 
     D(("called"));
 
-    IF_NO_PAMH("pam_acct_mgmt", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));

--- a/libpam/pam_auth.c
+++ b/libpam/pam_auth.c
@@ -17,7 +17,7 @@ int pam_authenticate(pam_handle_t *pamh, int flags)
 
     D(("pam_authenticate called"));
 
-    IF_NO_PAMH("pam_authenticate", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));
@@ -54,7 +54,7 @@ int pam_setcred(pam_handle_t *pamh, int flags)
 
     D(("pam_setcred called"));
 
-    IF_NO_PAMH("pam_setcred", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));

--- a/libpam/pam_data.c
+++ b/libpam/pam_data.c
@@ -45,7 +45,7 @@ static struct pam_data *_pam_locate_data(const pam_handle_t *pamh,
 
     D(("called"));
 
-    IF_NO_PAMH("_pam_locate_data", pamh, NULL);
+    IF_NO_PAMH(pamh, NULL);
 
     data = pamh->data;
 
@@ -69,7 +69,7 @@ int pam_set_data(
 
     D(("called"));
 
-    IF_NO_PAMH("pam_set_data", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_APP(pamh)) {
 	D(("called from application!?"));
@@ -122,7 +122,7 @@ int pam_get_data(
 
     D(("called"));
 
-    IF_NO_PAMH("pam_get_data", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_APP(pamh)) {
 	D(("called from application!?"));
@@ -151,7 +151,7 @@ void _pam_free_data(pam_handle_t *pamh, int status)
 
     D(("called"));
 
-    IF_NO_PAMH("_pam_free_data", pamh, /* no return value for void fn */);
+    IF_NO_PAMH(pamh, /* no return value for void fn */);
     data = pamh->data;
 
     while (data) {

--- a/libpam/pam_delay.c
+++ b/libpam/pam_delay.c
@@ -138,7 +138,7 @@ int pam_fail_delay(pam_handle_t *pamh, unsigned int usec)
 {
      unsigned int largest;
 
-     IF_NO_PAMH("pam_fail_delay", pamh, PAM_SYSTEM_ERR);
+     IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
      D(("setting delay to %u",usec));
 

--- a/libpam/pam_dispatch.c
+++ b/libpam/pam_dispatch.c
@@ -37,7 +37,7 @@ static int _pam_dispatch_aux(pam_handle_t *pamh, int flags, struct handler *h,
     int depth, impression, status, skip_depth, prev_level, stack_level;
     struct _pam_substack_state *substates = NULL;
 
-    IF_NO_PAMH("_pam_dispatch_aux", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (h == NULL) {
         const void *service=NULL;
@@ -337,7 +337,7 @@ int _pam_dispatch(pam_handle_t *pamh, int flags, int choice)
     int retval = PAM_SYSTEM_ERR, use_cached_chain;
     _pam_boolean resumed;
 
-    IF_NO_PAMH("_pam_dispatch", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from a module!?"));

--- a/libpam/pam_end.c
+++ b/libpam/pam_end.c
@@ -15,7 +15,7 @@ int pam_end(pam_handle_t *pamh, int pam_status)
 
     D(("entering pam_end()"));
 
-    IF_NO_PAMH("pam_end", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));

--- a/libpam/pam_env.c
+++ b/libpam/pam_env.c
@@ -56,7 +56,7 @@ int _pam_make_env(pam_handle_t *pamh)
 {
     D(("called."));
 
-    IF_NO_PAMH("_pam_make_env", pamh, PAM_ABORT);
+    IF_NO_PAMH(pamh, PAM_ABORT);
 
     /*
      * get structure memory
@@ -99,7 +99,7 @@ int _pam_make_env(pam_handle_t *pamh)
 void _pam_drop_env(pam_handle_t *pamh)
 {
     D(("called."));
-    IF_NO_PAMH("_pam_make_env", pamh, /* nothing to return */);
+    IF_NO_PAMH(pamh, /* nothing to return */);
 
     if (pamh->env != NULL) {
 	int i;
@@ -162,7 +162,7 @@ int pam_putenv(pam_handle_t *pamh, const char *name_value)
     int item, retval;
 
     D(("called."));
-    IF_NO_PAMH("pam_putenv", pamh, PAM_ABORT);
+    IF_NO_PAMH(pamh, PAM_ABORT);
 
     if (name_value == NULL) {
 	pam_syslog(pamh, LOG_ERR, "pam_putenv: no variable indicated");
@@ -295,7 +295,7 @@ const char *pam_getenv(pam_handle_t *pamh, const char *name)
     int item;
 
     D(("called."));
-    IF_NO_PAMH("pam_getenv", pamh, NULL);
+    IF_NO_PAMH(pamh, NULL);
 
     if (name == NULL) {
 	pam_syslog(pamh, LOG_ERR, "pam_getenv: no variable indicated");
@@ -368,7 +368,7 @@ char **pam_getenvlist(pam_handle_t *pamh)
     int i;
 
     D(("called."));
-    IF_NO_PAMH("pam_getenvlist", pamh, NULL);
+    IF_NO_PAMH(pamh, NULL);
 
     if (pamh->env == NULL || pamh->env->list == NULL) {
 	pam_syslog(pamh, LOG_ERR, "pam_getenvlist: no env%s found",

--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -392,7 +392,7 @@ int _pam_init_handlers(pam_handle_t *pamh)
     int retval;
 
     D(("called."));
-    IF_NO_PAMH("_pam_init_handlers",pamh,PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh,PAM_SYSTEM_ERR);
 
     /* Return immediately if everything is already loaded */
     if (pamh->handlers.handlers_loaded) {
@@ -796,7 +796,7 @@ int _pam_add_handler(pam_handle_t *pamh
     int mod_type = PAM_MT_FAULTY_MOD;
 
     D(("called."));
-    IF_NO_PAMH("_pam_add_handler",pamh,PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh,PAM_SYSTEM_ERR);
 
     D(("adding type %d, handler_type %d, module `%s'",
 	type, handler_type, mod_path));
@@ -954,7 +954,7 @@ int _pam_free_handlers(pam_handle_t *pamh)
     struct loaded_module *mod;
 
     D(("called."));
-    IF_NO_PAMH("_pam_free_handlers",pamh,PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh,PAM_SYSTEM_ERR);
 
     mod = pamh->handlers.module;
 

--- a/libpam/pam_item.c
+++ b/libpam/pam_item.c
@@ -31,7 +31,7 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
 
     D(("called"));
 
-    IF_NO_PAMH("pam_set_item", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     retval = PAM_SUCCESS;
 
@@ -177,7 +177,7 @@ int pam_get_item (const pam_handle_t *pamh, int item_type, const void **item)
     int retval = PAM_SUCCESS;
 
     D(("called."));
-    IF_NO_PAMH("pam_get_item", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (item == NULL) {
 	pam_syslog(pamh, LOG_ERR,
@@ -280,7 +280,7 @@ int pam_get_user(pam_handle_t *pamh, const char **user, const char *prompt)
 
     D(("called."));
 
-    IF_NO_PAMH("pam_get_user", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (user == NULL) {
         /* ensure that the module has supplied a destination */

--- a/libpam/pam_password.c
+++ b/libpam/pam_password.c
@@ -15,7 +15,7 @@ int pam_chauthtok(pam_handle_t *pamh, int flags)
 
     D(("called."));
 
-    IF_NO_PAMH("pam_chauthtok", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));

--- a/libpam/pam_private.h
+++ b/libpam/pam_private.h
@@ -287,9 +287,9 @@ void _pam_parse_control(int *control_array, char *tok);
  *       else
  */
 
-#define IF_NO_PAMH(X,pamh,ERR)                    \
+#define IF_NO_PAMH(pamh,ERR)                      \
 if ((pamh) == NULL) {                             \
-    syslog(LOG_ERR, _PAM_SYSTEM_LOG_PREFIX " " X ": NULL pam handle passed"); \
+    syslog(LOG_ERR, _PAM_SYSTEM_LOG_PREFIX " %s: NULL pam handle passed", __FUNCTION__); \
     return ERR;                                   \
 }
 

--- a/libpam/pam_session.c
+++ b/libpam/pam_session.c
@@ -14,7 +14,7 @@ int pam_open_session(pam_handle_t *pamh, int flags)
 
     D(("called"));
 
-    IF_NO_PAMH("pam_open_session", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));
@@ -31,7 +31,7 @@ int pam_close_session(pam_handle_t *pamh, int flags)
 
     D(("called"));
 
-    IF_NO_PAMH("pam_close_session", pamh, PAM_SYSTEM_ERR);
+    IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
     if (__PAM_FROM_MODULE(pamh)) {
 	D(("called from module!?"));


### PR DESCRIPTION
The first argument of IF_NO_PAMH is supposed to be the name of the function which was called with pamh being NULL.

With `__FUNCTION__` the name can be inserted automatically by the compiler which is also already done with D macro.

Fixes a bug in which _pam_drop_env erroneously logs with the function name _pam_make_env.