### PR TITLE
Assume getline exists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,7 +632,7 @@ AC_FUNC_VPRINTF
 AC_CHECK_FUNCS(fseeko getdomainname gethostname gettimeofday lckpwdf mkdir select)
 AC_CHECK_FUNCS(strcspn strdup strspn strstr strtol uname)
 AC_CHECK_FUNCS(getutent_r getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r getmntent_r)
-AC_CHECK_FUNCS(getgrouplist getline getdelim)
+AC_CHECK_FUNCS(getgrouplist)
 AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
 AC_CHECK_FUNCS(quotactl)
 AC_CHECK_FUNCS(unshare)

--- a/libpam/pam_modutil_searchkey.c
+++ b/libpam/pam_modutil_searchkey.c
@@ -70,29 +70,8 @@ pam_modutil_search_key(pam_handle_t *pamh UNUSED,
 
 	while (!feof(fp)) {
 		char *tmp, *cp;
-#if defined(HAVE_GETLINE)
 		ssize_t n = getline(&buf, &buflen, fp);
-#elif defined (HAVE_GETDELIM)
-		ssize_t n = getdelim(&buf, &buflen, '\n', fp);
-#else
-		ssize_t n;
 
-		if (buf == NULL) {
-			buflen = BUF_SIZE;
-			buf = malloc(buflen);
-			if (buf == NULL) {
-				fclose(fp);
-				return NULL;
-			}
-		}
-		buf[0] = '\0';
-		if (fgets(buf, buflen - 1, fp) == NULL)
-			break;
-		else if (buf != NULL)
-			n = strlen(buf);
-		else
-			n = 0;
-#endif /* HAVE_GETLINE / HAVE_GETDELIM */
 		cp = buf;
 
 		if (n < 1)

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -173,24 +173,8 @@ check_old_pass, const char *user, const char *newpass, const char *filename, int
   while (!feof (oldpf))
     {
       char *cp, *tmp;
-#if defined(HAVE_GETLINE)
       ssize_t n = getline (&buf, &buflen, oldpf);
-#elif defined (HAVE_GETDELIM)
-      ssize_t n = getdelim (&buf, &buflen, '\n', oldpf);
-#else
-      ssize_t n;
 
-      if (buf == NULL)
-        {
-          buflen = DEFAULT_BUFLEN;
-          buf = malloc (buflen);
-	  if (buf == NULL)
-	    return PAM_BUF_ERR;
-        }
-      buf[0] = '\0';
-      fgets (buf, buflen - 1, oldpf);
-      n = strlen (buf);
-#endif /* HAVE_GETLINE / HAVE_GETDELIM */
       cp = buf;
 
       if (n < 1)
@@ -380,29 +364,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
     while (!feof (oldpf))
       {
 	char *cp, *tmp, *save;
-#if defined(HAVE_GETLINE)
 	ssize_t n = getline (&buf, &buflen, oldpf);
-#elif defined (HAVE_GETDELIM)
-	ssize_t n = getdelim (&buf, &buflen, '\n', oldpf);
-#else
-	ssize_t n;
-
-	if (buf == NULL)
-	  {
-	    buflen = DEFAULT_BUFLEN;
-	    buf = malloc (buflen);
-	    if (buf == NULL)
-              {
-		fclose (oldpf);
-		fclose (newpf);
-		retval = PAM_BUF_ERR;
-		goto error_opasswd;
-              }
-	  }
-	buf[0] = '\0';
-	fgets (buf, buflen - 1, oldpf);
-	n = strlen (buf);
-#endif /* HAVE_GETLINE / HAVE_GETDELIM */
 
 	if (n < 1)
 	  break;

--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -118,6 +118,7 @@ static int perform_check(pam_handle_t *pamh)
 #else
     FILE *shellFile;
     char *p = NULL;
+    size_t n = 0;
 
     if (!check_file(SHELL_FILE, pamh))
         return PAM_AUTH_ERR;
@@ -130,16 +131,7 @@ static int perform_check(pam_handle_t *pamh)
 
     retval = 1;
 
-#if defined(HAVE_GETLINE) || defined (HAVE_GETDELIM)
-    size_t n = 0;
-
-    while (retval &&
-#if defined(HAVE_GETLINE)
-	   getline(&p, &n, shellFile)
-#elif defined (HAVE_GETDELIM)
-	   getdelim(&p, &n, '\n', shellFile)
-#endif
-	   != -1) {
+    while (retval && getline(&p, &n, shellFile) != -1) {
 	p[strcspn(p, "\n")] = '\0';
 
 	if (p[0] != '/') {
@@ -149,28 +141,6 @@ static int perform_check(pam_handle_t *pamh)
     }
 
     free(p);
-#else
-    char buf[PATH_MAX + 2];
-    int ignore = 0;
-
-    while (retval && fgets(buf, sizeof(buf), shellFile) != NULL) {
-	p = strchr(buf, '\n');
-	if (p == NULL) {
-		ignore = 1;
-		continue;
-	} else if (ignore) {
-		ignore = 0;
-		continue;
-	}
-	*p = '\0';
-
-	if (buf[0] != '/') {
-		continue;
-	}
-	retval = strcmp(buf, userShell);
-    }
-#endif
-
     fclose(shellFile);
 #endif
 


### PR DESCRIPTION
Apparently, getline is being used unconditionally in pam_namespace and pam_sepermit.  In pam_namespace, it is being used since 2006 when the module was introduced in the first place.

Let's assume getline is universally available and let's use it unconditionally in other cases, too.

* configure.ac (AC_CHECK_FUNCS): Remove getline and getdelim.
* libpam/pam_modutil_searchkey.c (pam_modutil_search_key): Use getline unconditionally.
* modules/pam_pwhistory/opasswd.c (check_old_pass, save_old_pass): Likewise.
* modules/pam_shells/pam_shells.c (perform_check): Likewise.