### PR TITLE
modules: use getline instead of fgets

### DIFF
--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -268,9 +268,10 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
       if (use_stdout)
 	{
-	  char buf[4096];
+	  char *buf = NULL;
+	  size_t n = 0;
 	  close(stdout_fds[1]);
-	  while (fgets(buf, sizeof(buf), stdout_file) != NULL)
+	  while (getline(&buf, &n, stdout_file) != -1)
 	    {
 	      size_t len;
 	      len = strlen(buf);
@@ -278,6 +279,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 		buf[len-1] = '\0';
 	      pam_info(pamh, "%s", buf);
 	    }
+	  free(buf);
 	  fclose(stdout_file);
 	}
 

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -52,11 +52,12 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
     const void *void_citemp;
     const char *citemp;
     const char *ifname=NULL;
-    char aline[256];
+    char *aline=NULL;
     const char *apply_val;
     struct stat fileinfo;
     FILE *inf;
     int apply_type;
+    size_t n=0;
 
     /* Stuff for "extended" items */
     struct passwd *userinfo;
@@ -280,8 +281,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
     assert(PAM_SUCCESS == 0);
     assert(PAM_AUTH_ERR != 0);
 #endif
-    while((fgets(aline,sizeof(aline),inf) != NULL)
-	  && retval) {
+    while(getline(&aline,&n,inf) != -1 && retval) {
 	const char *a = aline;
 
 	if(strlen(aline) == 0)
@@ -305,6 +305,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 	}
     }
 
+    free(aline);
     fclose(inf);
     if ((sense && retval) || (!sense && !retval)) {
 #ifdef PAM_DEBUG

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -339,17 +339,18 @@ static int _unix_run_update_binary(pam_handle_t *pamh, unsigned long long ctrl, 
 
 static int check_old_password(const char *forwho, const char *newpass)
 {
-	static char buf[16384];
+	char *buf = NULL;
 	char *s_pas;
 	int retval = PAM_SUCCESS;
 	FILE *opwfile;
+	size_t n = 0;
 	size_t len = strlen(forwho);
 
 	opwfile = fopen(OLD_PASSWORDS_FILE, "r");
 	if (opwfile == NULL)
 		return PAM_ABORT;
 
-	while (fgets(buf, 16380, opwfile)) {
+	while (getline(&buf, &n, opwfile) != -1) {
 		if (!strncmp(buf, forwho, len) && (buf[len] == ':' ||
 			buf[len] == ',')) {
 			char *sptr;
@@ -371,6 +372,7 @@ static int check_old_password(const char *forwho, const char *newpass)
 			break;
 		}
 	}
+	free(buf);
 	fclose(opwfile);
 
 	return retval;

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -288,9 +288,10 @@ check_acl(pam_handle_t *pamh,
 		}
 	}
 	if (fp) {
-		char buf[LINE_MAX];
+		char *buf = NULL;
+		size_t n = 0;
 		/* Scan the file for a list of specs of users to "trust". */
-		while (fgets(buf, sizeof(buf), fp) != NULL) {
+		while (getline(&buf, &n, fp) != -1) {
 			buf[strcspn(buf, "\r\n")] = '\0';
 			if (fnmatch(buf, other_user, 0) == 0) {
 				if (debug) {
@@ -298,6 +299,7 @@ check_acl(pam_handle_t *pamh,
 						   "%s %s allowed by %s",
 						   other_user, sense, path);
 				}
+				free(buf);
 				fclose(fp);
 				free(path);
 				return PAM_SUCCESS;
@@ -308,6 +310,7 @@ check_acl(pam_handle_t *pamh,
 			pam_syslog(pamh, LOG_DEBUG, "%s not listed in %s",
 				   other_user, path);
 		}
+		free(buf);
 		fclose(fp);
 		free(path);
 		return PAM_PERM_DENIED;


### PR DESCRIPTION
This PR changes most `fgets` calls to `getline`. Commits in this PR are quite simple, because we were able to prepare the affected code paths in previous commits.

The `pam_env` module is too complex to be added into this PR because it involves porting `_pam_assemble_line` and will be done in a separate PR.

The `pam_unix` module has one separate PR because of the involved complexity: https://github.com/linux-pam/linux-pam/pull/694