### PR TITLE
libpam: support arbitrarily long configuration file lines

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -32,7 +32,7 @@ static void _pam_free_handlers_aux(struct handler **hp);
 static int _pam_add_handler(pam_handle_t *pamh
 		     , int must_fail, int other, int stack_level, int type
 		     , int *actions, const char *mod_path
-		     , int argc, char **argv, int argvlen);
+		     , int argc, char **argv, size_t argvlen);
 
 /* Values for module type */
 
@@ -77,7 +77,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 	int handler_type = PAM_HT_MODULE; /* regular handler from a module */
 	int argc;
 	char **argv;
-	int argvlen;
+	size_t argvlen;
 
 	D(("LINE: %s", buf));
 	if (known_service != NULL) {
@@ -235,7 +235,7 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 	    if (nexttok != NULL) {
 		D(("list: %s",nexttok));
 	        argvlen = _pam_mkargv(nexttok, &argv, &argc);
-		D(("argvlen = %d",argvlen));
+		D(("argvlen = %zu",argvlen));
 		if (argvlen == 0) {
 		    /* memory allocation failed */
 		    D(("failed to allocate argument vector"));
@@ -247,7 +247,8 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 		}
 	    } else {               /* there are no arguments so fix by hand */
 		D(("empty argument list"));
-		argvlen = argc = 0;
+		argvlen = 0;
+		argc = 0;
 		argv = NULL;
 	    }
 
@@ -788,7 +789,7 @@ _pam_load_module(pam_handle_t *pamh, const char *mod_path, int handler_type)
 int _pam_add_handler(pam_handle_t *pamh
 		     , int handler_type, int other, int stack_level, int type
 		     , int *actions, const char *mod_path
-		     , int argc, char **argv, int argvlen)
+		     , int argc, char **argv, size_t argvlen)
 {
     struct loaded_module *mod = NULL;
     struct handler **handler_p;

--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -18,14 +18,23 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#define BUF_SIZE                  1024
 #define MODULE_CHUNK              4
 #define UNKNOWN_MODULE       "<*unknown module*>"
 #ifndef _PAM_ISA
 #define _PAM_ISA "."
 #endif
 
-static int _pam_assemble_line(FILE *f, char *buf, int buf_len);
+struct line_buffer {
+	char *assembled;
+	char *chunk;
+	size_t chunk_size;
+	size_t len;
+	size_t size;
+};
+
+static void _pam_buffer_init(struct line_buffer *buffer);
+
+static int _pam_assemble_line(FILE *f, struct line_buffer *buf);
 
 static void _pam_free_handlers_aux(struct handler **hp);
 
@@ -62,12 +71,15 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 #endif /* PAM_READ_BOTH_CONFS */
     )
 {
-    char buf[BUF_SIZE];
+    struct line_buffer buffer;
     int x;                    /* read a line from the FILE *f ? */
+
+    _pam_buffer_init(&buffer);
     /*
      * read a line from the configuration (FILE *) f
      */
-    while ((x = _pam_assemble_line(f, buf, BUF_SIZE)) > 0) {
+    while ((x = _pam_assemble_line(f, &buffer)) > 0) {
+	char *buf = buffer.assembled;
 	char *tok, *nexttok=NULL;
 	const char *this_service;
 	const char *mod_path;
@@ -572,94 +584,243 @@ int _pam_init_handlers(pam_handle_t *pamh)
     return PAM_SUCCESS;
 }
 
+static int _pam_buffer_add(struct line_buffer *buffer, char *start, char *end)
+{
+    size_t len = end - start;
+
+    D(("assembled: [%zu/%zu] '%s', adding [%zu] '%s'",
+	buffer->len, buffer->size,
+	buffer->assembled == NULL ? "" : buffer->assembled, len, start));
+
+    if (start == end)
+	return 0;
+
+    if (buffer->assembled == NULL && buffer->chunk == start) {
+	/* no extra allocation needed, just move chunk to assembled */
+	buffer->assembled = buffer->chunk;
+	buffer->len = len;
+	buffer->size = buffer->chunk_size;
+
+	buffer->chunk = NULL;
+	buffer->chunk_size = 0;
+
+	D(("exiting with quick exchange"));
+	return 0;
+    }
+
+    if (buffer->len + len + 1 > buffer->size) {
+	size_t size;
+	char *p;
+
+	size = buffer->len + len + 1;
+	if ((p = realloc(buffer->assembled, size)) == NULL)
+		return -1;
+
+	buffer->assembled = p;
+	buffer->size = size;
+    }
+
+    memcpy(buffer->assembled + buffer->len, start, len);
+    buffer->len += len;
+    buffer->assembled[buffer->len] = '\0';
+
+    D(("exiting"));
+    return 0;
+}
+
+static inline int _pam_buffer_add_eol(struct line_buffer *buffer,
+				      char *start, char *end)
+{
+    if (buffer->assembled != NULL || (*start != '\0' && *start != '\n'))
+	return _pam_buffer_add(buffer, start, end);
+    return 0;
+}
+
+static void _pam_buffer_clear(struct line_buffer *buffer)
+{
+    _pam_drop(buffer->assembled);
+    _pam_drop(buffer->chunk);
+    buffer->chunk_size = 0;
+    buffer->len = 0;
+    buffer->size = 0;
+}
+
+static void _pam_buffer_init(struct line_buffer *buffer)
+{
+    buffer->assembled = NULL;
+    buffer->chunk = NULL;
+    _pam_buffer_clear(buffer);
+}
+
+static void _pam_buffer_purge(struct line_buffer *buffer)
+{
+    _pam_drop(buffer->chunk);
+    buffer->chunk_size = 0;
+}
+
+static void _pam_buffer_shift(struct line_buffer *buffer)
+{
+    if (buffer->assembled == NULL)
+	return;
+
+    _pam_buffer_purge(buffer);
+    buffer->chunk = buffer->assembled;
+    buffer->chunk_size = buffer->size;
+
+    buffer->assembled = NULL;
+    buffer->size = 0;
+    buffer->len = 0;
+}
+
+static inline int _pam_buffer_valid(struct line_buffer *buffer)
+{
+    return buffer->assembled != NULL && *buffer->assembled != '\0';
+}
+
+/*
+ * Trim string to relevant parts of a configuration line.
+ *
+ * Preceding whitespaces are skipped and comment (#) marks the end of
+ * configuration line.
+ *
+ * Returns start of configuration line.
+ */
+static inline char *_pam_str_trim(char *str)
+{
+    /* skip leading spaces */
+    str += strspn(str, " \t");
+    /*
+     * we are only interested in characters before the first '#'
+     * character
+     */
+    str[strcspn(str, "#")] = '\0';
+
+    return str;
+}
+
+/*
+ * Remove escaped newline from end of string.
+ *
+ * Configuration lines may span across multiple lines in a file
+ * by ending a line with a backslash (\).
+ *
+ * If an escaped newline is encountered, the backslash will be
+ * replaced with a blank ' ' and the newline itself removed.
+ * Then the variable "end" will point to the new end of line.
+ *
+ * Returns 0 if escaped newline was found and replaced, 1 otherwise.
+ */
+static inline int _pam_str_unescnl(char *start, char **end)
+{
+    int ret = 1;
+    char *p = *end;
+
+    /*
+     * Check for backslash by scanning back from the end of
+     * the entered line, the '\n' should be included since
+     * normally a line is terminated with this character.
+     */
+    while (p > start && ((*--p == ' ') || (*p == '\t') || (*p == '\n')))
+	;
+    if (*p == '\\') {
+	*p++ = ' ';         /* replace backslash with ' ' */
+	*p = '\0';          /* truncate the line here */
+	*end = p;
+	ret = 0;
+    }
+
+    return ret;
+}
+
+/*
+ * Prepare line from file for configuration line parsing.
+ *
+ * A configuration line may span across multiple lines in a file.
+ * Remove comments and skip preceding whitespaces.
+ *
+ * Returns 0 if line spans across multiple lines, 1 if
+ * end of line is encountered.
+ */
+static inline int _pam_str_prepare(char *line, ssize_t len,
+				   char **start, char **end)
+{
+    int ret;
+
+    *start = line;
+    *end = line + len;
+
+    ret = _pam_str_unescnl(*start, end) || strchr(*start, '#') != NULL;
+
+    *start = _pam_str_trim(*start);
+
+    return ret;
+}
+
 /*
  * This is where we read a line of the PAM config file. The line may be
  * preceded by lines of comments and also extended with "\\\n"
+ *
+ * Returns 0 on EOF, 1 on successful line parsing, or -1 on error.
  */
 
-static int _pam_assemble_line(FILE *f, char *buffer, int buf_len)
+static int _pam_assemble_line(FILE *f, struct line_buffer *buffer)
 {
-    char *p = buffer;
-    char *endp = buffer + buf_len;
-    char *s, *os;
-    int used = 0;
+    int ret = 0;
 
     /* loop broken with a 'break' when a non-'\\n' ended line is read */
 
     D(("called."));
+
+    _pam_buffer_shift(buffer);
+
     for (;;) {
-	if (p >= endp - 1) {
-	    /* Overflow */
-	    D(("overflow"));
-	    return -1;
-	}
-	if (fgets(p, endp - p, f) == NULL) {
-	    if (used) {
+	char *start, *end;
+	ssize_t n;
+	int eol;
+
+	if ((n = getline(&buffer->chunk, &buffer->chunk_size, f)) == -1) {
+	    if (ret) {
 		/* Incomplete read */
-		return -1;
+		ret = -1;
 	    } else {
 		/* EOF */
-		return 0;
+		ret = 0;
 	    }
+	    break;
 	}
 
-	if (strchr(p, '\n') == NULL && !feof(f)) {
-	    /* Incomplete */
-	    D(("_pam_assemble_line: incomplete"));
-	    return -1;
-	}
+	eol = _pam_str_prepare(buffer->chunk, n, &start, &end);
 
-	/* skip leading spaces --- line may be blank */
-
-	s = p + strspn(p, " \n\t");
-	if (*s && (*s != '#')) {
-	    os = s;
-
-	    /*
-	     * we are only interested in characters before the first '#'
-	     * character
-	     */
-
-	    while (*s && *s != '#')
-		 ++s;
-	    if (*s == '#') {
-		 *s = '\0';
-		 used += strlen(os);
-		 break;                /* the line has been read */
+	if (eol) {
+	    if (_pam_buffer_add_eol(buffer, start, end)) {
+		ret = -1;
+		break;
 	    }
-
-	    s = os;
-
-	    /*
-	     * Check for backslash by scanning back from the end of
-	     * the entered line, the '\n' has been included since
-	     * normally a line is terminated with this
-	     * character. fgets() should only return one though!
-	     */
-
-	    s += strlen(s);
-	    while (s > os && ((*--s == ' ') || (*s == '\t')
-			      || (*s == '\n')));
-
-	    /* check if it ends with a backslash */
-	    if (*s == '\\') {
-		*s++ = ' ';             /* replace backslash with ' ' */
-		*s = '\0';              /* truncate the line here */
-		used += strlen(os);
-		p = s;                  /* there is more ... */
-	    } else {
-		/* End of the line! */
-		used += strlen(os);
-		break;                  /* this is the complete line */
+	    if (_pam_buffer_valid(buffer)) {
+		/* Successfully parsed a line */
+		ret = 1;
+		break;
 	    }
-
+	    /* Start parsing next line */
+	    _pam_buffer_shift(buffer);
+	    ret = 0;
 	} else {
-	    /* Nothing in this line */
-	    /* Don't move p         */
+	    /* Configuration line spans across multiple lines in file */
+	    if (_pam_buffer_add(buffer, start, end)) {
+		ret = -1;
+		break;
+	    }
+	    /* Keep parsing line */
+	    ret = 1;
 	}
     }
 
-    return used;
+    if (ret == 1)
+	_pam_buffer_purge(buffer);
+    else
+	_pam_buffer_clear(buffer);
+
+    return ret;
 }
 
 static char *

--- a/libpam/pam_private.h
+++ b/libpam/pam_private.h
@@ -16,6 +16,7 @@
 
 #include "config.h"
 
+#include <stddef.h>
 #include <syslog.h>
 
 #include <security/pam_appl.h>
@@ -272,7 +273,7 @@ char *_pam_strdup(const char *s);
 
 char *_pam_memdup(const char *s, int len);
 
-int _pam_mkargv(const char *s, char ***argv, int *argc);
+size_t _pam_mkargv(const char *s, char ***argv, int *argc);
 
 void _pam_sanitize(pam_handle_t *pamh);
 

--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -436,7 +436,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 	  _exit (err);
 	}
 
-      arggv = calloc (argc + 4, sizeof (char *));
+      arggv = calloc ((size_t) argc + 1, sizeof (char *));
       if (arggv == NULL)
 	_exit (ENOMEM);
 

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -97,7 +97,8 @@ static int process_args(pam_handle_t *pamh
 	char *p;
 	const char *user = NULL;
 	const void *tmp;
-	int i,size, retval;
+	int i, retval;
+	size_t size;
 
 	*filtername = *++argv;
 	if (ctrl & FILTER_DEBUG) {

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -72,14 +72,14 @@ static void try_to_display_fd(pam_handle_t *pamh, int fd)
  * Returns 0 in case of error, 1 in case of success.
  */
 static int pam_split_string(const pam_handle_t *pamh, char *arg, char delim,
-			    char ***out_arg_split, unsigned int *out_num_strs)
+			    char ***out_arg_split, size_t *out_num_strs)
 {
     char *arg_extracted = NULL;
     const char *arg_ptr = arg;
     char **arg_split = NULL;
     char delim_str[2];
-    unsigned int i = 0;
-    unsigned int num_strs = 0;
+    size_t i = 0;
+    size_t num_strs = 0;
     int retval = 0;
 
     delim_str[0] = delim;
@@ -168,13 +168,13 @@ static int compare_strings(const void *a, const void *b)
 }
 
 static void try_to_display_directories_with_overrides(pam_handle_t *pamh,
-	char **motd_dir_path_split, unsigned int num_motd_dirs, int report_missing)
+	char **motd_dir_path_split, size_t num_motd_dirs, int report_missing)
 {
     struct dirent ***dirscans = NULL;
     unsigned int *dirscans_sizes = NULL;
     unsigned int dirscans_size_total = 0;
     char **dirnames_all = NULL;
-    unsigned int i;
+    size_t i;
     unsigned int i_dirnames = 0;
 
     if (pamh == NULL || motd_dir_path_split == NULL) {
@@ -340,9 +340,8 @@ static int drop_privileges(pam_handle_t *pamh, struct pam_modutil_privs *privs)
 }
 
 static int try_to_display(pam_handle_t *pamh, char **motd_path_split,
-                          unsigned int num_motd_paths,
-                          char **motd_dir_path_split,
-                          unsigned int num_motd_dir_paths, int report_missing)
+                          size_t num_motd_paths, char **motd_dir_path_split,
+                          size_t num_motd_dir_paths, int report_missing)
 {
     PAM_MODUTIL_DEF_PRIVS(privs);
 
@@ -352,7 +351,7 @@ static int try_to_display(pam_handle_t *pamh, char **motd_path_split,
     }
 
     if (motd_path_split != NULL) {
-        unsigned int i;
+        size_t i;
 
         for (i = 0; i < num_motd_paths; i++) {
             int fd = open(motd_path_split[i], O_RDONLY, 0);
@@ -390,11 +389,11 @@ int pam_sm_open_session(pam_handle_t *pamh, int flags,
     int retval = PAM_IGNORE;
     const char *motd_path = NULL;
     char *motd_path_copy = NULL;
-    unsigned int num_motd_paths = 0;
+    size_t num_motd_paths = 0;
     char **motd_path_split = NULL;
     const char *motd_dir_path = NULL;
     char *motd_dir_path_copy = NULL;
-    unsigned int num_motd_dir_paths = 0;
+    size_t num_motd_dir_paths = 0;
     char **motd_dir_path_split = NULL;
     int report_missing;
 


### PR DESCRIPTION
This PR introduces a wrapper around getline, called pam_getline, and uses it within libpam to get rid of fgets calls.

Since this is mostly used when parsing configuration files, it fixes some issues with current code.

See this weird configuration file for example:
```
# this is a comment \
and this is another line
\
 \
   \
 word

line1 \

line2

# prior module.
password  required    pam_unix.so       yescrypt shadow try_first_pass \
                minlen=0
```

- The current code considers "and this is another line" as a new line which is parsed, even though the escaped newline in the comment should indicate otherwise.
- The "word" line has preceding whitespaces because the current code does not handle them well with escaped newlines.
- "line1" and "line2" should be separate lines, yet the current code merges them into "line1 line2"

Having NUL bytes in the file makes it even worse, but since it is a special case and hard to see in a PR report, I have left them out. Please note that I took a lot of care to get them right in the new implementation. Feel free to (and please) test on your own!

I have already exported pam_getline because I would like to use it in modules as well. I have another branch for testing purposes already available. Please note that it's very much work in progress and will be split into multiple PRs (like this one), yet it might indicate what I want to achieve: https://github.com/stoeckmann/linux-pam/tree/getline