### PR TITLE
pam_shells: fix regression (no release)

### DIFF
--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -140,6 +140,7 @@ static int perform_check(pam_handle_t *pamh)
 	   getdelim(&p, &n, '\n', shellFile)
 #endif
 	   != -1) {
+	p[strcspn(p, "\n")] = '\0';
 
 	if (p[0] != '/') {
 		continue;
@@ -161,6 +162,7 @@ static int perform_check(pam_handle_t *pamh)
 		ignore = 0;
 		continue;
 	}
+	*p = '\0';
 
 	if (buf[0] != '/') {
 		continue;


### PR DESCRIPTION
The \n at the end of a line has to be removed, otherwise the strcmp check will always fail.

Regression introduced in f800c5a8533003be7df56e6253821cf145f1a725.

Not part of any release.