### PR TITLE
treewide: assume free(NULL) is no-op

### DIFF
--- a/doc/specs/parse_y.y
+++ b/doc/specs/parse_y.y
@@ -282,9 +282,7 @@ char *new_counter(const char *key)
 
     counter_root = set_key(counter_root, key, new);
 
-    if (last_label) {
-	free(last_label);
-    }
+    free(last_label);
     last_label = strdup(new);
 
     return new;

--- a/libpam/include/security/_pam_macros.h
+++ b/libpam/include/security/_pam_macros.h
@@ -44,10 +44,8 @@ do {                                    \
 
 #define _pam_drop(X) \
 do {                 \
-    if (X) {         \
-        free(X);     \
-        X=NULL;      \
-    }                \
+    free(X);         \
+    X=NULL;          \
 } while (0)
 
 /*
@@ -64,8 +62,7 @@ do {                                              \
 	    free(reply[reply_i].resp);            \
 	}                                         \
     }                                             \
-    if (reply)                                    \
-	free(reply);                              \
+    free(reply);                                  \
 } while (0)
 
 /* some debugging code */

--- a/libpam/pam_modutil_cleanup.c
+++ b/libpam/pam_modutil_cleanup.c
@@ -12,8 +12,6 @@ void
 pam_modutil_cleanup (pam_handle_t *pamh UNUSED, void *data,
 		     int error_status UNUSED)
 {
-    if (data) {
 	/* junk it */
-	(void) free(data);
-    }
+	free(data);
 }

--- a/libpam/pam_modutil_getgrgid.c
+++ b/libpam/pam_modutil_getgrgid.c
@@ -54,9 +54,7 @@ pam_modutil_getgrgid(pam_handle_t *pamh, gid_t gid)
 	    D(("out of memory"));
 
 	    /* no memory for the user - so delete the memory */
-	    if (buffer) {
-		free(buffer);
-	    }
+	    free(buffer);
 	    return NULL;
 	}
 	buffer = new_buffer;

--- a/libpam/pam_modutil_getgrnam.c
+++ b/libpam/pam_modutil_getgrnam.c
@@ -44,9 +44,7 @@ pam_modutil_getgrnam(pam_handle_t *pamh, const char *group)
 	    D(("out of memory"));
 
 	    /* no memory for the group - so delete the memory */
-	    if (buffer) {
-		free(buffer);
-	    }
+	    free(buffer);
 	    return NULL;
 	}
 	buffer = new_buffer;

--- a/libpam/pam_modutil_getpwnam.c
+++ b/libpam/pam_modutil_getpwnam.c
@@ -44,9 +44,7 @@ pam_modutil_getpwnam(pam_handle_t *pamh, const char *user)
 	    D(("out of memory"));
 
 	    /* no memory for the user - so delete the memory */
-	    if (buffer) {
-		free(buffer);
-	    }
+	    free(buffer);
 	    return NULL;
 	}
 	buffer = new_buffer;

--- a/libpam/pam_modutil_getpwuid.c
+++ b/libpam/pam_modutil_getpwuid.c
@@ -54,9 +54,7 @@ pam_modutil_getpwuid(pam_handle_t *pamh, uid_t uid)
 	    D(("out of memory"));
 
 	    /* no memory for the user - so delete the memory */
-	    if (buffer) {
-		free(buffer);
-	    }
+	    free(buffer);
 	    return NULL;
 	}
 	buffer = new_buffer;

--- a/libpam/pam_modutil_getspnam.c
+++ b/libpam/pam_modutil_getspnam.c
@@ -44,9 +44,7 @@ pam_modutil_getspnam(pam_handle_t *pamh, const char *user)
 	    D(("out of memory"));
 
 	    /* no memory for the user - so delete the memory */
