### PR TITLE
modules: prevent config truncations

### DIFF
--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -106,21 +106,25 @@ args_parse(pam_handle_t *pamh, int argc, const char **argv,
 			opts->action = FAILLOCK_ACTION_AUTHSUCC;
 		}
 		else {
-			char buf[FAILLOCK_CONF_MAX_LINELEN + 1];
-			char *val;
+			char *name, *val;
 
-			strncpy(buf, argv[i], sizeof(buf) - 1);
-			buf[sizeof(buf) - 1] = '\0';
+			if ((name = strdup(argv[i])) == NULL) {
+				pam_syslog(pamh, LOG_CRIT,
+				    "Error allocating memory: %m");
+				return PAM_BUF_ERR;
+			}
 
-			val = strchr(buf, '=');
+			val = strchr(name, '=');
 			if (val != NULL) {
 				*val = '\0';
 				++val;
 			}
 			else {
-				val = buf + sizeof(buf) - 1;
+				val = name + strlen(name);
 			}
-			set_conf_opt(pamh, opts, buf, val);
+			set_conf_opt(pamh, opts, name, val);
+
+			free(name);
 		}
 	}
 

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -181,7 +181,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	}
     }
 
-    /* Short-circuit - test if this session apply for this user */
+    /* Short-circuit - test if this session applies for this user */
     {
 	const char *user_name;
 	int rval;

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -109,7 +109,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	    ifname = strdup(myval);
 	    if (!ifname)
 		return PAM_BUF_ERR;
-	} else if(!strcmp(mybuf,"item"))
+	} else if(!strcmp(mybuf,"item")) {
 	    if(!strcmp(myval,"user"))
 		citem = PAM_USER;
 	    else if(!strcmp(myval,"tty"))
@@ -127,20 +127,21 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 		    extitem = EI_SHELL;
 		else
 		    citem = 0;
-	    } else if(!strcmp(mybuf,"apply")) {
-		apply_type=APPLY_TYPE_NONE;
-		if (myval[0]=='@') {
-		    apply_type=APPLY_TYPE_GROUP;
-		    memcpy(apply_val,myval+1,sizeof(myval)-1);
-		} else {
-		    apply_type=APPLY_TYPE_USER;
-		    memcpy(apply_val,myval,sizeof(myval));
-		}
-	    } else {
-		free(ifname);
-		pam_syslog(pamh,LOG_ERR, "Unknown option: %s",mybuf);
-		return onerr;
 	    }
+	} else if(!strcmp(mybuf,"apply")) {
+	    apply_type=APPLY_TYPE_NONE;
+	    if (myval[0]=='@') {
+		apply_type=APPLY_TYPE_GROUP;
+		memcpy(apply_val,myval+1,sizeof(myval)-1);
+	    } else {
+		apply_type=APPLY_TYPE_USER;
+		memcpy(apply_val,myval,sizeof(myval));
+	    }
+	} else {
+	    free(ifname);
+	    pam_syslog(pamh,LOG_ERR, "Unknown option: %s",mybuf);
+	    return onerr;
+	}
     }
 
     if(!citem) {

--- a/modules/pam_wheel/pam_wheel.c
+++ b/modules/pam_wheel/pam_wheel.c
@@ -54,11 +54,11 @@
 
 static int
 _pam_parse (const pam_handle_t *pamh, int argc, const char **argv,
-	    char *use_group, size_t group_length)
+	    const char **use_group)
 {
      int ctrl=0;
 
-     memset(use_group, '\0', group_length);
+     *use_group = "";
 
      /* step through arguments */
      for (ctrl=0; argc-- > 0; ++argv) {
@@ -77,7 +77,7 @@ _pam_parse (const pam_handle_t *pamh, int argc, const char **argv,
           else if (!strcmp(*argv,"root_only"))
                ctrl |= PAM_ROOT_ONLY_ARG;
 	  else if ((str = pam_str_skip_prefix(*argv, "group=")) != NULL)
-	       strncpy(use_group, str, group_length - 1);
+	       *use_group = str;
           else {
                pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
           }
@@ -237,10 +237,10 @@ int
 pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 		     int argc, const char **argv)
 {
-    char use_group[BUFSIZ];
+    const char *use_group;
     int ctrl;
 
-    ctrl = _pam_parse(pamh, argc, argv, use_group, sizeof(use_group));
+    ctrl = _pam_parse(pamh, argc, argv, &use_group);
 
     return perform_check(pamh, ctrl, use_group);
 }
@@ -256,10 +256,10 @@ int
 pam_sm_acct_mgmt (pam_handle_t *pamh, int flags UNUSED,
 		  int argc, const char **argv)
 {
-    char use_group[BUFSIZ];
+    const char *use_group;
     int ctrl;
 
-    ctrl = _pam_parse(pamh, argc, argv, use_group, sizeof(use_group));
+    ctrl = _pam_parse(pamh, argc, argv, &use_group);
 
     return perform_check(pamh, ctrl, use_group);
 }


### PR DESCRIPTION
The modules pam_faillock, pam_listfile and pam_wheel could silently truncate very long arguments coming from pam configuration files.

This was true for pam_listfile even before the arbitrary line length adjustment.