### PR TITLE
libpam: use correct function definition

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -947,10 +947,10 @@ _pam_load_module(pam_handle_t *pamh, const char *mod_path, int handler_type)
     return success == PAM_SUCCESS ? mod : NULL;
 }
 
-int _pam_add_handler(pam_handle_t *pamh
-		     , int handler_type, int other, int stack_level, int type
-		     , int *actions, const char *mod_path
-		     , int argc, char **argv, size_t argvlen)
+static int _pam_add_handler(pam_handle_t *pamh
+			    , int handler_type, int other, int stack_level
+			    , int type, int *actions, const char *mod_path
+			    , int argc, char **argv, size_t argvlen)
 {
     struct loaded_module *mod = NULL;
     struct handler **handler_p;


### PR DESCRIPTION
The declaration uses static keyword, the definition does not. Fix the definition, because the function is only used in this file.