### PR TITLE
treewide: support building outside of source directory

### DIFF
--- a/Make.xml.rules.in
+++ b/Make.xml.rules.in
@@ -9,18 +9,18 @@ README: README.xml
 
 %.1: %.1.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_builddir)/doc/custom-man.xsl $<
 
 %.3: %.3.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_builddir)/doc/custom-man.xsl $<
 
 %.5: %.5.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_builddir)/doc/custom-man.xsl $<
 
 %.8: %.8.xml
 	$(XMLLINT) --nonet --xinclude --relaxng $(DOCBOOK_RNG) --noout $<
-	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_srcdir)/doc/custom-man.xsl $<
+	$(XSLTPROC) -o $@ --path $(srcdir) --xinclude @STRINGPARAM_VENDORDIR@ @STRINGPARAM_PROFILECONDITIONS@ --nonet $(top_builddir)/doc/custom-man.xsl $<
 
 #CLEANFILES += $(man_MANS) README

--- a/configure.ac
+++ b/configure.ac
@@ -263,9 +263,10 @@ AC_ARG_ENABLE(txt_stylesheet,
 	TXT_STYLESHEET=$enableval, TXT_STYLESHEET=http://docbook.sourceforge.net/release/xsl-ns/current/html/docbook.xsl)
 
 
+${MKDIR_P} doc
 AC_SUBST(TXT_STYLESHEET)
 # It has to be TXT_STYLESHEET otherwise a html tree will be generated while generating all README files.
-sed "s+HTML_STYLESHEET+$TXT_STYLESHEET+g" <doc/custom-html.xsl.in >doc/custom-html.xsl
+sed "s+HTML_STYLESHEET+$TXT_STYLESHEET+g" <$srcdir/doc/custom-html.xsl.in >doc/custom-html.xsl
 
 AC_ARG_ENABLE(pdf_stylesheet,
 	AS_HELP_STRING([--enable-pdf-stylesheet=FILE],[pdf stylesheet path @<:@default=http://docbook.sourceforge.net/release/xsl-ns/current/fo/docbook.xsl@:>@]),
@@ -278,7 +279,7 @@ AC_ARG_ENABLE(man_stylesheet,
 
 
 AC_SUBST(MAN_STYLESHEET)
-sed "s+MAN_STYLESHEET+$MAN_STYLESHEET+g" <doc/custom-man.xsl.in >doc/custom-man.xsl
+sed "s+MAN_STYLESHEET+$MAN_STYLESHEET+g" <$srcdir/doc/custom-man.xsl.in >doc/custom-man.xsl
 
 AC_ARG_ENABLE(securedir,
 	AS_HELP_STRING([--enable-securedir=DIR],[path to location of PAMs @<:@default=$libdir/security@:>@]),

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,7 @@
 
 SUBDIRS = man specs sag adg mwg
 
-CLEANFILES = *~
+CLEANFILES = *~ custom-html.xsl custom-man.xsl
 
 dist_html_DATA = index.html
 

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -59,5 +59,5 @@ pam.d.5: pam.conf.5
 pam_get_item.3: pam_item_types_std.inc.xml pam_item_types_ext.inc.xml
 pam_set_data.3: pam_item_types_std.inc.xml pam_item_types_ext.inc.xml
 pam.conf.5: pam.conf-desc.xml pam.conf-dir.xml pam.conf-syntax.xml
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -54,7 +54,6 @@ pam_vinfo.3: pam_info.3
 pam_vprompt.3: pam_prompt.3
 pam_vsyslog.3: pam_syslog.3
 pam.d.5: pam.conf.5
-	test -f $(srcdir)/pam\\.d.5 && mv $(srcdir)/pam\\.d.5 $(srcdir)/pam.d.5 ||:
 
 pam_get_item.3: pam_item_types_std.inc.xml pam_item_types_ext.inc.xml
 pam_set_data.3: pam_item_types_std.inc.xml pam_item_types_ext.inc.xml

--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -35,5 +35,5 @@ dist_secureconf_DATA = access.conf
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_canonicalize_user/Makefile.am
+++ b/modules/pam_canonicalize_user/Makefile.am
@@ -33,5 +33,5 @@ tst_pam_canonicalize_user_retval_LDFLAGS = -Wl,--export-dynamic
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_debug/Makefile.am
+++ b/modules/pam_debug/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_debug_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_deny/Makefile.am
+++ b/modules/pam_deny/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_deny_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_echo/Makefile.am
+++ b/modules/pam_echo/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_echo_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -39,6 +39,6 @@ dist_sysconf_DATA = environment
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
-environment.5: pam_env.conf.5.xml
+environment.5: pam_env.conf.5
 -include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -40,5 +40,5 @@ dist_sysconf_DATA = environment
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
 environment.5: pam_env.conf.5.xml
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_exec/Makefile.am
+++ b/modules/pam_exec/Makefile.am
@@ -33,5 +33,5 @@ pam_exec_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_faildelay/Makefile.am
+++ b/modules/pam_faildelay/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_faildelay_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_faillock/Makefile.am
+++ b/modules/pam_faillock/Makefile.am
@@ -53,5 +53,5 @@ faillock_SOURCES = main.c faillock.c faillock_config.c
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_filter/Makefile.am
+++ b/modules/pam_filter/Makefile.am
@@ -37,5 +37,5 @@ securelib_LTLIBRARIES = pam_filter.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_ftp/Makefile.am
+++ b/modules/pam_ftp/Makefile.am
@@ -33,5 +33,5 @@ pam_ftp_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -35,5 +35,5 @@ dist_secureconf_DATA = group.conf
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_issue/Makefile.am
+++ b/modules/pam_issue/Makefile.am
@@ -33,5 +33,5 @@ pam_issue_la_LIBADD = $(top_builddir)/libpam/libpam.la $(SYSTEMD_LIBS)
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_keyinit/Makefile.am
+++ b/modules/pam_keyinit/Makefile.am
@@ -33,5 +33,5 @@ pam_keyinit_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_lastlog/Makefile.am
+++ b/modules/pam_lastlog/Makefile.am
@@ -33,5 +33,5 @@ pam_lastlog_la_LIBADD = $(top_builddir)/libpam/libpam.la -lutil
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -40,5 +40,5 @@ install-data-local:
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_listfile/Makefile.am
+++ b/modules/pam_listfile/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_listfile_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_localuser/Makefile.am
+++ b/modules/pam_localuser/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_localuser_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_loginuid/Makefile.am
+++ b/modules/pam_loginuid/Makefile.am
@@ -33,5 +33,5 @@ pam_loginuid_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBAUDIT@
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_mail/Makefile.am
+++ b/modules/pam_mail/Makefile.am
@@ -33,5 +33,5 @@ pam_mail_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_mkhomedir/Makefile.am
+++ b/modules/pam_mkhomedir/Makefile.am
@@ -44,5 +44,5 @@ tst_pam_mkhomedir_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_motd/Makefile.am
+++ b/modules/pam_motd/Makefile.am
@@ -33,5 +33,5 @@ pam_motd_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -48,5 +48,5 @@ sbin_SCRIPTS = pam_namespace_helper
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_nologin/Makefile.am
+++ b/modules/pam_nologin/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_nologin_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_permit/Makefile.am
+++ b/modules/pam_permit/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_permit_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -51,5 +51,5 @@ tst_pam_pwhistory_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_rhosts/Makefile.am
+++ b/modules/pam_rhosts/Makefile.am
@@ -33,5 +33,5 @@ pam_rhosts_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_rootok/Makefile.am
+++ b/modules/pam_rootok/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_rootok_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_securetty/Makefile.am
+++ b/modules/pam_securetty/Makefile.am
@@ -33,5 +33,5 @@ pam_securetty_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_selinux/Makefile.am
+++ b/modules/pam_selinux/Makefile.am
@@ -37,5 +37,5 @@ pam_selinux_check_LDADD = $(top_builddir)/libpam/libpam.la \
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_sepermit/Makefile.am
+++ b/modules/pam_sepermit/Makefile.am
@@ -44,5 +44,5 @@ install-data-local:
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_setquota/Makefile.am
+++ b/modules/pam_setquota/Makefile.am
@@ -29,5 +29,5 @@ pam_setquota_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -33,5 +33,5 @@ pam_shells_la_LIBADD = $(top_builddir)/libpam/libpam.la $(ECONF_LIBS)
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_stress/Makefile.am
+++ b/modules/pam_stress/Makefile.am
@@ -32,5 +32,5 @@ pam_stress_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_succeed_if/Makefile.am
+++ b/modules/pam_succeed_if/Makefile.am
@@ -33,5 +33,5 @@ pam_succeed_if_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -37,5 +37,5 @@ tst_pam_time_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_timestamp/Makefile.am
+++ b/modules/pam_timestamp/Makefile.am
@@ -57,5 +57,5 @@ endif
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_tty_audit/Makefile.am
+++ b/modules/pam_tty_audit/Makefile.am
@@ -28,5 +28,5 @@ securelib_LTLIBRARIES = pam_tty_audit.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_umask/Makefile.am
+++ b/modules/pam_umask/Makefile.am
@@ -33,5 +33,5 @@ pam_umask_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -79,5 +79,5 @@ endif
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_userdb/Makefile.am
+++ b/modules/pam_userdb/Makefile.am
@@ -35,5 +35,5 @@ noinst_HEADERS = pam_userdb.h
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_usertype/Makefile.am
+++ b/modules/pam_usertype/Makefile.am
@@ -34,5 +34,5 @@ pam_usertype_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_warn/Makefile.am
+++ b/modules/pam_warn/Makefile.am
@@ -36,5 +36,5 @@ tst_pam_warn_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_wheel/Makefile.am
+++ b/modules/pam_wheel/Makefile.am
@@ -33,5 +33,5 @@ pam_wheel_la_LIBADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif

--- a/modules/pam_xauth/Makefile.am
+++ b/modules/pam_xauth/Makefile.am
@@ -33,5 +33,5 @@ pam_xauth_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBSELINUX@
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README
--include $(top_srcdir)/Make.xml.rules
+-include $(top_builddir)/Make.xml.rules
 endif


### PR DESCRIPTION
If build directory is not equal to the source directory, building documentation fails:
```
mkdir build
cd build
../configure
make
```

This happens because some of the Makefile.am files and configure.ac do not strictly separate their logics between srcdir and builddir for source files and generated files.

This PR allows the build to complete even if `--disable-doc` is omitted. There is still an issue if some of the requirements for document generation are not met, but that would not fit into this PR.