### PR TITLE
pam_exec: fix stack overflow on \0 output

### DIFF
--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -274,7 +274,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 	    {
 	      size_t len;
 	      len = strlen(buf);
-	      if (buf[len-1] == '\n')
+	      if (len > 0 && buf[len-1] == '\n')
 		buf[len-1] = '\0';
 	      pam_info(pamh, "%s", buf);
 	    }

--- a/modules/pam_securetty/pam_securetty.c
+++ b/modules/pam_securetty/pam_securetty.c
@@ -158,8 +158,10 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
 
     while ((fgets(ttyfileline, sizeof(ttyfileline)-1, ttyfile) != NULL)
 	   && retval) {
-	if (ttyfileline[strlen(ttyfileline) - 1] == '\n')
-	    ttyfileline[strlen(ttyfileline) - 1] = '\0';
+	size_t len;
+	len = strlen(ttyfileline);
+	if (len > 0 && ttyfileline[len - 1] == '\n')
+	    ttyfileline[len - 1] = '\0';
 
 	retval = ( strcmp(ttyfileline, uttyname)
 		   && (!ptname[0] || strcmp(ptname, uttyname)) );
@@ -211,9 +213,12 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
             fclose(consoleactivefile);
 
 	    if (p) {
+		size_t len;
+
 		/* remove the newline character at end */
-		if (line[strlen(line)-1] == '\n')
-		    line[strlen(line)-1] = 0;
+		len = strlen(line);
+		if (len && line[len-1] == '\n')
+		    line[len-1] = 0;
 
 		for (n = p; n != NULL; p = n+1) {
 		    if ((n = strchr(p, ' ')) != NULL)


### PR DESCRIPTION
If an executed program prints \0 at the beginning of a line, then pam_exec triggers an out of boundary read (and possible) write on the stack.

Proof of Concept (compile with -fsanitize=address):
```
auth optional pam_exec.so stdout /bin/echo -ne \x00
```