### PR TITLE
RFC: libpam: remove unneeded allocations

### DIFF
--- a/libpam/pam_modutil_getgrgid.c
+++ b/libpam/pam_modutil_getgrgid.c
@@ -15,28 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static int intlen(int number)
-{
-    int len = 2;
-    while (number != 0) {
-        number /= 10;
-	len++;
-    }
-    return len;
-}
-
-static int longlen(long number)
-{
-    int len = 2;
-    while (number != 0) {
-        number /= 10;
-	len++;
-    }
-    return len;
-}
-
 struct group *
-pam_modutil_getgrgid(pam_handle_t *pamh, gid_t gid)
+pam_modutil_getgrgid(pam_handle_t *pamh UNUSED, gid_t gid)
 {
 #ifdef HAVE_GETGRGID_R
 
@@ -67,49 +47,8 @@ pam_modutil_getgrgid(pam_handle_t *pamh, gid_t gid)
 			    sizeof(struct group) + (char *) buffer,
 			    length, &result);
 	if (!status && (result == buffer)) {
-	    char *data_name;
-	    const void *ignore;
-	    int i;
-
-	    data_name = malloc(strlen("_pammodutil_getgrgid") + 1 +
-			       longlen((long)gid) + 1 + intlen(INT_MAX) + 1);
-	    if ((pamh != NULL) && (data_name == NULL)) {
-	        D(("was unable to register the data item [%s]",
-	           pam_strerror(pamh, status)));
-		free(buffer);
-		return NULL;
-	    }
-
-	    if (pamh != NULL) {
-	        for (i = 0; i < INT_MAX; i++) {
-	            sprintf(data_name, "_pammodutil_getgrgid_%ld_%d",
-			    (long) gid, i);
-		    status = PAM_NO_MODULE_DATA;
-	            if (pam_get_data(pamh, data_name, &ignore) != PAM_SUCCESS) {
-		        status = pam_set_data(pamh, data_name,
-					      result, pam_modutil_cleanup);
-		    }
-		    if (status == PAM_SUCCESS) {
-		        break;
-		    }
-		}
-	    } else {
-	        status = PAM_SUCCESS;
-	    }
-
-	    free(data_name);
-
-	    if (status == PAM_SUCCESS) {
-		D(("success"));
-		return result;
-	    }
-
-	    D(("was unable to register the data item [%s]",
-	       pam_strerror(pamh, status)));
-
-	    free(buffer);
-	    return NULL;
-
+	    D(("success"));
+	    return result;
 	} else if (errno != ERANGE && errno != EINTR) {
 		/* no sense in repeating the call */
 		break;


### PR DESCRIPTION
The pam_modutil functions store results of reentrant functions by calling pam_set_data, but these entries are never retrieved again.

If reentrant functions do not exist, no such storing is performed either.