### PR TITLE
treewide: use asprintf/strdup for string creations

### DIFF
--- a/conf/pam_conv1/pam_conv_y.y
+++ b/conf/pam_conv1/pam_conv_y.y
@@ -78,8 +78,10 @@ line
     /* $1 = service-name */
     yyerror("Appending to " PAM_D "/%s", $1);
 
-    filename = malloc(strlen($1) + sizeof(PAM_D) + 6);
-    sprintf(filename, PAM_D_FILE_FMT, $1);
+    if (asprintf(&filename, PAM_D_FILE_FMT, $1) < 0) {
+	yyerror("unable to create filename - aborting");
+	exit(1);
+    }
     conf = fopen(filename, "r");
     if (conf == NULL) {
 	/* new file */
@@ -140,12 +142,11 @@ tokenls
     $$=NULL;
 }
 | tokenls tok {
-    int len;
-
     if ($1) {
-	len = strlen($1) + strlen($2) + 2;
-	$$ = malloc(len);
-	sprintf($$,"%s %s",$1,$2);
+	if (asprintf(&$$, "%s %s", $1, $2) < 0) {
+	    yyerror("failed to assemble tokenls");
+	    exit(1);
+	}
 	free($1);
 	free($2);
     } else {

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -116,14 +116,8 @@ char *_pam_strdup(const char *x)
      register char *new=NULL;
 
      if (x != NULL) {
-	  register size_t len;
-
-	  len = strlen (x) + 1;  /* length of string including NUL */
-	  if ((new = malloc(len)) == NULL) {
-	       len = 0;
+	  if ((new = strdup(x)) == NULL) {
 	       pam_syslog(NULL, LOG_CRIT, "_pam_strdup: failed to get memory");
-	  } else {
-	       strcpy (new, x);
 	  }
 	  x = NULL;
      }

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -224,14 +224,13 @@ int pamc_disable(pamc_handle_t pch, const char *agent_id)
 	return PAM_BPC_FALSE;
     }
 
-    block->id =	malloc(1 + strlen(agent_id));
+    block->id =	strdup(agent_id);
     if (block->id == NULL) {
 	D(("no memory for agent id"));
 	free(block);
 	return PAM_BPC_FALSE;
     }
 
-    strcpy(block->id, agent_id);
     block->next = pch->blocked_agents;
     pch->blocked_agents = block;
 
@@ -372,10 +371,8 @@ static pamc_id_node_t *__pamc_add_node(pamc_id_node_t *root, const char *id,
 	pamc_id_node_t *node = calloc(1, sizeof(pamc_id_node_t));
 
 	if (node) {
-	    node->agent_id = malloc(1+strlen(id));
-	    if (node->agent_id) {
-		strcpy(node->agent_id, id);
-	    } else {
+	    node->agent_id = strdup(id);
+	    if (node->agent_id == NULL) {
 		free(node);
 		node = NULL;
 	    }

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -759,7 +759,7 @@ remote_match (pam_handle_t *pamh, char *tok, struct login_info *item)
 		  DIAG_PUSH_IGNORE_CAST_ALIGN;
 		  inet_ntop (runp->ai_family,
 			     &((struct sockaddr_in *) runp->ai_addr)->sin_addr,
-			     buf, sizeof (buf));
+			     buf, sizeof (buf) - 1);
 		  DIAG_POP_IGNORE_CAST_ALIGN;
 
 		  strcat (buf, ".");

--- a/modules/pam_faillock/faillock.c
+++ b/modules/pam_faillock/faillock.c
@@ -36,6 +36,7 @@
 
 #include "config.h"
 #include <string.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
@@ -55,22 +56,19 @@ open_tally (const char *dir, const char *user, uid_t uid, int create)
 {
 	char *path;
 	int flags = O_RDWR;
-	int fd;
+	int fd, r;
 
 	if (dir == NULL || strstr(user, "../") != NULL)
 	/* just a defensive programming as the user must be a
 	 * valid user on the system anyway
 	 */
 		return -1;
-	path = malloc(strlen(dir) + strlen(user) + 2);
-	if (path == NULL)
+	if (*dir && dir[strlen(dir) - 1] != '/')
+		r = asprintf(&path, "%s/%s", dir, user);
+	else
+		r = asprintf(&path, "%s%s", dir, user);
+	if (r < 0)
 		return -1;
-
-	strcpy(path, dir);
-	if (*dir && dir[strlen(dir) - 1] != '/') {
-		strcat(path, "/");
-	}
-	strcat(path, user);
 
 	if (create) {
 		flags |= O_CREAT;

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -138,81 +138,45 @@ static int process_args(pam_handle_t *pamh
 
 	/* the "SERVICE" variable */
 
-#define SERVICE_NAME      "SERVICE="
-#define SERVICE_OFFSET    (sizeof(SERVICE_NAME) - 1)
-
 	retval = pam_get_item(pamh, PAM_SERVICE, &tmp);
 	if (retval != PAM_SUCCESS || tmp == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "service name not found");
-	    if (levp) {
-		free(levp[0]);
-		free(levp);
-	    }
+	    free(levp[0]);
+	    free(levp);
 	    return -1;
 	}
-	size = SERVICE_OFFSET+strlen(tmp);
 
-	levp[1] = malloc(size+1);
-	if (levp[1] == NULL) {
+	if (asprintf(&levp[1], "SERVICE=%s", (const char *) tmp) < 0) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for service name");
-	    if (levp) {
-		free(levp[0]);
-		free(levp);
-	    }
+	    free(levp[0]);
+	    free(levp);
 	    return -1;
 	}
-
-	strcpy(levp[1], SERVICE_NAME);
-	strcpy(levp[1]+SERVICE_OFFSET, tmp);
-	levp[1][size] = '\0';                      /* <NUL> terminate */
 
 	/* the "USER" variable */
-
-#define USER_NAME      "USER="
-#define USER_OFFSET    (sizeof(USER_NAME) - 1)
 
 	if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS) {
 	    user = "<unknown>";
 	}
-	size = USER_OFFSET+strlen(user);
 
-	levp[2] = malloc(size+1);
-	if (levp[2] == NULL) {
+	if (asprintf(&levp[2], "USER=%s", user) < 0) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for user's name");
-	    if (levp) {
-		free(levp[1]);
-		free(levp[0]);
-		free(levp);
-	    }
+	    free(levp[1]);
+	    free(levp[0]);
+	    free(levp);
 	    return -1;
 	}
-
-	strcpy(levp[2], USER_NAME);
-	strcpy(levp[2]+USER_OFFSET, user);
-	levp[2][size] = '\0';                      /* <NUL> terminate */
 
 	/* the "USER" variable */
 
-#define TYPE_NAME      "TYPE="
-#define TYPE_OFFSET    (sizeof(TYPE_NAME) - 1)
-
-	size = TYPE_OFFSET+strlen(type);
-
-	levp[3] = malloc(size+1);
-	if (levp[3] == NULL) {
+	if (asprintf(&levp[3], "TYPE=%s", type) < 0) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for type");
-	    if (levp) {
-		free(levp[2]);
-		free(levp[1]);
-		free(levp[0]);
-		free(levp);
-	    }
+	    free(levp[2]);
+	    free(levp[1]);
+	    free(levp[0]);
+	    free(levp);
 	    return -1;
 	}
-
-	strcpy(levp[3], TYPE_NAME);
-	strcpy(levp[3]+TYPE_OFFSET, type);
-	levp[3][size] = '\0';                      /* <NUL> terminate */
 
 	levp[4] = NULL;	                     /* end list */
 

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -94,6 +94,7 @@ static int process_args(pam_handle_t *pamh
 	*evp = NULL;
     } else {
 	char **levp;
+	char *p;
 	const char *user = NULL;
 	const void *tmp;
 	int i,size, retval;
@@ -127,13 +128,11 @@ static int process_args(pam_handle_t *pamh
 	    return -1;
 	}
 
-	strcpy(levp[0], ARGS_NAME);
-	size = ARGS_OFFSET;
+	p = stpcpy(levp[0], ARGS_NAME);
 	for (i=0; i<argc; ++i) {
 	    if (i)
-		levp[0][size++] = ' ';
-	    strcpy(levp[0]+size, argv[i]);
-	    size += strlen(argv[i]);
+		p = stpcpy(p, " ");
+	    p = stpcpy(p, argv[i]);
 	}
 
 	/* the "SERVICE" variable */

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -106,10 +106,9 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	    }
 	else if(!strcmp(mybuf,"file")) {
 	    free(ifname);
-	    ifname = malloc(strlen(myval)+1);
+	    ifname = strdup(myval);
 	    if (!ifname)
 		return PAM_BUF_ERR;
-	    strcpy(ifname,myval);
 	} else if(!strcmp(mybuf,"item"))
 	    if(!strcmp(myval,"user"))
 		citem = PAM_USER;

--- a/modules/pam_mkhomedir/mkhomedir_helper.c
+++ b/modules/pam_mkhomedir/mkhomedir_helper.c
@@ -32,7 +32,7 @@ struct dir_spec {
 };
 
 static unsigned long u_mask = 0022;
-static char skeldir[BUFSIZ] = "/etc/skel";
+static const char *skeldir = "/etc/skel";
 
 static int create_homedir(struct dir_spec *, const struct passwd *, mode_t,
 			  const char *, const char *);
@@ -420,11 +420,7 @@ main(int argc, char *argv[])
    }
 
    if (argc >= 4) {
-	if (strlen(argv[3]) >= sizeof(skeldir)) {
-		pam_syslog(NULL, LOG_ERR, "Too long skeldir path.");
-		return PAM_SESSION_ERR;
-	}
-	strcpy(skeldir, argv[3]);
+	skeldir = argv[3];
    }
 
    if (argc >= 5) {

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -1295,13 +1295,12 @@ static int check_inst_parent(char *ipath, struct instance_data *idata)
 	 * admin explicitly instructs to ignore the instance parent
 	 * mode by the "ignore_instance_parent_mode" argument).
 	 */
-	inst_parent = malloc(strlen(ipath)+1);
+	inst_parent = strdup(ipath);
 	if (!inst_parent) {
 		pam_syslog(idata->pamh, LOG_CRIT, "Error allocating pathname string");
 		return PAM_SESSION_ERR;
 	}
 
-	strcpy(inst_parent, ipath);
 	trailing_slash = strrchr(inst_parent, '/');
 	if (trailing_slash)
 		*trailing_slash = '\0';

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -722,12 +722,9 @@ int _unix_verify_password(pam_handle_t * pamh, const char *name
 
 	retval = get_pwd_hash(pamh, name, &pwd, &salt);
 
-	data_name = malloc(sizeof(FAIL_PREFIX) + strlen(name));
-	if (data_name == NULL) {
+	if (asprintf(&data_name, "%s%s", FAIL_PREFIX, name) < 0) {
 		pam_syslog(pamh, LOG_CRIT, "no memory for data-name");
-	} else {
-		strcpy(data_name, FAIL_PREFIX);
-		strcpy(data_name + sizeof(FAIL_PREFIX) - 1, name);
+		data_name = NULL;
 	}
 
 	if (p != NULL && strlen(p) > PAM_MAX_RESP_SIZE) {

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -501,6 +501,10 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 	/* Figure out where the source user's .Xauthority file is. */
 	if (getenv(XAUTHENV) != NULL) {
 		cookiefile = strdup(getenv(XAUTHENV));
+		if (cookiefile == NULL) {
+			retval = PAM_SESSION_ERR;
+			goto cleanup;
+		}
 	} else {
 		cookiefile = malloc(strlen(rpwd->pw_dir) + 1 +
 				    strlen(XAUTHDEF) + 1);


### PR DESCRIPTION
These functions are easier to review than a combination of malloc, strcpy, and strcat.