### PR TITLE
pam_timestamp_check: fix potential null pointer dereference on error path

### DIFF
--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -815,7 +815,8 @@ main(int argc, char **argv)
 	/* Get the name of the invoking (requesting) user. */
 	pwd = getpwuid(getuid());
 	if (pwd == NULL) {
-		retval = 4;
+		fprintf(stderr, "unknown user\n");
+		return 4;
 	}
 #ifdef USE_LOGIND
 	uid = pwd->pw_uid;

--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -845,8 +845,11 @@ main(int argc, char **argv)
 	}
 
 	/* Generate the name of the timestamp file. */
-	format_timestamp_name(path, sizeof(path), TIMESTAMPDIR,
-			      tty, user, target_user);
+	if (format_timestamp_name(path, sizeof(path), TIMESTAMPDIR,
+				  tty, user, target_user) >= (int) sizeof(path)) {
+		fprintf(stderr, "path too long\n");
+		return 4;
+	}
 
 	do {
 		retval = 0;


### PR DESCRIPTION
If the pointer variable pwd is null, then a null pointer dereference problem occurs when fetching the contents of pw_uid and pw_name from the pwd variable.
To avoid this problem, I think we should return the value of the variable retval directly after determining that pwd is null.
https://github.com/linux-pam/linux-pam/issues/677
