### PR TITLE
unix_chkpwd, unix_update: Use exit codes 128+ on signals

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -1154,7 +1154,7 @@ su_sighandler(int sig)
 	}
 #endif
         if (sig > 0) {
-                _exit(sig);
+                _exit(128 + (sig & 127));
         }
 }
 


### PR DESCRIPTION
`setup_signals()` and thus its signal handler patched in this PR are used by the `unix_chkpwd` and `unix_update` helper programs. These programs communicate their completion status to the calling process by exit code, using one of the `PAM_*` error codes - or normally `PAM_SUCCESS`. Unfortunately, before the change proposed here, the signal handler would use the signal number as the exit code. The intercepted signals are generally low-numbered and are likely to clash with `PAM_*` error codes, confusing the caller.

Luckily, they would not normally clash with `PAM_SUCCESS`, which is 0, and the code has an explicit check for `sig > 0`. While on some obscure systems (e.g., with "sub-signals" on SPARC) the signal handler may be called with more than just the signal number encoded in its argument, I'm not currently aware of a way to make that value a multiple of 256 (which would map to 0 exit code due to exit codes' limited range). So we seem to be spared from this being a vulnerability.

As a quick non-invasive fix, I propose mapping the signal numbers onto the 128 to 255 range like bash does, assuming this range is not in use by `PAM_*` codes.

Longer-term, I think the helpers should switch to using a more reliable mechanism to communicate their status, safer from such clashes e.g. with possible abnormal and system-specific process exits triggered by library code or the kernel, as well as from Mayhem/Rowhammer (https://www.openwall.com/lists/oss-security/2023/12/21/9). Something like what we had done in `tcb`. But that's a different story, for a separate issue/PR.

These observations and fix are due to my work on Rocky Linux security sponsored by CIQ.