### PR TITLE
pam_env: allow escaping of escape character

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -607,7 +607,7 @@ _expand_arg(pam_handle_t *pamh, char **value)
   while (*orig) {     /* while there is some input to deal with */
     if ('\\' == *orig) {
       ++orig;
-      if ('$' != *orig && '@' != *orig) {
+      if ('$' != *orig && '@' != *orig && '\\' != *orig) {
 	D(("Unrecognized escaped character: <%c> - ignoring", *orig));
 	pam_syslog(pamh, LOG_ERR,
 		   "Unrecognized escaped character: <%c> - ignoring",

--- a/modules/pam_env/tst-pam_env-retval.c
+++ b/modules/pam_env/tst-pam_env-retval.c
@@ -73,7 +73,7 @@ setup(void)
 			     "PAGER\tDEFAULT=more\n"
 			     "# ignore escaped newlines in comments \\\n"
 			     "NAME\tDEFAULT=@{PAM_\\ \t\n"
-			     "USER}\n"));
+			     "USER}\\\\name\n"));
 	ASSERT_EQ(0, fclose(fp));
 
 	ASSERT_NE(NULL, fp = fopen(my_env, "w"));
@@ -234,7 +234,7 @@ main(void)
 			     cwd, my_conf, "/dev/null"));
 	ASSERT_EQ(0, fclose(fp));
 
-	const char *env1[] = { "EDITOR=vim", "PAGER=more", "NAME=user", NULL };
+	const char *env1[] = { "EDITOR=vim", "PAGER=more", "NAME=user\\name", NULL };
 	check_env(env1);
 
 	/*


### PR DESCRIPTION
Otherwise it is not possible to add \ into an environment variable.