### PR TITLE
treewide: fix typos

### DIFF
--- a/doc/adg/Linux-PAM_ADG.xml
+++ b/doc/adg/Linux-PAM_ADG.xml
@@ -528,7 +528,7 @@ cc -o application .... -lpam -lpam_misc
             him/herself in a variety of ways. Updating the user's
             authentication token thus corresponds to
             <emphasis>refreshing</emphasis> the object they use to
-            authenticate themself with the system. The word password is
+            authenticate themselves with the system. The word password is
             avoided to keep open the possibility that the authentication
             involves a retinal scan or other non-textual mode of
             challenge/response.

--- a/libpam/include/security/_pam_macros.h
+++ b/libpam/include/security/_pam_macros.h
@@ -49,7 +49,7 @@ do {                 \
 } while (0)
 
 /*
- * WARNING: Do NOT use this macro, as it does not reliable override the memory.
+ * WARNING: Do NOT use this macro, as it does not reliably override the memory.
  */
 
 #define _pam_drop_reply(/* struct pam_response * */ reply, /* int */ replies) \

--- a/libpam/pam_audit.c
+++ b/libpam/pam_audit.c
@@ -203,7 +203,7 @@ int
 _pam_audit_end(pam_handle_t *pamh, int status UNUSED)
 {
   if (! (pamh->audit_state & PAMAUDIT_LOGGED)) {
-    /* PAM library is being shut down without any of the auditted
+    /* PAM library is being shut down without any of the audited
      * stacks having been run. Assume that this is sshd faking
      * things for an unknown user.
      */

--- a/libpam/pam_dispatch.c
+++ b/libpam/pam_dispatch.c
@@ -28,7 +28,7 @@
 
 /*
  * walk a stack of modules.  Interpret the administrator's instructions
- * when combining the return code of each module.
+ * when combining the return codes of each module.
  */
 
 static int _pam_dispatch_aux(pam_handle_t *pamh, int flags, struct handler *h,

--- a/libpam/pam_end.c
+++ b/libpam/pam_end.c
@@ -26,7 +26,7 @@ int pam_end(pam_handle_t *pamh, int pam_status)
     _pam_audit_end(pamh, pam_status);
 #endif
 
-    /* first liberate the modules (it is not inconcevible that the
+    /* first liberate the modules (it is not inconceivable that the
        modules may need to use the service_name etc. to clean up) */
 
     _pam_free_data(pamh, pam_status);

--- a/libpam/pam_misc.c
+++ b/libpam/pam_misc.c
@@ -206,7 +206,7 @@ size_t _pam_mkargv(const char *s, char ***argv, int *argc)
 
 /*
  * this function is used to protect the modules from accidental or
- * semi-mallicious harm that an application may do to confuse the API.
+ * semi-malicious harm that an application may do to confuse the API.
  */
 
 void _pam_sanitize(pam_handle_t *pamh)

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -749,7 +749,7 @@ _check_var(pam_handle_t *pamh, VAR *var)
     return retval;
   }
 
-  /* Now its easy */
+  /* Now it's easy */
 
   if (var->override && *(var->override)) {
     /* if there is a non-empty string in var->override, we use it */

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -318,7 +318,7 @@ set_filter (pam_handle_t *pamh, int flags UNUSED, int ctrl,
 		close(t);
 	    }
 
-	    /* make this process it's own process leader */
+	    /* make this process its own process leader */
 	    if (setsid() == -1) {
 		pam_syslog(pamh, LOG_ERR,
 			   "child cannot become new session: %m");
@@ -468,7 +468,7 @@ set_filter (pam_handle_t *pamh, int flags UNUSED, int ctrl,
 
 	    } else if (chid == child2) {
 		/*
-		 * if the filter has exited. Let the child die
+		 * if the filter has exited, let the child die
 		 * naturally below
 		 */
 		if (WIFEXITED(lstatus) || WIFSIGNALED(lstatus))

--- a/modules/pam_namespace/namespace.conf.5.xml
+++ b/modules/pam_namespace/namespace.conf.5.xml
@@ -161,7 +161,7 @@
       which is used for polyinstantiation is the context used for executing
       a new process as obtained by getexeccon. This context must be set
       by the calling application or <filename>pam_selinux.so</filename>
-      module. If this context is not set the polyinstatiation will be
+      module. If this context is not set the polyinstantiation will be
       based just on user name.
     </para>
 

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -473,7 +473,7 @@ static int parse_method(char *method, struct polydir_s *poly,
  * of the namespace configuration file. It skips over comments and incomplete
  * or malformed lines. It processes a valid line with information on
  * polyinstantiating a directory by populating appropriate fields of a
- * polyinstatiated directory structure and then calling add_polydir_entry to
+ * polyinstantiated directory structure and then calling add_polydir_entry to
  * add that entry to the linked list of polyinstantiated directories.
  */
 static int process_line(char *line, const char *home, const char *rhome,

--- a/modules/pam_namespace/pam_namespace.h
+++ b/modules/pam_namespace/pam_namespace.h
@@ -114,7 +114,7 @@
 #define PAMNS_MOUNT_PRIVATE   0x00080000 /* Make the polydir mounts private */
 
 /* polydir flags */
-#define POLYDIR_EXCLUSIVE     0x00000001 /* polyinstatiate exclusively for override uids */
+#define POLYDIR_EXCLUSIVE     0x00000001 /* polyinstantiate exclusively for override uids */
 #define POLYDIR_CREATE        0x00000002 /* create the polydir */
 #define POLYDIR_NOINIT        0x00000004 /* no init script */
 #define POLYDIR_SHARED        0x00000008 /* share context/level instances among users */

--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -207,7 +207,7 @@
             This argument can be used to discourage the authentication
             component from requesting a delay should the authentication
             as a whole fail. The default action is for the module to
-            request a delay-on-failure of the order of two second.
+            request a delay-on-failure of the order of two seconds.
           </para>
         </listitem>
       </varlistentry>
@@ -397,7 +397,7 @@
         <listitem>
           <para>
             Set a minimum password length of <replaceable>n</replaceable>
-            characters. The max. for DES crypt based passwords are 8
+            characters. The max. for DES crypt based passwords is 8
             characters.
           </para>
         </listitem>
@@ -459,7 +459,7 @@
       <programlisting>
 # Authenticate the user
 auth       required   pam_unix.so
-# Ensure users account and password are still active
+# Ensure user's account and password are still active
 account    required   pam_unix.so
 # Change the user's password, but at first check the strength
 # with pam_passwdqc(8)


### PR DESCRIPTION
Typos in comments and in documentation fixed.