### PR TITLE
libpam: fix _pam_mkargv return value on error path

### DIFF
--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -192,6 +192,7 @@ int _pam_mkargv(const char *s, char ***argv, int *argc)
 	    if ((our_argv = argvbuf = malloc(argvlen)) == NULL) {
 		pam_syslog(NULL, LOG_CRIT,
 			   "pam_mkargv: null returned by malloc");
+		argvlen = 0;
 	    } else {
 		char *tmp=NULL;
 


### PR DESCRIPTION
* libpam/pam_misc.c (_pam_mkargv): Return 0 in case of memory allocation failure.