### PR TITLE
pam_access: add quiet_log option

### DIFF
--- a/modules/pam_access/pam_access.8.xml
+++ b/modules/pam_access/pam_access.8.xml
@@ -29,6 +29,9 @@
         noaudit
       </arg>
       <arg choice="opt" rep="norepeat">
+        quiet_log
+      </arg>
+      <arg choice="opt" rep="norepeat">
         accessfile=<replaceable>file</replaceable>
       </arg>
       <arg choice="opt" rep="norepeat">
@@ -125,6 +128,18 @@
         <listitem>
           <para>
             Do not report logins from disallowed hosts and ttys to the audit subsystem.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          quiet_log
+        </term>
+        <listitem>
+          <para>
+            Do not log denials with
+            <citerefentry><refentrytitle>syslog</refentrytitle><manvolnum>3</manvolnum></citerefentry>.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -99,6 +99,7 @@ struct login_info {
     int debug;				/* Print debugging messages. */
     int only_new_group_syntax;		/* Only allow group entries of the form "(xyz)" */
     int noaudit;			/* Do not audit denials */
+    int quiet_log;			/* Do not log denials */
     const char *fs;			/* field separator */
     const char *sep;			/* list-element separator */
     int from_remote_host;               /* If PAM_RHOST was used for from */
@@ -115,6 +116,7 @@ parse_args(pam_handle_t *pamh, struct login_info *loginfo,
     int i;
 
     loginfo->noaudit = NO;
+    loginfo->quiet_log = NO;
     loginfo->debug = NO;
     loginfo->only_new_group_syntax = NO;
     loginfo->fs = ":";
@@ -150,6 +152,8 @@ parse_args(pam_handle_t *pamh, struct login_info *loginfo,
 	    loginfo->only_new_group_syntax = YES;
 	} else if (strcmp (argv[i], "noaudit") == 0) {
 	    loginfo->noaudit = YES;
+	} else if (strcmp (argv[i], "quiet_log") == 0) {
+	    loginfo->quiet_log = YES;
 	} else {
 	    pam_syslog(pamh, LOG_ERR, "unrecognized option [%s]", argv[i]);
 	}
@@ -1105,8 +1109,10 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
     if (rv) {
 	return (PAM_SUCCESS);
     } else {
-	pam_syslog(pamh, LOG_ERR,
-                   "access denied for user `%s' from `%s'",user,from);
+	if (!loginfo.quiet_log) {
+	    pam_syslog(pamh, LOG_ERR,
+	               "access denied for user `%s' from `%s'",user,from);
+	}
 	return (PAM_PERM_DENIED);
     }
 }


### PR DESCRIPTION
This pull request adds a quiet_log option to pam_access. If quiet_log is set, no "access denied" message is written to the syslog. Closes #706.