### PR TITLE
Treat INT_MAX limitations in pam_modutil_ioloop.c

### DIFF
--- a/libpam/pam_modutil_ioloop.c
+++ b/libpam/pam_modutil_ioloop.c
@@ -1,8 +1,8 @@
 /*
  * $Id$
  *
- * These functions provides common methods for ensure a complete read or
- * write occurs. It handles EINTR and partial read/write returns.
+ * These functions provide common methods to ensure a complete read or
+ * write occurs. They handle EINTR and partial read/write returns.
  */
 
 #include "pam_modutil_private.h"

--- a/libpam/pam_modutil_ioloop.c
+++ b/libpam/pam_modutil_ioloop.c
@@ -15,6 +15,11 @@ pam_modutil_read(int fd, char *buffer, int count)
 {
        int block, offset = 0;
 
+       if (count < 0) {
+               errno = EINVAL;
+               return -1;
+       }
+
        while (count > 0) {
                block = read(fd, &buffer[offset], count);
 
@@ -35,6 +40,11 @@ int
 pam_modutil_write(int fd, const char *buffer, int count)
 {
        int block, offset = 0;
+
+       if (count < 0) {
+               errno = EINVAL;
+               return -1;
+       }
 
        while (count > 0) {
                block = write(fd, &buffer[offset], count);

--- a/modules/pam_echo/pam_echo.c
+++ b/modules/pam_echo/pam_echo.c
@@ -183,7 +183,7 @@ pam_echo (pam_handle_t *pamh, int flags, int argc, const char **argv)
 	  return PAM_IGNORE;
 	}
 
-      if ((uintmax_t) st.st_size >= (uintmax_t) SIZE_MAX)
+      if ((uintmax_t) st.st_size > (uintmax_t) INT_MAX)
 	{
 	  close (fd);
 	  return PAM_BUF_ERR;
@@ -196,7 +196,7 @@ pam_echo (pam_handle_t *pamh, int flags, int argc, const char **argv)
 	  return PAM_BUF_ERR;
 	}
 
-      if (pam_modutil_read (fd, mtmp, st.st_size) == -1)
+      if (pam_modutil_read (fd, mtmp, st.st_size) != st.st_size)
 	{
 	  pam_syslog (pamh, LOG_ERR, "Error while reading %s: %m", file);
 	  free (mtmp);

--- a/modules/pam_nologin/pam_nologin.c
+++ b/modules/pam_nologin/pam_nologin.c
@@ -6,7 +6,9 @@
 
 #include "config.h"
 
+#include <limits.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -111,7 +113,13 @@ static int perform_check(pam_handle_t *pamh, struct opt_s *opts)
 	/* Don't print anything if the message is empty, will only
 	   disturb the output with empty lines */
 	if (st.st_size > 0) {
-	    char *mtmp = malloc(st.st_size+1);
+	    char *mtmp;
+	    if ((uintmax_t)st.st_size > (uintmax_t)INT_MAX) {
+	        pam_syslog(pamh, LOG_CRIT, "file too large");
+	        retval = PAM_SYSTEM_ERR;
+	        goto clean_up_fd;
+	    }
+	    mtmp = malloc(st.st_size+1);
 	    if (!mtmp) {
 	        pam_syslog(pamh, LOG_CRIT, "out of memory");
 	        retval = PAM_BUF_ERR;


### PR DESCRIPTION
The size arguments to pam_modutil_read and pam_modutil_write are of type int. I would like to change these to size_t to make them look like size arguments of system calls read and write, but since they are exported through header files, this would imply an API change.

A negative size value should not lead to a 0 return value, but -1 instead. Otherwise this can be interpreted as a short read, which leads to issues in pam_echo.

Since module pam_timestamp did not properly check for negative return values, I have adjusted the code there as well to avoid any side-effects due to my changes.

Proof of Concept for pam_echo:
1. Add pam_echo to a tool of your choice, e.g. /etc/pam.d/su
```
session   optional    pam_echo.so   file=/tmp/poc.txt
```
2. Create a file larger than INT_MAX
```
echo "hello world" > /tmp/poc.txt
dd if=/dev/zero of=/tmp/poc.txt bs=1 count=1 seek=2147483648 conv=notrunc
```
3. Trigger the line, e.g. run su

You will most likely encounter an empty line after the password prompt. If you skip the dd command, you will see "hello world" instead. The empty line would imply that the malloc-returned memory started with '\0' which is most likely the case.