-	    if (buffer) {
-		free(buffer);
-	    }
+	    free(buffer);
 	    return NULL;
 	}
 	buffer = new_buffer;

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -393,10 +393,8 @@ static pamc_id_node_t *__pamc_add_node(pamc_id_node_t *root, const char *id,
 static pamc_id_node_t *__pamc_liberate_nodes(pamc_id_node_t *tree)
 {
     if (tree) {
-	if (tree->agent_id) {
-	    free(tree->agent_id);
-	    tree->agent_id = NULL;
-	}
+	free(tree->agent_id);
+	tree->agent_id = NULL;
 
 	tree->left = __pamc_liberate_nodes(tree->left);
 	tree->right = __pamc_liberate_nodes(tree->right);

--- a/libpamc/test/modules/pam_secret.c
+++ b/libpamc/test/modules/pam_secret.c
@@ -171,9 +171,7 @@ static int converse(pam_handle_t *pamh, struct ps_state_s *new)
 	    }
 	}
 
-	if (single_reply) {
-	    free(single_reply);
-	}
+	free(single_reply);
     }
 
 #ifdef PAM_DEBUG

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -238,8 +238,7 @@ static void free_evp(char *evp[])
 
     if (evp)
 	for (i=0; i<4; ++i) {
-	    if (evp[i])
-		free(evp[i]);
+	    free(evp[i]);
 	}
     free(evp);
 }

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -92,7 +92,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	    else if(!strcmp(myval,"fail"))
 		onerr = PAM_SERVICE_ERR;
 	    else {
-	        if (ifname) free (ifname);
+	        free(ifname);
 		return PAM_SERVICE_ERR;
 	    }
 	else if(!strcmp(mybuf,"sense"))
@@ -101,11 +101,11 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	    else if(!strcmp(myval,"deny"))
 		sense=1;
 	    else {
-	        if (ifname) free (ifname);
+	        free(ifname);
 		return onerr;
 	    }
 	else if(!strcmp(mybuf,"file")) {
-	    if (ifname) free (ifname);
+	    free(ifname);
 	    ifname = malloc(strlen(myval)+1);
 	    if (!ifname)
 		return PAM_BUF_ERR;

--- a/modules/pam_namespace/argv_parse.c
+++ b/modules/pam_namespace/argv_parse.c
@@ -65,7 +65,7 @@ int argv_parse(const char *in_buf, int *ret_argc, char ***ret_argv)
 				new_argv = realloc(argv,
 						  (max_argc+1)*sizeof(char *));
 				if (!new_argv) {
-					if (argv) free(argv);
+					free(argv);
 					free(buf);
 					return -1;
 				}
@@ -131,8 +131,7 @@ int argv_parse(const char *in_buf, int *ret_argc, char ***ret_argv)
 void argv_free(char **argv)
 {
 	if (argv) {
-		if (*argv)
-			free(*argv);
+		free(*argv);
 		free(argv);
 	}
 }

--- a/modules/pam_stress/pam_stress.c
+++ b/modules/pam_stress/pam_stress.c
@@ -476,10 +476,8 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 	  resp = NULL;
 
 	  retval = converse(pamh,i,pmsg,&resp);
-	  if (txt) {
-	       free(txt);
-	       txt = NULL;               /* clean up */
-	  }
+	  free(txt);
+	  txt = NULL;               /* clean up */
 	  if (retval != PAM_SUCCESS) {
 	       return retval;
 	  }

--- a/modules/pam_timestamp/hmac_openssl_wrapper.c
+++ b/modules/pam_timestamp/hmac_openssl_wrapper.c
@@ -297,9 +297,7 @@ hmac_management(pam_handle_t *pamh, int debug, void **out, size_t *out_length,
     ret = PAM_SUCCESS;
 
 done:
-    if (hmac_message != NULL) {
-        free(hmac_message);
-    }
+    free(hmac_message);
     if (key != NULL) {
         pam_overwrite_n(key, key_length);
         free(key);

--- a/modules/pam_unix/pam_unix_auth.c
+++ b/modules/pam_unix/pam_unix_auth.c
@@ -86,8 +86,7 @@ do {									\
 static void
 setcred_free (pam_handle_t *pamh UNUSED, void *ptr, int err UNUSED)
 {
-	if (ptr)
-		free (ptr);
+	free (ptr);
 }
 
 int

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -197,9 +197,7 @@ run_coprocess(pam_handle_t *pamh, const char *input, char **output,
 		tmp = realloc(buffer, buffer_size + i + 1);
 		if (tmp == NULL) {
 			/* Uh-oh, bail. */
-			if (buffer != NULL) {
-				free(buffer);
-			}
+			free(buffer);
 			close(opipe[0]);
 			waitpid(child, NULL, 0);
 			sigaction(SIGCHLD, &oldsa, NULL);   /* restore old signal handler */
@@ -545,10 +543,8 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 			char *t, *screen;
 			size_t tlen, slen;
 			/* Free the useless cookie string. */
-			if (cookie != NULL) {
-				free(cookie);
-				cookie = NULL;
-			}
+			free(cookie);
+			cookie = NULL;
 			/* Allocate enough space to hold an adjusted name. */
 			tlen = strlen(display) + LINE_MAX + 1;
 			t = calloc(1, tlen);


### PR DESCRIPTION
The C standard guarantees that if the argument of free() is a null pointer, no action occurs.