### PR TITLE
treewide: do not cast calloc/malloc/realloc

### DIFF
--- a/libpam/pam_env.c
+++ b/libpam/pam_env.c
@@ -62,7 +62,7 @@ int _pam_make_env(pam_handle_t *pamh)
      * get structure memory
      */
 
-    pamh->env = (struct pam_environ *) malloc(sizeof(struct pam_environ));
+    pamh->env = malloc(sizeof(struct pam_environ));
     if (pamh->env == NULL) {
 	pam_syslog(pamh, LOG_CRIT, "_pam_make_env: out of memory");
 	return PAM_BUF_ERR;
@@ -72,7 +72,7 @@ int _pam_make_env(pam_handle_t *pamh)
      * get list memory
      */
 
-    pamh->env->list = (char **)calloc( PAM_ENV_CHUNK, sizeof(char *) );
+    pamh->env->list = calloc( PAM_ENV_CHUNK, sizeof(char *) );
     if (pamh->env->list == NULL) {
 	pam_syslog(pamh, LOG_CRIT, "_pam_make_env: no memory for list");
 	_pam_drop(pamh->env);
@@ -333,7 +333,7 @@ static char **_copy_env(pam_handle_t *pamh)
     D(("now get some memory for dump"));
 
     /* allocate some memory for this (plus the null tail-pointer) */
-    dump = (char **) calloc(i, sizeof(char *));
+    dump = calloc(i, sizeof(char *));
     D(("dump = %p", dump));
     if (dump == NULL) {
 	return NULL;

--- a/libpam/pam_item.c
+++ b/libpam/pam_item.c
@@ -113,8 +113,7 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
 	} else {
 	    struct pam_conv *tconv;
 
-	    if ((tconv=
-		 (struct pam_conv *) malloc(sizeof(struct pam_conv))
+	    if ((tconv = malloc(sizeof(struct pam_conv))
 		) == NULL) {
 		pam_syslog(pamh, LOG_CRIT,
 				"pam_set_item: malloc failed for pam_conv");

--- a/libpam_misc/misc_conv.c
+++ b/libpam_misc/misc_conv.c
@@ -285,8 +285,7 @@ int misc_conv(int num_msg, const struct pam_message **msgm,
 
     D(("allocating empty response structure array."));
 
-    reply = (struct pam_response *) calloc(num_msg,
-					   sizeof(struct pam_response));
+    reply = calloc(num_msg, sizeof(struct pam_response));
     if (reply == NULL) {
 	D(("no memory for responses"));
 	return PAM_CONV_ERR;

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -103,7 +103,7 @@ static int process_args(pam_handle_t *pamh
 	    pam_syslog(pamh, LOG_DEBUG, "will run filter %s", *filtername);
 	}
 
-	levp = (char **) malloc(5*sizeof(char *));
+	levp = malloc(5*sizeof(char *));
 	if (levp == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for environment of filter");
 	    return -1;
@@ -152,7 +152,7 @@ static int process_args(pam_handle_t *pamh
 	}
 	size = SERVICE_OFFSET+strlen(tmp);
 
-	levp[1] = (char *) malloc(size+1);
+	levp[1] = malloc(size+1);
 	if (levp[1] == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for service name");
 	    if (levp) {
@@ -176,7 +176,7 @@ static int process_args(pam_handle_t *pamh
 	}
 	size = USER_OFFSET+strlen(user);
 
-	levp[2] = (char *) malloc(size+1);
+	levp[2] = malloc(size+1);
 	if (levp[2] == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for user's name");
 	    if (levp) {
@@ -198,7 +198,7 @@ static int process_args(pam_handle_t *pamh
 
 	size = TYPE_OFFSET+strlen(type);
 
-	levp[3] = (char *) malloc(size+1);
+	levp[3] = malloc(size+1);
 	if (levp[3] == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for type");
 	    if (levp) {

--- a/modules/pam_group/pam_group.c
+++ b/modules/pam_group/pam_group.c
@@ -87,7 +87,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state,
 
     /* is buf set ? */
     if (! *buf) {
-	*buf = (char *) calloc(1, PAM_GROUP_BUFLEN+1);
+	*buf = calloc(1, PAM_GROUP_BUFLEN+1);
 	if (! *buf) {
 	    pam_syslog(pamh, LOG_CRIT, "out of memory");
 	    D(("no memory"));
@@ -530,8 +530,7 @@ static int mkgrplist(pam_handle_t *pamh, char *buf, gid_t **list, int len)
 	       gid_t *tmp;
 
 	       D(("allocating new block"));
-	       tmp = (gid_t *) realloc((*list)
-				       , sizeof(gid_t) * (blks += GROUP_BLK));
+	       tmp = realloc((*list), sizeof(gid_t) * (blks += GROUP_BLK));
 	       if (tmp != NULL) {
 		    (*list) = tmp;
 	       } else {

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -106,7 +106,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	    }
 	else if(!strcmp(mybuf,"file")) {
 	    if (ifname) free (ifname);
-	    ifname = (char *)malloc(strlen(myval)+1);
+	    ifname = malloc(strlen(myval)+1);
 	    if (!ifname)
 		return PAM_BUF_ERR;
 	    strcpy(ifname,myval);

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -645,7 +645,7 @@ static int process_line(char *line, const char *home, const char *rhome,
            sstr = strchr(ustr, ',');
 
         poly->num_uids = count;
-        poly->uid = (uid_t *) malloc(count * sizeof (uid_t));
+        poly->uid = malloc(count * sizeof (uid_t));
         uidptr = poly->uid;
         if (uidptr == NULL) {
             goto erralloc;
@@ -1295,7 +1295,7 @@ static int check_inst_parent(char *ipath, struct instance_data *idata)
 	 * admin explicitly instructs to ignore the instance parent
 	 * mode by the "ignore_instance_parent_mode" argument).
 	 */
-	inst_parent = (char *) malloc(strlen(ipath)+1);
+	inst_parent = malloc(strlen(ipath)+1);
 	if (!inst_parent) {
 		pam_syslog(idata->pamh, LOG_CRIT, "Error allocating pathname string");
 		return PAM_SESSION_ERR;

--- a/modules/pam_time/pam_time.c
+++ b/modules/pam_time/pam_time.c
@@ -139,7 +139,7 @@ read_field(const pam_handle_t *pamh, int fd, char **buf, int *from, int *state, 
 
     /* is buf set ? */
     if (! *buf) {
-	*buf = (char *) calloc(1, PAM_TIME_BUFLEN+1);
+	*buf = calloc(1, PAM_TIME_BUFLEN+1);
 	if (! *buf) {
 	    pam_syslog(pamh, LOG_CRIT, "out of memory");
 	    D(("no memory"));

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -268,7 +268,7 @@ hmac_management(pam_handle_t *pamh, int debug, void **out, size_t *out_length,
         goto done;
     }
 
-    hmac_message = (unsigned char*)malloc(sizeof(unsigned char) * MAX_HMAC_LENGTH);
+    hmac_message = malloc(sizeof(unsigned char) * MAX_HMAC_LENGTH);
     if (!hmac_message) {
         pam_syslog(pamh, LOG_CRIT, "Not enough memory");
         goto done;

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -687,7 +687,7 @@ int _unix_verify_password(pam_handle_t * pamh, const char *name
 
 	retval = get_pwd_hash(pamh, name, &pwd, &salt);
 
-	data_name = (char *) malloc(sizeof(FAIL_PREFIX) + strlen(name));
+	data_name = malloc(sizeof(FAIL_PREFIX) + strlen(name));
 	if (data_name == NULL) {
 		pam_syslog(pamh, LOG_CRIT, "no memory for data-name");
 	} else {


### PR DESCRIPTION
It is not required to cast the results of calloc, malloc, realloc, etc.