### PR TITLE
libpam: use getrandom if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -638,7 +638,7 @@ AC_CHECK_FUNCS(explicit_bzero memset_explicit)
 AC_CHECK_FUNCS([ruserok_af ruserok], [break])
 AC_CHECK_FUNCS(close_range)
 
-dnl For module/pam_timestamp
+dnl For libpam/pam_delay and modules/pam_timestamp
 AC_CHECK_HEADERS([sys/random.h])
 dnl May require libbsd/libSystem on non-Linux platforms
 AC_CHECK_FUNCS(getrandom)

--- a/libpam/pam_delay.c
+++ b/libpam/pam_delay.c
@@ -18,6 +18,10 @@
 #include <unistd.h>
 #include <time.h>
 
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+
 /* **********************************************************************
  * initialize the time as unset, this is set on the return from the
  * authenticating pair of the libpam pam_XXX calls.
@@ -52,11 +56,20 @@ void _pam_start_timer(pam_handle_t *pamh)
  * in C'. It is *not* a cryptographically strong generator, but it is
  * probably "good enough" for our purposes here.
  *
- * /dev/random might be a better place to look for some numbers...
+ * If getrandom is available, retrieve random number from there.
  */
 
 static unsigned int _pam_rand(unsigned int seed)
 {
+#ifdef HAVE_GETRANDOM
+     unsigned int value;
+
+     if (getrandom(&value, sizeof(value), GRND_NONBLOCK) ==
+	 (ssize_t) sizeof(value)) {
+	  return value;
+     }
+#endif
+
 #define N1 1664525
 #define N2 1013904223
      return N1*seed + N2;


### PR DESCRIPTION
Use getrandom to retrieve random numbers for delay calculation.

If it fails or is not available, keep using current algorithm.

The getrandom call has been introduced in 4936f7dc386e0f0e16d4835954ab061e87399912.