### PR TITLE
treewide: fix typos in comments and documentation

### DIFF
--- a/doc/man/pam.3.xml
+++ b/doc/man/pam.3.xml
@@ -150,7 +150,7 @@
         <citerefentry>
           <refentrytitle>pam_get_item</refentrytitle><manvolnum>3</manvolnum>
         </citerefentry>
-        functions allows applications and PAM service modules to set and
+        functions allow applications and PAM service modules to set and
         retrieve PAM information.
       </para>
       <para>
@@ -169,7 +169,7 @@
         <citerefentry>
           <refentrytitle>pam_get_data</refentrytitle><manvolnum>3</manvolnum>
         </citerefentry>
-        functions allows PAM service modules to set and retrieve free-form
+        function allows PAM service modules to set and retrieve free-form
         data from one invocation to another.
       </para>
     </refsect2>

--- a/doc/man/pam_open_session.3.xml
+++ b/doc/man/pam_open_session.3.xml
@@ -40,7 +40,7 @@
       It should be noted that the effective uid,
       <citerefentry>
         <refentrytitle>geteuid</refentrytitle><manvolnum>2</manvolnum>
-      </citerefentry>. of the application should be of sufficient
+      </citerefentry>, of the application should be of sufficient
       privilege to perform such tasks as creating or mounting the
       user's home directory for example.
     </para>

--- a/libpam/pam_delay.c
+++ b/libpam/pam_delay.c
@@ -19,7 +19,7 @@
 
 /* **********************************************************************
  * initialize the time as unset, this is set on the return from the
- * authenticating pair of of the libpam pam_XXX calls.
+ * authenticating pair of the libpam pam_XXX calls.
  */
 
 void _pam_reset_timer(pam_handle_t *pamh)

--- a/libpam/pam_dispatch.c
+++ b/libpam/pam_dispatch.c
@@ -299,7 +299,7 @@ static int _pam_dispatch_aux(pam_handle_t *pamh, int flags, struct handler *h,
 	}
 	continue;
 
-decision_made:     /* by getting  here we have made a decision */
+decision_made:     /* by getting here we have made a decision */
 	while (h->next != NULL && h->next->stack_level >= stack_level) {
 	    h = h->next;
 	    ++depth;

--- a/libpam/pam_password.c
+++ b/libpam/pam_password.c
@@ -22,7 +22,7 @@ int pam_chauthtok(pam_handle_t *pamh, int flags)
 	return PAM_SYSTEM_ERR;
     }
 
