### PR TITLE
libpam: treat NUL in passwd files correctly

### DIFF
--- a/modules/pam_localuser/tst-pam_localuser-retval.c
+++ b/modules/pam_localuser/tst-pam_localuser-retval.c
@@ -55,7 +55,7 @@ main(void)
 	ASSERT_EQ(PAM_SUCCESS,
 		  pam_start_confdir(service_file, name, &conv, ".", &pamh));
 	ASSERT_NE(NULL, pamh);
-	ASSERT_EQ(PAM_SERVICE_ERR, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_PERM_DENIED, pam_authenticate(pamh, 0));
 	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
 	pamh = NULL;
 
@@ -105,7 +105,7 @@ main(void)
 	ASSERT_EQ(PAM_SUCCESS,
 		  pam_start_confdir(service_file, name, &conv, ".", &pamh));
 	ASSERT_NE(NULL, pamh);
-	ASSERT_EQ(PAM_SERVICE_ERR, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_PERM_DENIED, pam_authenticate(pamh, 0));
 	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
 	pamh = NULL;
 


### PR DESCRIPTION
This already implies that the passwd file itself is broken. Yet do not skip lines by accident due to fgets limitations.

As a positive side effect, arbitrarily long lines and user names are supported now as well.