### PR TITLE
pam_env: allow long argument expansions

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -673,6 +673,13 @@ _expand_arg(pam_handle_t *pamh, char **value)
   const char *orig=*value;
   struct string_buffer buf;
 
+  /*
+   * Return early if there are no special characters present in the value.
+   */
+  if ((*value)[strcspn(*value, "\\$@")] == '\0') {
+    return PAM_SUCCESS;
+  }
+
   _strbuf_init(&buf);
 
   /*

--- a/modules/pam_env/tst-pam_env-retval.c
+++ b/modules/pam_env/tst-pam_env-retval.c
@@ -71,7 +71,9 @@ setup(void)
 	ASSERT_LT(0, fprintf(fp,
 			     "EDITOR\tDEFAULT=vi DEFAULT= DEFAULT=vim\n"
 			     "PAGER\tDEFAULT=more\n"
-			     "NAME\tDEFAULT=@{PAM_USER}\n"));
+			     "# ignore escaped newlines in comments \\\n"
+			     "NAME\tDEFAULT=@{PAM_\\ \t\n"
+			     "USER}\n"));
 	ASSERT_EQ(0, fclose(fp));
 
 	ASSERT_NE(NULL, fp = fopen(my_env, "w"));

--- a/modules/pam_env/tst-pam_env-retval.c
+++ b/modules/pam_env/tst-pam_env-retval.c
@@ -70,7 +70,8 @@ setup(void)
 	ASSERT_NE(NULL, fp = fopen(my_conf, "w"));
 	ASSERT_LT(0, fprintf(fp,
 			     "EDITOR\tDEFAULT=vi DEFAULT= DEFAULT=vim\n"
-			     "PAGER\tDEFAULT=more\n"));
+			     "PAGER\tDEFAULT=more\n"
+			     "NAME\tDEFAULT=@{PAM_USER}\n"));
 	ASSERT_EQ(0, fclose(fp));
 
 	ASSERT_NE(NULL, fp = fopen(my_env, "w"));
@@ -127,7 +128,7 @@ check_env(const char **list)
 	pam_handle_t *pamh = NULL;
 
 	ASSERT_EQ(PAM_SUCCESS,
-		  pam_start_confdir(service_file, "", &conv, ".", &pamh));
+		  pam_start_confdir(service_file, "user", &conv, ".", &pamh));
 	ASSERT_NE(NULL, pamh);
 
 	ASSERT_EQ(PAM_SUCCESS, pam_open_session(pamh, 0));
@@ -231,7 +232,7 @@ main(void)
 			     cwd, my_conf, "/dev/null"));
 	ASSERT_EQ(0, fclose(fp));
 
-	const char *env1[] = { "EDITOR=vim", "PAGER=more", NULL };
+	const char *env1[] = { "EDITOR=vim", "PAGER=more", "NAME=user", NULL };
 	check_env(env1);
 
 	/*


### PR DESCRIPTION
The arguments in a `pam_env` configuration file can be substituted with environment variables or PAM items. This expansion can become larger than the original input line.

Allow them to grow arbitrarily since PAM environment variables can handle such situations already. Also, this is a preparation to use getline for configuration file parsing.

This PR includes a test case for variable substitution and how `pam_env` handles escaped newlines. There is a subtle difference between libpam and pam_env: The backslash character is not replaced by a blank but removed as well. The added test covers this.