### PR TITLE
libpam: fix integer overflow when parsing configs

### DIFF
--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -37,6 +37,7 @@
 
 #include "pam_private.h"
 
+#include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -329,8 +330,17 @@ void _pam_parse_control(int *control_array, char *tok)
 	    /* parse a number */
 	    act = 0;
 	    do {
+		int digit = *tok - '0';
+		if (act > INT_MAX / 10) {
+		    error = "expecting smaller jump number";
+		    goto parse_error;
+		}
 		act *= 10;
-		act += *tok - '0';      /* XXX - this assumes ascii behavior */
+		if (act > INT_MAX - digit) {
+		    error = "expecting smaller jump number";
+		    goto parse_error;
+		}
+		act += digit;      /* XXX - this assumes ascii behavior */
 	    } while (*++tok && isdigit((unsigned char)*tok));
 	    if (! act) {
 		/* we do not allow 0 jumps.  There is a token ('ignore')


### PR DESCRIPTION
It is possible to trigger a signed integer overflow when parsing jump numbers for pam return types.

Fail if the number becomes too large.

Proof of Concept (compile with -fsanitize=undefined):

1. Create invalid /tmp/poc
```
echo "auth success=111111111111111111111111" > /tmp/po
```
2. Run Proof of Concept
```
#include <security/pam_appl.h>

#include <err.h>
#include <limits.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>

static int
test_conv (int num_msg, const struct pam_message **msgm,
           struct pam_response **response, void *appdata_ptr) {
  return 0;
}

static struct pam_conv conv = {
  test_conv,
  NULL
};

int main(void) {
        pam_handle_t *pamh;
        pam_start_confdir("poc", "nobody", &conv, "/tmp", &pamh);
        return 0;
}
```

Output is:
```
../../libpam/pam_misc.c:332:7: runtime error: signed integer overflow: 1111111111 * 10 cannot be represented in type 'int'
```