### PR TITLE
pam_unix: do not truncate user names

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -1190,16 +1190,12 @@ char *
 getuidname(uid_t uid)
 {
         struct passwd *pw;
-        static char username[256];
 
         pw = getpwuid(uid);
         if (pw == NULL)
                 return NULL;
 
-        strncpy(username, pw->pw_name, sizeof(username));
-        username[sizeof(username) - 1] = '\0';
-
-        return username;
+        return pw->pw_name;
 }
 
 #endif

--- a/modules/pam_unix/unix_chkpwd.c
+++ b/modules/pam_unix/unix_chkpwd.c
@@ -138,11 +138,11 @@ int main(int argc, char *argv[])
 	  /* if the caller specifies the username, verify that user
 	     matches it */
 	  if (user == NULL || strcmp(user, argv[1])) {
-	    user = argv[1];
 	    /* no match -> permanently change to the real user and proceed */
 	    if (setuid(getuid()) != 0)
 		return PAM_AUTH_ERR;
 	  }
+	  user = argv[1];
 	}
 
 	option=argv[2];


### PR DESCRIPTION
This could allow users with very long names to impersonate a user with a 255 characters long name.

The check if the argument argv[1] actually matches the user name implies that "user" can unconditionally be set to argv[1]: If they are equal, the strings are obviously equal. If they are not or if null is returned by getuidname, "user" is set to argv[1] anyway.

This way, the static buffer can be safely removed because the result of getpwuid() is not stored, which means that subsequent calls to such functions can safely overwrite their internal buffers.

It would be difficult to justify this as a proper security issue, therefor a public PR. It takes a user name with 256+ characters which starts with the same 255 characters of another user who must have exactly 255 characters.

Also, having such long names as home directories would lead to issues reading shadow entries with glibc, therefor it also takes a special useradd call.

And all that for having a chance to test passwords against the hash of another user...

Nevertheless, it can be provoked. Even if it's just for educational purpose and for testing the PR.

Proof of Concept (run as root):
```
USER1=$(python -c 'print(255*"a")')
USER2=$(python -c 'print(255*"a"+"b")')

useradd -d /home/user1 $USER1
useradd -d /home/user2 $USER2
passwd $USER1

for PASSWD in "abc" "123"
do
  echo -e "$PASSWD\0" | sudo -u $USER2 /tmp/unix_chkpwd $USER1 "nonull"
  echo "result of password $PASSWD: $?"
done
```

If you enter the password "123" for $USER1, then $USER2 can successfully test against it. You can see an output like:
```
New password:
Retype new password:
passwd: password updated successfully
result of password abc: 7
result of password 123: 0
```
7 is PAM_PERM_DENIED (bad password), 0 is PAM_SUCCESS (correct password).

With the PR applied, you see:
```
New password:
Retype new password:
passwd: password updated successfully
result of password abc: 9
result of password 123: 9
```
9 is PAM_AUTH_ERR, which is great.