### PR TITLE
pam_env: various cleanups

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -696,8 +696,8 @@ _expand_arg(pam_handle_t *pamh, char **value)
     free(*value);
     if ((*value = malloc(idx + 1)) == NULL) {
       D(("Couldn't malloc %zu bytes for expanded var", idx + 1));
-      pam_syslog (pamh, LOG_CRIT, "Couldn't malloc %lu bytes for expanded var",
-	       (unsigned long)idx+1);
+      pam_syslog (pamh, LOG_CRIT, "Couldn't malloc %zu bytes for expanded var",
+	       idx+1);
       goto buf_err;
     }
   }

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -581,9 +581,9 @@ _expand_arg(pam_handle_t *pamh, char **value)
 		    * a constant so that the compiler will shut up when I
 		    * call pam_getenv and _pam_get_item_byname -- sigh
 		    */
+  const char *tmpval;
 
-  /* No unexpanded variable can be bigger than BUF_SIZE */
-  char type, tmpval[BUF_SIZE];
+  char type;
 
   /* I know this shouldn't be hard-coded but it's so much easier this way */
   char tmp[MAX_ENV] = {};
@@ -639,8 +639,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
 		     "Unterminated expandable variable: <%s>", orig-2);
 	  goto abort_err;
 	}
-	strncpy(tmpval, orig, sizeof(tmpval));
-	tmpval[sizeof(tmpval)-1] = '\0';
+	tmpval = orig;
 	orig=ptr;
 	/*
 	 * so, we know we need to expand tmpval, it is either
@@ -704,17 +703,14 @@ _expand_arg(pam_handle_t *pamh, char **value)
   }
   strcpy(*value, tmp);
   pam_overwrite_array(tmp);
-  pam_overwrite_array(tmpval);
   D(("Exit."));
 
   return PAM_SUCCESS;
 buf_err:
   pam_overwrite_array(tmp);
-  pam_overwrite_array(tmpval);
   return PAM_BUF_ERR;
 abort_err:
   pam_overwrite_array(tmp);
-  pam_overwrite_array(tmpval);
   return PAM_ABORT;
 }
 

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -498,6 +498,8 @@ _parse_line(const pam_handle_t *pamh, const char *buffer, VAR *var)
       quoteflg++;
     }
     if (length) {
+      if (*valptr != &quote)
+	free(*valptr);
       if ((*valptr = malloc(length + 1)) == NULL) {
 	D(("Couldn't malloc %d bytes", length+1));
 	pam_syslog(pamh, LOG_CRIT, "Couldn't malloc %d bytes", length+1);

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -609,9 +609,9 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	tmp[idx++] = *orig++;        /* Note the increment */
       } else {
 	/* is it really a good idea to try to log this? */
-	D(("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr));
-	pam_syslog (pamh, LOG_ERR, "Variable buffer overflow: <%s> + <%s>",
-		 tmp, tmpptr);
+	D(("Variable buffer overflow: <%s> + <%c>", tmp, *orig));
+	pam_syslog (pamh, LOG_ERR, "Variable buffer overflow: <%s> + <%c>",
+		 tmp, *orig);
 	goto buf_err;
       }
       continue;
@@ -684,9 +684,9 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	tmp[idx++] = *orig++;        /* Note the increment */
       } else {
 	/* is it really a good idea to try to log this? */
-	D(("Variable buffer overflow: <%s> + <%s>", tmp, tmpptr));
+	D(("Variable buffer overflow: <%s> + <%c>", tmp, *orig));
 	pam_syslog(pamh, LOG_ERR,
-		   "Variable buffer overflow: <%s> + <%s>", tmp, tmpptr);
+		   "Variable buffer overflow: <%s> + <%c>", tmp, *orig);
 	goto buf_err;
       }
     }

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -575,15 +575,7 @@ _pam_get_item_byname(pam_handle_t *pamh, const char *name)
 static int
 _expand_arg(pam_handle_t *pamh, char **value)
 {
-  const char *orig=*value, *tmpptr=NULL;
-  char *ptr;       /*
-		    * Sure would be nice to use tmpptr but it needs to be
-		    * a constant so that the compiler will shut up when I
-		    * call pam_getenv and _pam_get_item_byname -- sigh
-		    */
-  const char *tmpval;
-
-  char type;
+  const char *orig=*value;
 
   /* I know this shouldn't be hard-coded but it's so much easier this way */
   char tmp[MAX_ENV] = {};
@@ -627,6 +619,14 @@ _expand_arg(pam_handle_t *pamh, char **value)
 	}
 	continue;
       } else {
+	const char *tmpptr=NULL, *tmpval;
+	char *ptr;       /*
+			  * Sure would be nice to use tmpptr but it needs to be
+			  * a constant so that the compiler will shut up when I
+			  * call pam_getenv and _pam_get_item_byname -- sigh
+			  */
+	char type;
+
 	D(("Expandable argument: <%s>", orig));
 	type = *orig;
 	orig+=2;     /* skip the ${ or @{ characters */

--- a/modules/pam_env/tst-pam_env-retval.c
+++ b/modules/pam_env/tst-pam_env-retval.c
@@ -69,7 +69,7 @@ setup(void)
 
 	ASSERT_NE(NULL, fp = fopen(my_conf, "w"));
 	ASSERT_LT(0, fprintf(fp,
-			     "EDITOR\tDEFAULT=vim\n"
+			     "EDITOR\tDEFAULT=vi DEFAULT= DEFAULT=vim\n"
 			     "PAGER\tDEFAULT=more\n"));
 	ASSERT_EQ(0, fclose(fp));
 


### PR DESCRIPTION
A memory leak can occur if DEFAULT or OVERRIDE are supplied multiple times in a line.

While at it, prepare a change for later pam_assemble_line port from libpam to pam_env by removing the usage of a fixed sized stack variable. It doesn't take copying actually.

Also improve debug and error messages and reduce variable visibility so it is easier to trace where variables are actually used (which makes the debug and error message adjustment also easier to verify).