### PR TITLE
libpam: simplify _pam_StrTok

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -85,7 +85,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 	    /* No service field: all lines are for the known service. */
 	    this_service = known_service;
 	} else {
-	    this_service = tok = _pam_StrTok(buf, " \n\t", &nexttok);
+	    this_service = tok = _pam_tokenize(buf, " \n\t", &nexttok);
 	}
 
 #ifdef PAM_READ_BOTH_CONFS
@@ -103,7 +103,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 	    /* This is a service we are looking for */
 	    D(("Found PAM config entry for: %s", this_service));
 
-	    tok = _pam_StrTok(NULL, " \n\t", &nexttok);
+	    tok = _pam_tokenize(NULL, " \n\t", &nexttok);
 	    if (tok == NULL) {
 	        /* module type does not exist */
 	        D(("empty module type for %s", this_service));
@@ -150,7 +150,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 		for (i=0; i<_PAM_RETURN_VALUES;
 		     actions[i++] = _PAM_ACTION_UNDEF);
 	    }
-	    tok = _pam_StrTok(NULL, " \n\t", &nexttok);
+	    tok = _pam_tokenize(NULL, " \n\t", &nexttok);
 	    if (tok == NULL) {
 		/* no module name given */
 		D(("no control flag supplied"));
@@ -195,7 +195,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 		_pam_set_default_control(actions, _PAM_ACTION_BAD);
 	    }
 
