### PR TITLE
pam_timestamp: OpenSSL wrapper updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -640,6 +640,11 @@ AC_CHECK_FUNCS(explicit_bzero memset_explicit)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
 AC_CHECK_FUNCS(close_range)
 
+dnl For module/pam_timestamp
+AC_CHECK_HEADERS([sys/random.h])
+dnl May require libbsd/libSystem on non-Linux platforms
+AC_CHECK_FUNCS(getrandom)
+
 AC_ARG_ENABLE([regenerate-docu],
   AS_HELP_STRING([--disable-regenerate-docu],[Don't re-build documentation from XML sources]),
   [enable_docu=$enableval], [enable_docu=yes])

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -105,6 +105,7 @@ generate_key(pam_handle_t *pamh, char **key, size_t key_size)
 
     if (bytes_read < 0 || (size_t)bytes_read < key_size) {
         pam_syslog(pamh, LOG_ERR, "Short read on random device");
+        pam_overwrite_n(tmp, key_size);
         free(tmp);
         return PAM_AUTH_ERR;
     }
@@ -192,6 +193,7 @@ write_file(pam_handle_t *pamh, const char *file_name, char *text,
 
     if (bytes_written < 0 || (size_t)bytes_written < text_length) {
         pam_syslog(pamh, LOG_ERR, "Short write on %s", file_name);
+        pam_overwrite_n(text, text_length);
         free(text);
         return PAM_AUTH_ERR;
     }

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -87,7 +87,7 @@ generate_key(pam_handle_t *pamh, char **key, size_t key_size)
     ssize_t bytes_read = 0;
     char *tmp = *key = NULL;
 
-    tmp = malloc(key_size);
+    tmp = calloc(1, key_size);
     if (!tmp) {
         pam_syslog(pamh, LOG_CRIT, "Not enough memory");
         return PAM_AUTH_ERR;
@@ -141,7 +141,7 @@ read_file(pam_handle_t *pamh, int fd, char **text, size_t *text_length)
         return PAM_AUTH_ERR;
     }
 
-    tmp = malloc(st.st_size);
+    tmp = calloc(1, st.st_size);
     if (!tmp) {
         pam_syslog(pamh, LOG_CRIT, "Not enough memory");
         close(fd);

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -81,6 +81,7 @@ get_crypto_algorithm(pam_handle_t *pamh, int debug){
 }
 
 static int
+PAM_NONNULL((1, 2))
 generate_key(pam_handle_t *pamh, char **key, size_t key_size)
 {
     int fd = 0;
@@ -117,6 +118,7 @@ generate_key(pam_handle_t *pamh, char **key, size_t key_size)
 }
 
 static int
+PAM_NONNULL((1, 3, 4))
 read_file(pam_handle_t *pamh, int fd, char **text, size_t *text_length)
 {
     struct stat st;
@@ -165,6 +167,7 @@ read_file(pam_handle_t *pamh, int fd, char **text, size_t *text_length)
 }
 
 static int
+PAM_NONNULL((1, 2, 3))
 write_file(pam_handle_t *pamh, const char *file_name, char *text,
            size_t text_length, uid_t owner, gid_t group)
 {
@@ -203,6 +206,7 @@ write_file(pam_handle_t *pamh, const char *file_name, char *text,
 }
 
 static int
+PAM_NONNULL((1, 2, 3))
 key_management(pam_handle_t *pamh, const char *file_name, char **text,
                 size_t text_length, uid_t owner, gid_t group)
 {

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -49,6 +49,7 @@
 #include <openssl/evp.h>
 #include <openssl/params.h>
 #include <openssl/core_names.h>
+#include <openssl/rand.h>
 
 #include <security/pam_ext.h>
 #include <security/pam_modutil.h>
@@ -96,6 +97,12 @@ generate_key(pam_handle_t *pamh, char **key, size_t key_size)
     if (!tmp) {
         pam_syslog(pamh, LOG_CRIT, "Not enough memory");
         return PAM_AUTH_ERR;
+    }
+
+    /* Try to get random data from OpenSSL first */
+    if (RAND_priv_bytes((unsigned char *)tmp, key_size) == 1) {
+        *key = tmp;
+        return PAM_SUCCESS;
     }
 
 #ifdef HAVE_GETRANDOM

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -85,18 +85,19 @@ generate_key(pam_handle_t *pamh, char **key, size_t key_size)
 {
     int fd = 0;
     ssize_t bytes_read = 0;
-    char * tmp = NULL;
-
-    fd = open("/dev/urandom", O_RDONLY);
-    if (fd == -1) {
-        pam_syslog(pamh, LOG_ERR, "Cannot open /dev/urandom: %m");
-        return PAM_AUTH_ERR;
-    }
+    char *tmp = *key = NULL;
 
     tmp = malloc(key_size);
     if (!tmp) {
         pam_syslog(pamh, LOG_CRIT, "Not enough memory");
-        close(fd);
+        return PAM_AUTH_ERR;
+    }
+
+    fd = open("/dev/urandom", O_RDONLY);
+    if (fd == -1) {
+        pam_syslog(pamh, LOG_ERR, "Cannot open /dev/urandom: %m");
+        pam_overwrite_n(tmp, key_size);
+        free(tmp);
         return PAM_AUTH_ERR;
     }
 


### PR DESCRIPTION
This is a follow-up to my notes on #644.

The changes are mainly:
1. Ensure memory buffers with key material should always be wiped. This limits exposure of those buffers. This is mostly defense-in-depth, as those buffers are never exposed to the caller (error paths).

2. Prefer proper APIs for retrieving CSRNG data like OpenSSL's `RAND_priv_bytes` and `getrandom(5)`. As this is a wrapper for OpenSSL the call to `RAND_priv_bytes` is tried first, with `getrandom(5)` tried second. Only if both fail, a fallback to reading `/dev/urandom` is tried (which based on the implementation of `RAND_priv_bytes` is likely to fail too at this point).

I also added some checks for `PAM_NONNULL` to some of the functions to have the compiler check their inputs for valid pointers (as those checks were not performed inside those functions. If desired I can add those for the other functions too.