### PR TITLE
pam_access: fix nul byte handling in config

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -448,6 +448,8 @@ login_access (pam_handle_t *pamh, struct login_info *item)
     if ((fp = fopen(item->config_file, "r"))!=NULL) {
 	while (!match && fgets(line, sizeof(line), fp)) {
 	    lineno++;
+	    if (line[0] == 0)
+		continue;
 	    if (line[end = strlen(line) - 1] != '\n') {
 		pam_syslog(pamh, LOG_ERR,
                            "%s: line %zu: missing newline or line too long",


### PR DESCRIPTION
Even though NUL bytes are not supposed to show up in a configuration file, treat them properly and avoid out of boundary accesses.

Proof of Concept (compile with -fsanitize=address):
1. Create access.conf file with NUL byte at start of line
```
dd if=/dev/zero of=/tmp/access.conf bs=1 count=1
```
2. Use pam_access.so in e.g. /etc/pam.d/passwd
```
password  required    pam_access.so     accessfile=/tmp/access.conf
```
3. Run passwd
```
$ passwd
SUMMARY: AddressSanitizer: stack-buffer-overflow (/usr/lib/security/pam_access.so+0xf1ed) in login_access
```