### PR TITLE
conf/pam_conv1: fix memory and integer handling

### DIFF
--- a/conf/pam_conv1/pam_conv_l.l
+++ b/conf/pam_conv1/pam_conv_l.l
@@ -17,7 +17,7 @@
 
 #include "pam_conv_y.h"
 
-    extern int current_line;
+    extern unsigned long long current_line;
 %}
 
 %option noyywrap

--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -24,7 +24,7 @@
 
     extern int yylex(void);
 
-    int current_line=1;
+    unsigned long long current_line=1;
     extern char *yytext;
 
 /* XXX - later we'll change this to be the specific conf file(s) */
@@ -191,7 +191,7 @@ void yyerror(const char *format, ...)
 {
     va_list args;
 
-    fprintf(stderr, "line %d: ", current_line);
+    fprintf(stderr, "line %llu: ", current_line);
     va_start(args, format);
     vfprintf(stderr, format, args);
     va_end(args);

--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -100,6 +100,7 @@ line
 	exit(1);
     }
     free(filename);
+    free($1);
 
     /* $2 = module-type */
     fprintf(conf, "%-10s", $2);

--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -211,8 +211,8 @@ int main(void)
 {
     if (mkdir(PAM_D, PAM_D_MODE) != 0) {
 	yyerror(PAM_D " already exists.. aborting");
-	exit(1);
+	return 1;
     }
     yyparse();
-    exit(0);
+    return 0;
 }

--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -158,11 +158,19 @@ path
 : TOK {
     /* XXX - this could be used to check if file present */
     $$ = strdup(yytext);
+    if ($$ == NULL) {
+	yyerror("failed to duplicate path");
+	exit(1);
+    }
 }
 
 tok
 : TOK {
     $$ = strdup(yytext);
+    if ($$ == NULL) {
+	yyerror("failed to duplicate token");
+	exit(1);
+    }
 }
 
 %%

--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -24,7 +24,7 @@
 
     extern int yylex(void);
 
-    unsigned long long current_line=1;
+    unsigned long long current_line=0;
     extern char *yytext;
 
 /* XXX - later we'll change this to be the specific conf file(s) */


### PR DESCRIPTION
Fix various issues in the pam_conv1 tool, which is not installed by default:
- Show correct line number in output
- Fix memory leak of service name (-fsanitize=address shows leakage)
- Check strdup return values
- Avoid undefined behavior with input files having a lot of lines
- Use return instead of exit in main to support stack protector of main function

Spotted by @BenBE and fixed together.

Proof of Concept (signed overflow of input lines):
```
$ dd if=/dev/zero bs=1024 count=4194305 | tr '\0' '\n' > pam.conf
$ pam_conv1 < pam.conf
../../../conf/pam_conv1/pam_conv_l.l:43:5: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
```

Proof of Concept (line number output):
```
$ echo -n "su auth required pam_filter.so run1 filter " > pam.conf
$ pam_conv1 < pam.conf
line 2: Appending to ./pam.d/su
```