### PR TITLE
pam_echo: avoid heap overflow on huge files

### DIFF
--- a/modules/pam_echo/pam_echo.c
+++ b/modules/pam_echo/pam_echo.c
@@ -41,6 +41,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <limits.h>
@@ -180,6 +181,12 @@ pam_echo (pam_handle_t *pamh, int flags, int argc, const char **argv)
 	{
 	  close (fd);
 	  return PAM_IGNORE;
+	}
+
+      if ((uintmax_t) st.st_size >= (uintmax_t) SIZE_MAX)
+	{
+	  close (fd);
+	  return PAM_BUF_ERR;
 	}
 
       mtmp = malloc (st.st_size + 1);


### PR DESCRIPTION
The module might overflow heap on 32 bit systems if a 4 GB file is supplied as argument.

I have used the size limit which is also in place for pam_motd already.

Proof of Concept (on a 32 bit system):

1. Create a 4 GB file
```
dd if=/dev/zero of=/tmp/huge bs=1 count=1 seek=4294967295
```
2. Create a PAM configuration with pam_echo
```
session                optional        pam_echo.so file=/tmp/huge
```
3. Use the PAM tool, e.g. su (if the line is added to your su configuration)