### PR TITLE
treewide: store strlen results in size_t

### DIFF
--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -264,7 +264,8 @@ void _pam_parse_control(int *control_array, char *tok)
     int ret;
 
     while (*tok) {
-	int act, len;
+	size_t len;
+	int act;
 
 	/* skip leading space */
 	while (isspace((unsigned char)*tok) && *++tok);

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -245,7 +245,7 @@ int pamc_disable(pamc_handle_t pch, const char *agent_id)
 int pamc_load(pamc_handle_t pch, const char *agent_id)
 {
     pamc_agent_t *agent;
-    int length;
+    size_t length;
 
     /* santity checking */
 

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -427,8 +427,8 @@ login_access (pam_handle_t *pamh, struct login_info *item)
 #ifdef HAVE_LIBAUDIT
     int     nonall_match = NO;
 #endif
-    int     end;
-    int     lineno = 0;		/* for diagnostics */
+    size_t  end;
+    size_t  lineno = 0;		/* for diagnostics */
     char   *sptr;
 
     if (item->debug)
@@ -450,7 +450,7 @@ login_access (pam_handle_t *pamh, struct login_info *item)
 	    lineno++;
 	    if (line[end = strlen(line) - 1] != '\n') {
 		pam_syslog(pamh, LOG_ERR,
-                           "%s: line %d: missing newline or line too long",
+                           "%s: line %zu: missing newline or line too long",
 		           item->config_file, lineno);
 		continue;
 	    }
@@ -466,18 +466,18 @@ login_access (pam_handle_t *pamh, struct login_info *item)
 	    if (!(perm = strtok_r(line, item->fs, &sptr))
 		|| !(users = strtok_r(NULL, item->fs, &sptr))
 		|| !(froms = strtok_r(NULL, "\n", &sptr))) {
-		pam_syslog(pamh, LOG_ERR, "%s: line %d: bad field count",
+		pam_syslog(pamh, LOG_ERR, "%s: line %zu: bad field count",
 			   item->config_file, lineno);
 		continue;
 	    }
 	    if (perm[0] != '+' && perm[0] != '-') {
-		pam_syslog(pamh, LOG_ERR, "%s: line %d: bad first field",
+		pam_syslog(pamh, LOG_ERR, "%s: line %zu: bad first field",
 			   item->config_file, lineno);
 		continue;
 	    }
 	    if (item->debug)
 	      pam_syslog (pamh, LOG_DEBUG,
-			  "line %d: %s : %s : %s", lineno, perm, users, froms);
+			  "line %zu: %s : %s : %s", lineno, perm, users, froms);
 	    match = list_match(pamh, users, NULL, item, user_match);
 	    if (item->debug)
 	      pam_syslog (pamh, LOG_DEBUG, "user_match=%d, \"%s\"",

--- a/modules/pam_debug/pam_debug.c
+++ b/modules/pam_debug/pam_debug.c
@@ -40,7 +40,7 @@ static int parse_args(int retval, const char *event,
     int i;
 
     for (i=0; i<argc; ++i) {
-	int length = strlen(event);
+	size_t length = strlen(event);
 	if (!strncmp(event, argv[i], length) && (argv[i][length] == '=')) {
 	    int j;
 	    const char *return_string = argv[i] + (length+1);

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -207,7 +207,7 @@ static char *expand_variables(const char *orig, const char *var_names[], const c
 		if (*src == '$') {
 			int i;
 			for (i = 0; var_names[i]; i++) {
-				int namelen = strlen(var_names[i]);
+				size_t namelen = strlen(var_names[i]);
 				if (strncmp(var_names[i], src+1, namelen) == 0) {
 					dstlen += strlen(var_values[i]) - 1; /* $ */
 					src += namelen;
@@ -225,7 +225,7 @@ static char *expand_variables(const char *orig, const char *var_names[], const c
 		if (c == '$') {
 			int i;
 			for (i = 0; var_names[i]; i++) {
-				int namelen = strlen(var_names[i]);
+				size_t namelen = strlen(var_names[i]);
 				if (strncmp(var_names[i], src+1, namelen) == 0) {
 					dst = stpcpy(dst, var_values[i]);
 					--dst;
@@ -419,7 +419,7 @@ static int parse_method(char *method, struct polydir_s *poly,
 
     while ((flag=strtok_r(NULL, ":", &sptr)) != NULL) {
 	for (i = 0; flag_names[i]; i++) {
-		int namelen = strlen(flag_names[i]);
+		size_t namelen = strlen(flag_names[i]);
 
 		if (strncmp(flag, flag_names[i], namelen) == 0) {
 			poly->flags |= flag_values[i];
@@ -480,7 +480,7 @@ static int process_line(char *line, const char *home, const char *rhome,
     static const char *var_names[] = {"HOME", "USER", NULL};
     const char *var_values[] = {home, idata->user};
     const char *rvar_values[] = {rhome, idata->ruser};
-    int len;
+    size_t len;
 
     /*
      * skip the leading white space

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -582,7 +582,7 @@ static int _unix_run_helper_binary(pam_handle_t *pamh, const char *passwd,
 	/* if the stored password is NULL */
         int rc=0;
 	if (passwd != NULL) {            /* send the password to the child */
-	    int len = strlen(passwd);
+	    size_t len = strlen(passwd);
 
 	    if (len > PAM_MAX_RESP_SIZE)
 	      len = PAM_MAX_RESP_SIZE;


### PR DESCRIPTION
Very long strings could overflow the int data type. Make sure to use the correct data type.

Spotted and fixed with @BenBE and @Maaxxs based on discovery by @ellcs.

This is also a preparation for transition from fgets to getline in pam_access.