### PR TITLE
pam_unix: use getline in _unix_getpwnam

### DIFF
--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -404,37 +404,37 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 
 		spasswd = strchr(slogin, ':');
 		if (spasswd == NULL) {
-			return matched;
+			goto fail;
 		}
 		*spasswd++ = '\0';
 
 		suid = strchr(spasswd, ':');
 		if (suid == NULL) {
-			return matched;
+			goto fail;
 		}
 		*suid++ = '\0';
 
 		sgid = strchr(suid, ':');
 		if (sgid == NULL) {
-			return matched;
+			goto fail;
 		}
 		*sgid++ = '\0';
 
 		sgecos = strchr(sgid, ':');
 		if (sgecos == NULL) {
-			return matched;
+			goto fail;
 		}
 		*sgecos++ = '\0';
 
 		shome = strchr(sgecos, ':');
 		if (shome == NULL) {
-			return matched;
+			goto fail;
 		}
 		*shome++ = '\0';
 
 		sshell = strchr(shome, ':');
 		if (sshell == NULL) {
-			return matched;
+			goto fail;
 		}
 		*sshell++ = '\0';
 
@@ -446,21 +446,17 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 			 strlen(sshell) + 1;
 		*ret = calloc(retlen, sizeof(char));
 		if (*ret == NULL) {
-			return matched;
+			goto fail;
 		}
 
 		(*ret)->pw_uid = strtol(suid, &p, 10);
 		if ((strlen(suid) == 0) || (*p != '\0')) {
-			free(*ret);
-			*ret = NULL;
-			return matched;
+			goto fail;
 		}
 
 		(*ret)->pw_gid = strtol(sgid, &p, 10);
 		if ((strlen(sgid) == 0) || (*p != '\0')) {
-			free(*ret);
-			*ret = NULL;
-			return matched;
+			goto fail;
 		}
 
 		p = ((char*)(*ret)) + sizeof(struct passwd);
@@ -478,11 +474,14 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 
 		if (pam_set_data(pamh, buf,
 				 *ret, _unix_cleanup) != PAM_SUCCESS) {
-			free(*ret);
-			*ret = NULL;
+			goto fail;
 		}
 	}
 
+	return matched;
+fail:
+	free(*ret);
+	*ret = NULL;
 	return matched;
 }
 

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -348,9 +348,9 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 {
 	FILE *passwd;
 	char buf[16384];
-	int matched = 0, buflen;
+	int matched = 0;
 	char *slogin, *spasswd, *suid, *sgid, *sgecos, *shome, *sshell, *p;
-	size_t userlen;
+	size_t retlen, userlen;
 
 	memset(buf, 0, sizeof(buf));
 
@@ -438,17 +438,17 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 		}
 		*sshell++ = '\0';
 
-		buflen = sizeof(struct passwd) +
+		retlen = sizeof(struct passwd) +
 			 strlen(slogin) + 1 +
 			 strlen(spasswd) + 1 +
 			 strlen(sgecos) + 1 +
 			 strlen(shome) + 1 +
 			 strlen(sshell) + 1;
-		*ret = malloc(buflen);
+		*ret = malloc(retlen);
 		if (*ret == NULL) {
 			return matched;
 		}
-		memset(*ret, '\0', buflen);
+		memset(*ret, '\0', retlen);
 
 		(*ret)->pw_uid = strtol(suid, &p, 10);
 		if ((strlen(suid) == 0) || (*p != '\0')) {

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -346,13 +346,12 @@ static void _unix_cleanup(pam_handle_t *pamh UNUSED, void *data, int error_statu
 int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 		   int files, int nis, struct passwd **ret)
 {
-	FILE *passwd;
 	char *buf = NULL;
 	int matched = 0;
-	char *slogin, *spasswd, *suid, *sgid, *sgecos, *shome, *sshell, *p;
-	size_t retlen;
 
 	if (!matched && files && strchr(name, ':') == NULL) {
+		FILE *passwd;
+
 		passwd = fopen("/etc/passwd", "r");
 		if (passwd != NULL) {
 			size_t n = 0, userlen;
@@ -363,6 +362,8 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 			while ((r = getline(&buf, &n, passwd)) != -1) {
 				if ((size_t)r > userlen && (buf[userlen] == ':') &&
 				    (strncmp(name, buf, userlen) == 0)) {
+					char *p;
+
 					p = buf + strlen(buf) - 1;
 					while (isspace((unsigned char)*p) && (p >= buf)) {
 						*p-- = '\0';
@@ -401,6 +402,9 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 #endif
 
 	if (matched && (ret != NULL)) {
+		char *slogin, *spasswd, *suid, *sgid, *sgecos, *shome, *sshell, *p;
+		size_t retlen;
+
 		*ret = NULL;
 
 		slogin = buf;

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -350,14 +350,15 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 	char *buf = NULL;
 	int matched = 0;
 	char *slogin, *spasswd, *suid, *sgid, *sgecos, *shome, *sshell, *p;
-	size_t retlen, userlen;
+	size_t retlen;
 
-	userlen = strlen(name);
 	if (!matched && files && strchr(name, ':') == NULL) {
 		passwd = fopen("/etc/passwd", "r");
 		if (passwd != NULL) {
-			size_t n = 0;
+			size_t n = 0, userlen;
 			ssize_t r;
+
+			userlen = strlen(name);
 
 			while ((r = getline(&buf, &n, passwd)) != -1) {
 				if ((size_t)r > userlen && (buf[userlen] == ':') &&

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -444,11 +444,10 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 			 strlen(sgecos) + 1 +
 			 strlen(shome) + 1 +
 			 strlen(sshell) + 1;
-		*ret = malloc(retlen);
+		*ret = calloc(retlen, sizeof(char));
 		if (*ret == NULL) {
 			return matched;
 		}
-		memset(*ret, '\0', retlen);
 
 		(*ret)->pw_uid = strtol(suid, &p, 10);
 		if ((strlen(suid) == 0) || (*p != '\0')) {


### PR DESCRIPTION
The `_unix_getpwnam` function takes a bit of refactoring to be getline-compatible.
I have performed every step in a single commit to allow easier review.

Feel free to squash or ask me to squash them if review is complete.

Since I have no NIS environment, the NIS code path is not tested (compiles on my system though).