-	    tok = _pam_StrTok(NULL, " \n\t", &nexttok);
+	    tok = _pam_tokenize(NULL, " \n\t", &nexttok);
 	    if (pam_include) {
 		if (substack) {
 		    res = _pam_add_handler(pamh, PAM_HT_SUBSTACK, other,

--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -85,7 +85,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 	    /* No service field: all lines are for the known service. */
 	    this_service = known_service;
 	} else {
-	    this_service = tok = _pam_tokenize(buf, " \n\t", &nexttok);
+	    this_service = tok = _pam_tokenize(buf, &nexttok);
 	}
 
 #ifdef PAM_READ_BOTH_CONFS
@@ -103,7 +103,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 	    /* This is a service we are looking for */
 	    D(("Found PAM config entry for: %s", this_service));
 
-	    tok = _pam_tokenize(NULL, " \n\t", &nexttok);
+	    tok = _pam_tokenize(NULL, &nexttok);
 	    if (tok == NULL) {
 	        /* module type does not exist */
 	        D(("empty module type for %s", this_service));
@@ -150,7 +150,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 		for (i=0; i<_PAM_RETURN_VALUES;
 		     actions[i++] = _PAM_ACTION_UNDEF);
 	    }
-	    tok = _pam_tokenize(NULL, " \n\t", &nexttok);
+	    tok = _pam_tokenize(NULL, &nexttok);
 	    if (tok == NULL) {
 		/* no module name given */
 		D(("no control flag supplied"));
@@ -195,7 +195,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 		_pam_set_default_control(actions, _PAM_ACTION_BAD);
 	    }
 
-	    tok = _pam_tokenize(NULL, " \n\t", &nexttok);
+	    tok = _pam_tokenize(NULL, &nexttok);
 	    if (pam_include) {
 		if (substack) {
 		    res = _pam_add_handler(pamh, PAM_HT_SUBSTACK, other,

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -45,13 +45,14 @@
 #include <syslog.h>
 #include <ctype.h>
 
-char *_pam_tokenize(char *from, const char *format, char **next)
+char *_pam_tokenize(char *from, char **next)
 /*
- * this function is a variant of the standard strtok, it differs in that
- * it takes an additional argument and doesn't nul terminate tokens until
+ * this function is a variant of the standard strtok_r, it differs in that
+ * it uses a fixed set of delimiters and doesn't nul terminate tokens until
  * they are actually reached.
  */
 {
+     const char *format = " \n\t";
      char table[256], *end;
      int i;
 
@@ -71,11 +72,9 @@ char *_pam_tokenize(char *from, const char *format, char **next)
      if (*from == '[') {
 	 /*
 	  * special case, "[...]" is considered to be a single
-	  * object.  Note, however, if one of the format[] chars is
-	  * '[' this single string will not be read correctly.
-	  * Note, any '[' inside the outer "[...]" pair will survive.
-	  * Note, the first ']' will terminate this string, but
-	  *  that "\]" will get compressed into "]". That is:
+	  * object.  Note, any '[' inside the outer "[...]" pair will
+	  * survive.  Note, the first ']' will terminate this string,
+	  * but that "\]" will get compressed into "]". That is:
 	  *
 	  *   "[..[..\]..]..." --> "..[..].."
 	  */
@@ -198,7 +197,7 @@ int _pam_mkargv(const char *s, char ***argv, int *argc)
 
 		argvbufp = (char *) argvbuf + (l * sizeof(char *));
 		D(("[%s]",sbuf));
-		while ((sbuf = _pam_tokenize(sbuf, " \n\t", &tmp))) {
+		while ((sbuf = _pam_tokenize(sbuf, &tmp))) {
 		    D(("arg #%d",++count));
 		    D(("->[%s]",sbuf));
 		    strcpy(argvbufp, sbuf);

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -45,6 +45,8 @@
 #include <syslog.h>
 #include <ctype.h>
 
+#define DELIMITERS " \n\t"
+
 char *_pam_tokenize(char *from, char **next)
 /*
  * this function is a variant of the standard strtok_r, it differs in that
@@ -52,22 +54,13 @@ char *_pam_tokenize(char *from, char **next)
  * they are actually reached.
  */
 {
-     const char *format = " \n\t";
-     char table[256], *end;
-     int i;
+     char *end;
 
      if (from == NULL && (from = *next) == NULL)
 	  return from;
 
-     /* initialize table */
-     for (i=1; i<256; table[i++] = '\0');
-     for (i=0; format[i] ;
-	  table[(unsigned char)format[i++]] = 'y');
-
      /* look for first non-format char */
-     while (*from && table[(unsigned char)*from]) {
-	  ++from;
-     }
+     from += strspn(from, DELIMITERS);
 
      if (*from == '[') {
 	 /*
@@ -93,7 +86,7 @@ char *_pam_tokenize(char *from, char **next)
             remains */
      } else if (*from) {
 	 /* simply look for next blank char */
-	 for (end=from; *end && !table[(unsigned char)*end]; ++end);
+	 end = from + strcspn(from, DELIMITERS);
      } else {
 	 return (*next = NULL);                    /* no tokens left */
      }

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -45,7 +45,7 @@
 #include <syslog.h>
 #include <ctype.h>
 
-char *_pam_StrTok(char *from, const char *format, char **next)
+char *_pam_tokenize(char *from, const char *format, char **next)
 /*
  * this function is a variant of the standard strtok, it differs in that
  * it takes an additional argument and doesn't nul terminate tokens until
@@ -198,7 +198,7 @@ int _pam_mkargv(const char *s, char ***argv, int *argc)
 
 		argvbufp = (char *) argvbuf + (l * sizeof(char *));
 		D(("[%s]",sbuf));
-		while ((sbuf = _pam_StrTok(sbuf, " \n\t", &tmp))) {
+		while ((sbuf = _pam_tokenize(sbuf, " \n\t", &tmp))) {
 		    D(("arg #%d",++count));
 		    D(("->[%s]",sbuf));
 		    strcpy(argvbufp, sbuf);

--- a/libpam/pam_private.h
+++ b/libpam/pam_private.h
@@ -266,7 +266,7 @@ struct pam_data {
 
 void _pam_free_data(pam_handle_t *pamh, int status);
 
-char *_pam_tokenize(char *from, const char *format, char **next);
+char *_pam_tokenize(char *from, char **next);
 
 char *_pam_strdup(const char *s);
 

--- a/libpam/pam_private.h
+++ b/libpam/pam_private.h
@@ -266,7 +266,7 @@ struct pam_data {
 
 void _pam_free_data(pam_handle_t *pamh, int status);
 
-char *_pam_StrTok(char *from, const char *format, char **next);
+char *_pam_tokenize(char *from, const char *format, char **next);
 
 char *_pam_strdup(const char *s);
 


### PR DESCRIPTION
I have split this PR into multiple commits for easier review. Feel free to squash!

The format argument to _pam_StrTok is always the same and the function is not exposed through API, which means that it can be easily adjusted. It uses a table internally to support variable formats. But since the format is always the same, it can just use strspn/strcspn.

Due to this, I have renamed the function to _pam_tokenize so nobody expects strtok-like arguments.