### PR TITLE
pam_listfile: treat \r like \n

### DIFF
--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -284,14 +284,9 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
     while(getline(&aline,&n,inf) != -1 && retval) {
 	const char *a = aline;
 
-	if(strlen(aline) == 0)
+	aline[strcspn(aline, "\r\n")] = '\0';
+	if(aline[0] == '\0')
 	    continue;
-	if(aline[strlen(aline) - 1] == '\n')
-	    aline[strlen(aline) - 1] = '\0';
-	if(strlen(aline) == 0)
-	    continue;
-	if(aline[strlen(aline) - 1] == '\r')
-	    aline[strlen(aline) - 1] = '\0';
 	if(citem == PAM_TTY) {
 	    const char *str = pam_str_skip_prefix(a, "/dev/");
 	    if (str != NULL)


### PR DESCRIPTION
The characters \r and \n are replaced by NUL byte. Treat a line which is empty after removal of \r just like lines which are empty after the removal of \n.