### PR TITLE
pam_exec: allow also expose_authtok for password PAM_TYPE

### DIFF
--- a/modules/pam_exec/pam_exec.8.xml
+++ b/modules/pam_exec/pam_exec.8.xml
@@ -103,7 +103,7 @@
           </term>
           <listitem>
             <para>
-              During authentication the calling command can read
+              During authentication and password change the calling command can read
               the password from <citerefentry>
               <refentrytitle>stdin</refentrytitle><manvolnum>3</manvolnum>
               </citerefentry>. Only first <emphasis>PAM_MAX_RESP_SIZE</emphasis>

--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -156,7 +156,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
   if (expose_authtok == 1)
     {
-      if (strcmp (pam_type, "auth") != 0)
+      if (strcmp (pam_type, "auth") != 0 && strcmp (pam_type, "password") != 0)
 	{
 	  pam_syslog (pamh, LOG_ERR,
 		      "expose_authtok not supported for type %s", pam_type);


### PR DESCRIPTION
I'm developing an integration between linux PAM and OpenZFS native encryption for datasets to automatically encrypt users' home directories. 
The pam_exec module fitted almost 100% to unlock the user's home directory dataset provided the password is used also as the key source for the dataset.
Apparently, when the password changes, the key must also be updated to keep them in sync.

However pam_exec exposes the password thru expose_authtok for auth PAM_TYPE only. This trivial patch allows pam_exec to expose the new password when the user or admin changes the password. 

please consider accepting this patch into the master branch.

Best regards
Anton Gubarkov. 