### PR TITLE
pam_namespace: handle huge namespace.conf lines

### DIFF
--- a/modules/pam_namespace/argv_parse.c
+++ b/modules/pam_namespace/argv_parse.c
@@ -28,6 +28,7 @@
  * Version 1.1, modified 2/27/1999
  */
 
+#include <limits.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
@@ -61,6 +62,11 @@ int argv_parse(const char *in_buf, int *ret_argc, char ***ret_argv)
 			/* Not whitespace, so start a new token */
 			state = STATE_TOKEN;
 			if (argc >= max_argc) {
+				if (max_argc >= INT_MAX - 3) {
+					free(argv);
+					free(buf);
+					return -1;
+				}
 				max_argc += 3;
 				new_argv = realloc(argv,
 						  (max_argc+1)*sizeof(char *));


### PR DESCRIPTION
If a lot of arguments are found in a namespace.conf file, argc might overflow, which is an undefined behavior.

In most cases, the realloc will instantly fail due to a wrap around.

Protect properly by avoiding the calculation in the first place.