-    /* applications are not allowed to set this flags */
+    /* applications are not allowed to set these flags */
     if (flags & (PAM_PRELIM_CHECK | PAM_UPDATE_AUTHTOK)) {
       pam_syslog (pamh, LOG_ERR,
 		  "PAM_PRELIM_CHECK or PAM_UPDATE_AUTHTOK set by application");

--- a/libpam/pam_private.h
+++ b/libpam/pam_private.h
@@ -255,7 +255,7 @@ const char *_pam_dlerror (void);
 
 /* For now we just use a stack and linear search for module data. */
 /* If it becomes apparent that there is a lot of data, it should  */
-/* changed to either a sorted list or a hash table.               */
+/* be changed to either a sorted list or a hash table.            */
 
 struct pam_data {
      char *name;

--- a/libpam_misc/misc_conv.c
+++ b/libpam_misc/misc_conv.c
@@ -97,7 +97,7 @@ static int get_delay(void)
     expired = 0;                                        /* reset flag */
     (void) time(&now);
 
-    /* has the quit time past? */
+    /* has the quit time passed? */
     if (pam_misc_conv_die_time && now >= pam_misc_conv_die_time) {
 	fprintf(stderr,"%s",pam_misc_conv_die_line);
 
@@ -105,7 +105,7 @@ static int get_delay(void)
 	return -1;                                           /* time is up */
     }
 
-    /* has the warning time past? */
+    /* has the warning time passed? */
     if (pam_misc_conv_warn_time && now >= pam_misc_conv_warn_time) {
 	fprintf(stderr, "%s", pam_misc_conv_warn_line);
 	pam_misc_conv_warn_time = 0;                    /* reset warn_time */

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -247,7 +247,7 @@ int pamc_load(pamc_handle_t pch, const char *agent_id)
     pamc_agent_t *agent;
     size_t length;
 
-    /* santity checking */
+    /* sanity checking */
 
     if (pch == NULL) {
 	D(("pch is NULL"));

--- a/libpamc/test/agents/secret@here
+++ b/libpamc/test/agents/secret@here
@@ -83,7 +83,7 @@ sub HandleAgentSelection ($) {
 	return (0x04, "");
     }
 
-    # the selection request is acompanied with a hexadecimal cookie
+    # the selection request is accompanied with a hexadecimal cookie
     my @tokens = split '\|', $payload;
 
     unless ((scalar @tokens) == 2) {

--- a/libpamc/test/modules/pam_secret.c
+++ b/libpamc/test/modules/pam_secret.c
@@ -378,7 +378,7 @@ static int auth_sequence(pam_handle_t *pamh,
 
 	/* expect to receive the following {<seqid>|<a_cookie>} */
 	if (new->current_reply == NULL) {
-	    D(("converstation returned [%s] but gave no reply",
+	    D(("conversation returned [%s] but gave no reply",
 	       pam_strerror(pamh, retval)));
 	    new->state = PS_STATE_DEAD;
 	    return PAM_CONV_ERR;

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -158,7 +158,7 @@ parse_args(pam_handle_t *pamh, struct login_info *loginfo,
     return 1;  /* OK */
 }
 
-/* --- evaluting all files in VENDORDIR/security/access.d and /etc/security/access.d --- */
+/* --- evaluating all files in VENDORDIR/security/access.d and /etc/security/access.d --- */
 static const char *base_name(const char *path)
 {
     const char *base = strrchr(path, '/');

--- a/modules/pam_env/pam_env.8.xml
+++ b/modules/pam_env/pam_env.8.xml
@@ -181,7 +181,7 @@
         <listitem>
           <para>
             Indicate an alternative <filename>.pam_environment</filename>
-            file to override the default.The syntax is the same as
+            file to override the default. The syntax is the same as
 	    for <emphasis>/etc/security/pam_env.conf</emphasis>.
 	    The filename is relative to the user home directory.
 	    This can be useful when different services need different

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -914,7 +914,7 @@ parse_config_file(pam_handle_t *pamh, const char *uname, uid_t uid, gid_t gid,
 	    for(j=0; j < strlen(value); j++)
 		value[j]=tolower((unsigned char)value[j]);
 
-            if (strcmp(uname, domain) == 0) /* this user have a limit */
+            if (strcmp(uname, domain) == 0) /* this user has a limit */
                 process_limit(pamh, LIMITS_DEF_USER, ltype, item, value, ctrl, pl);
             else if (domain[0]=='@') {
 		if (ctrl & PAM_DEBUG_ARG) {

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -1122,7 +1122,7 @@ static int setup_limits(pam_handle_t *pamh,
     return retval;
 }
 
-/* --- evaluting all files in VENDORDIR/security/limits.d and /etc/security/limits.d --- */
+/* --- evaluating all files in VENDORDIR/security/limits.d and /etc/security/limits.d --- */
 static const char *
 base_name(const char *path)
 {

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -39,7 +39,7 @@
 #include "pam_namespace.h"
 #include "argv_parse.h"
 
-/* --- evaluting all files in VENDORDIR/security/namespace.d and /etc/security/namespace.d --- */
+/* --- evaluating all files in VENDORDIR/security/namespace.d and /etc/security/namespace.d --- */
 static const char *base_name(const char *path)
 {
     const char *base = strrchr(path, '/');

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -425,7 +425,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 		/* increase count.  */
 		entry.count++;
 
-		/* check that we don't remember to many passwords.  */
+		/* check that we don't remember too many passwords.  */
 		while (entry.count > howmany && entry.count > 1)
 		  {
 		    char *p = strpbrk (entry.old_passwords, ",");

--- a/modules/pam_unix/md5_crypt.c
+++ b/modules/pam_unix/md5_crypt.c
@@ -38,7 +38,7 @@ char *MD5Name(crypt_md5)(const char *pw, const char *salt)
 {
 	const char *magic = "$1$";
 	/* This string is magic for this algorithm.  Having
-	 * it this way, we can get get better later on */
+	 * it this way, we can get better later on */
 	char *passwd, *p;
 	const char *sp, *ep;
 	unsigned char final[16];

--- a/modules/pam_unix/pam_unix_auth.c
+++ b/modules/pam_unix/pam_unix_auth.c
@@ -118,7 +118,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
 		/*
 		 * Various libraries at various times have had bugs related to
 		 * '+' or '-' as the first character of a user name. Don't
-		 * allow this characters here.
+		 * allow these characters here.
 		 */
 		if (name[0] == '-' || name[0] == '+') {
 			pam_syslog(pamh, LOG_NOTICE, "bad username [%s]", name);

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -698,7 +698,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
 		} else {
 			D(("process run by root so do nothing this time around"));
 			pass_old = NULL;
-			retval = PAM_SUCCESS;	/* root doesn't have too */
+			retval = PAM_SUCCESS;	/* root doesn't have to */
 		}
 
 		if (retval != PAM_SUCCESS) {

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -648,7 +648,7 @@ _unix_blankpasswd (pam_handle_t *pamh, unsigned long long ctrl, const char *name
 
 	/*
 	 * This function does not have to be too smart if something goes
-	 * wrong, return FALSE and let this case to be treated somewhere
+	 * wrong, return FALSE and let this case be treated somewhere
 	 * else (CG)
 	 */
 


### PR DESCRIPTION
Spotted during review and with the tool `codespell`.