### PR TITLE
pam_setquota: plug memory leak

### DIFF
--- a/modules/pam_setquota/pam_setquota.c
+++ b/modules/pam_setquota/pam_setquota.c
@@ -201,6 +201,7 @@ pam_sm_open_session(pam_handle_t *pamh, int flags UNUSED,
    */
   if (val) {
     param.start_uid = str_to_uid(pamh, val, param.start_uid, PATH_LOGIN_DEFS":UID_MIN");
+    _pam_drop(val);
   }
 
   /* Parse parameter values


### PR DESCRIPTION
The result of pam_modutil_search_key must be freed.

I have checked other pam_modutil_search_key callers and was unable to find other occurrences of memory leaks.

Proof of Concept (compiled with -fsanitize=address):
1. In /etc/pam.d/su:
```
session  required   pam_setquota.so
```
2. In /etc/login.defs:
```
UID_MIN                  1000
```
3. Run a successful su session and exit again

You should be able to see something like:
```
=================================================================
==63378==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fd88766d718 in __interceptor_strdup ../../../../libsanitizer/asan/asan_interceptors.cpp:454
    #1 0x7fd8873f815d in pam_modutil_search_key (/usr/lib/libpam.so.0+0x8b15d)
    #2 0x7fd886292e55  (<unknown module>)
    #3 0x7fd8873c4304 in _pam_dispatch_aux (/usr/lib/libpam.so.0+0x57304)
    #4 0x7fd8873c6652 in _pam_dispatch (/usr/lib/libpam.so.0+0x59652)
    #5 0x7fd8873e659f in pam_open_session (/usr/lib/libpam.so.0+0x7959f)
    #6 0x55aaba7795e6 in main (/usr/bin/su+0x1c5e6)
    #7 0x7fd886b40c49 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 5 byte(s) leaked in 1 allocation(s).
```