### PR TITLE
libpam: remove function prefixes in debug messages

### DIFF
--- a/libpam/pam_auth.c
+++ b/libpam/pam_auth.c
@@ -15,7 +15,7 @@ int pam_authenticate(pam_handle_t *pamh, int flags)
 {
     int retval;
 
-    D(("pam_authenticate called"));
+    D(("called."));
 
     IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
@@ -36,7 +36,7 @@ int pam_authenticate(pam_handle_t *pamh, int flags)
     if (retval != PAM_INCOMPLETE) {
 	_pam_sanitize(pamh);
 	_pam_await_timer(pamh, retval);   /* if unsuccessful then wait now */
-	D(("exit"));
+	D(("exiting"));
     } else {
 	D(("will resume when ready"));
     }
@@ -52,7 +52,7 @@ int pam_setcred(pam_handle_t *pamh, int flags)
 {
     int retval;
 
-    D(("pam_setcred called"));
+    D(("called."));
 
     IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
@@ -67,7 +67,7 @@ int pam_setcred(pam_handle_t *pamh, int flags)
 
     retval = _pam_dispatch(pamh, flags, PAM_SETCRED);
 
-    D(("pam_setcred exit"));
+    D(("exiting"));
 
     return retval;
 }

--- a/libpam/pam_end.c
+++ b/libpam/pam_end.c
@@ -13,7 +13,7 @@ int pam_end(pam_handle_t *pamh, int pam_status)
 {
     int ret;
 
-    D(("entering pam_end()"));
+    D(("called."));
 
     IF_NO_PAMH(pamh, PAM_SYSTEM_ERR);
 
@@ -93,7 +93,7 @@ int pam_end(pam_handle_t *pamh, int pam_status)
 
     _pam_drop(pamh);
 
-    D(("exiting pam_end() successfully"));
+    D(("exiting successfully"));
 
     return PAM_SUCCESS;
 }

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -210,7 +210,7 @@ int _pam_mkargv(const char *s, char ***argv, int *argc)
 
     *argv = our_argv;
 
-    D(("_pam_mkargv returned"));
+    D(("exiting"));
 
     return(argvlen);
 }

--- a/libpam/pam_password.c
+++ b/libpam/pam_password.c
@@ -52,7 +52,7 @@ int pam_chauthtok(pam_handle_t *pamh, int flags)
 	_pam_sanitize(pamh);
 	pamh->former.update = PAM_FALSE;
 	_pam_await_timer(pamh, retval);   /* if unsuccessful then wait now */
-	D(("pam_chauthtok exit %d - %d", retval, pamh->former.choice));
+	D(("exiting %d - %d", retval, pamh->former.choice));
     } else {
 	D(("will resume when ready"));
     }

--- a/libpam/pam_start.c
+++ b/libpam/pam_start.c
@@ -168,7 +168,7 @@ static int _pam_start_internal (
 	return PAM_ABORT;
     }
 
-    D(("exiting pam_start successfully"));
+    D(("exiting successfully"));
 
     return PAM_SUCCESS;
 }


### PR DESCRIPTION
The D macro itself already adds the function names.

It is a follow up to 79f97b5dfddbd54942036851e49c369502689853.