### PR TITLE
pam_unix: read yescrypt rounds from login.defs

### DIFF
--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -99,8 +99,13 @@ unsigned long long _set_ctrl(pam_handle_t *pamh, int flags, int *remember,
 	  free (val);
 
 	  /* read number of rounds for crypt algo */
-	  if (rounds && (on(UNIX_SHA256_PASS, ctrl) || on(UNIX_SHA512_PASS, ctrl))) {
-	    val = pam_modutil_search_key(pamh, LOGIN_DEFS, "SHA_CRYPT_MAX_ROUNDS");
+	  if (rounds) {
+	    val = NULL;
+	    if (on(UNIX_SHA256_PASS, ctrl) || on(UNIX_SHA512_PASS, ctrl)) {
+	      val = pam_modutil_search_key(pamh, LOGIN_DEFS, "SHA_CRYPT_MAX_ROUNDS");
+	    } else if (on(UNIX_YESCRYPT_PASS, ctrl)) {
+	      val = pam_modutil_search_key(pamh, LOGIN_DEFS, "YESCRYPT_COST_FACTOR");
+	    }
 
 	    if (val) {
 	      *rounds = strtol(val, NULL, 10);


### PR DESCRIPTION
Retrieves `YESCRYPT_COST_FACTOR` from `/etc/login.defs` for Yescrypt, in a similar fashion to reading the number of rounds for SHA-2.

Resolves #607.