### PR TITLE
pam_namespace: validate amount of uids in config

### DIFF
--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -637,7 +637,7 @@ static int process_line(char *line, const char *home, const char *rhome,
     if (uids) {
         uid_t *uidptr;
         const char *ustr, *sstr;
-        int count, i;
+        size_t count, i;
 
 	if (*uids == '~') {
 		poly->flags |= POLYDIR_EXCLUSIVE;
@@ -645,6 +645,11 @@ static int process_line(char *line, const char *home, const char *rhome,
 	}
         for (count = 0, ustr = sstr = uids; sstr; ustr = sstr + 1, count++)
            sstr = strchr(ustr, ',');
+
+        if (count > UINT_MAX || count > SIZE_MAX / sizeof(uid_t)) {
+            pam_syslog(idata->pamh, LOG_ERR, "Too many uids encountered in configuration");
+            goto skipping;
+        }
 
         poly->num_uids = count;
         poly->uid = malloc(count * sizeof (uid_t));


### PR DESCRIPTION
If more than INT_MAX uids are found in a configuration line, the variable `count` would trigger a signed integer overflow.

If more than UINT_MAX uids are found in a configuration line, then the `num_uids` counter is invalid, which could eventually lead to out of boundary accesses.

Also make sure that size multiplication for malloc does not overflow.