### PR TITLE
pam_unix: sync expiry checks with shadow

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -337,7 +337,7 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 			D(("need a new password 2"));
 			return PAM_NEW_AUTHTOK_REQD;
 		}
-		if (spent->sp_warn >= 0) {
+		if (spent->sp_warn > 0) {
 			long warn = spent->sp_warn > spent->sp_max ? -1 :
 			    spent->sp_max - spent->sp_warn;
 			if (passed >= warn) {
@@ -346,7 +346,7 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 			}
 		}
 	}
-	if (spent->sp_min >= 0 && passed < spent->sp_min) {
+	if (spent->sp_min > 0 && passed < spent->sp_min) {
 		/*
 		 * The last password change was too recent. This error will be ignored
 		 * if no password change is attempted.

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -311,6 +311,11 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 		*daysleft = 0;
 		return PAM_NEW_AUTHTOK_REQD;
 	}
+	if (spent->sp_lstchg < 0) {
+		D(("password aging disabled"));
+		*daysleft = 0;
+		return PAM_SUCCESS;
+	}
 	if (curdays < spent->sp_lstchg) {
 		pam_syslog(pamh, LOG_DEBUG,
 			 "account %s has password changed in future",

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -322,20 +322,20 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 		if (spent->sp_inact >= 0) {
 			long inact = spent->sp_max < LONG_MAX - spent->sp_inact ?
 			    spent->sp_max + spent->sp_inact : LONG_MAX;
-			if (passed > inact) {
+			if (passed >= inact) {
 				*daysleft = subtract(inact, passed);
 				D(("authtok expired"));
 				return PAM_AUTHTOK_EXPIRED;
 			}
 		}
-		if (passed > spent->sp_max) {
+		if (passed >= spent->sp_max) {
 			D(("need a new password 2"));
 			return PAM_NEW_AUTHTOK_REQD;
 		}
 		if (spent->sp_warn >= 0) {
 			long warn = spent->sp_warn > spent->sp_max ? -1 :
 			    spent->sp_max - spent->sp_warn;
-			if (passed > warn) {
+			if (passed >= warn) {
 				*daysleft = subtract(spent->sp_max, passed);
 				D(("warn before expiry"));
 			}


### PR DESCRIPTION
The shadow library uses "greater than or equal to" checks instead of current "greater than" checks in pam_unix.

The account expiry check is already "greater than or equal to" so this adjustment can even be argued without making references to other projects.

This is no regression with my last integer overflow adjustments (checked twice). At first I thought that it might even make sense to adjust shadow code instead, but a scenario with max age and inactive being set to 0 (pretty much a one time password setup) could not be reproduced in current pam_unix.so code. Also the "greater than or equal to" checks can be found in OpenBSD's auth_check_expire code.

References:
https://github.com/shadow-maint/shadow/blob/master/lib/isexpired.c#L55
https://github.com/shadow-maint/shadow/blob/master/lib/isexpired.c#L75
https://github.com/shadow-maint/shadow/blob/master/lib/age.c#L70
https://cvsweb.openbsd.org/src/lib/libc/gen/auth_subr.c?rev=1.56&content-type=text/x-cvsweb-markup
