### PR TITLE
pam_unix: handle invalid names in _unix_getpwnam

### DIFF
--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -321,11 +321,12 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 	char buf[16384];
 	int matched = 0, buflen;
 	char *slogin, *spasswd, *suid, *sgid, *sgecos, *shome, *sshell, *p;
+	size_t userlen;
 
 	memset(buf, 0, sizeof(buf));
 
-	if (!matched && files) {
-		int userlen = strlen(name);
+	userlen = strlen(name);
+	if (!matched && files && userlen < sizeof(buf) && strchr(name, ':') == NULL) {
 		passwd = fopen("/etc/passwd", "r");
 		if (passwd != NULL) {
 			while (fgets(buf, sizeof(buf), passwd) != NULL) {


### PR DESCRIPTION
It is possible to trigger an out of boundary read with very long usernames (strlen's result is stored in an int) or, with even longer usernames, match other users with same prefix. This would mean that roott[and lots of t's following] could match root user.

Also do not allow ':' in names when iterating through the passwd file this way.

With help of joern, @ellcs spotted one of the int assignments of strlen's return value. @BenBE noticed that the module can be reached from pam_start.

Please note though that this PoC only works if `pam_chauthtok` is called directly after `pam_start`, which popular tools do not do. Even the ones you could get into this code path have limitations on user names which makes this more theoretical than it might look at first.

Proof of Concept for OOB access (compile Linux-PAM with -fsanitize=address):
1. Prepare /tmp/poc/poc
```
mkdir /tmp/poc
echo "password required pam_unix.so" > /tmp/poc/poc
```
2. Compile poc.c
```
#include <security/pam_appl.h>
#include <security/pam_misc.h>

#include <err.h>
#include <string.h>
#include <unistd.h>

static struct pam_conv conv = {
  misc_conv,
  NULL
};

#define NAME_LENGTH 16385

int main(void) {
  char *buf;
  int ret;
  pam_handle_t *pamh = NULL;

  /* prepare a sufficiently large user name */
  if ((buf = malloc(NAME_LENGTH)) == NULL)
    err(1, NULL);
  memset(buf, 'A', NAME_LENGTH);
  buf[NAME_LENGTH - 1] = '\0';

  ret = pam_start_confdir("poc", buf, &conv, "/tmp/poc", &pamh);
  if (ret == 0) {
    ret = pam_chauthtok(pamh, 0);
    pam_end(pamh, ret);
  }
  free(buf);

  return ret;
}
```
```
$ cc -fsanitize=address -lpam -lpam_misc -o poc poc.c
```
3. Run poc
```
$ ./poc
==71775==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f73aea04040 at pc 0x7f73af9966d8 bp 0x7ff[27/1890] sp 0x7ffc3e7d9fe0
```
