### PR TITLE
modules: do not call pam_sm_authenticate

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -977,9 +977,8 @@ network_netmask_match (pam_handle_t *pamh,
 
 /* --- public PAM management functions --- */
 
-int
-pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
-		     int argc, const char **argv)
+static int
+pam_access(pam_handle_t *pamh, int argc, const char **argv)
 {
     struct login_info loginfo;
     const char *user=NULL;
@@ -1125,31 +1124,38 @@ pam_sm_setcred (pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 int
-pam_sm_acct_mgmt (pam_handle_t *pamh, int flags,
-		  int argc, const char **argv)
-{
-  return pam_sm_authenticate (pamh, flags, argc, argv);
-}
-
-int
-pam_sm_open_session(pam_handle_t *pamh, int flags,
+pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
 		    int argc, const char **argv)
 {
-  return pam_sm_authenticate(pamh, flags, argc, argv);
+  return pam_access(pamh, argc, argv);
 }
 
 int
-pam_sm_close_session(pam_handle_t *pamh, int flags,
-		     int argc, const char **argv)
-{
-  return pam_sm_authenticate(pamh, flags, argc, argv);
-}
-
-int
-pam_sm_chauthtok(pam_handle_t *pamh, int flags,
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
 		 int argc, const char **argv)
 {
-  return pam_sm_authenticate(pamh, flags, argc, argv);
+  return pam_access(pamh, argc, argv);
+}
+
+int
+pam_sm_open_session(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
+{
+  return pam_access(pamh, argc, argv);
+}
+
+int
+pam_sm_close_session(pam_handle_t *pamh, int flags UNUSED,
+		     int argc, const char **argv)
+{
+  return pam_access(pamh, argc, argv);
+}
+
+int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
+{
+  return pam_access(pamh, argc, argv);
 }
 
 /* end of module definition */

--- a/modules/pam_lastlog/pam_lastlog.c
+++ b/modules/pam_lastlog/pam_lastlog.c
@@ -665,9 +665,8 @@ cleanup:
 }
 
 /* --- authentication (locking out inactive users) functions --- */
-int
-pam_sm_authenticate(pam_handle_t *pamh, int flags,
-		    int argc, const char **argv)
+static int
+pam_auth(pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
     int retval, ctrl;
     const char *user = NULL;
@@ -742,10 +741,17 @@ pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 int
+pam_sm_authenticate(pam_handle_t *pamh, int flags,
+		    int argc, const char **argv)
+{
+    return pam_auth(pamh, flags, argc, argv);
+}
+
+int
 pam_sm_acct_mgmt(pam_handle_t *pamh, int flags,
 		    int argc, const char **argv)
 {
-    return pam_sm_authenticate(pamh, flags, argc, argv);
+    return pam_auth(pamh, flags, argc, argv);
 }
 
 /* --- session management functions --- */

--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -44,9 +44,8 @@
 
 #define LESSER(a, b) ((a) < (b) ? (a) : (b))
 
-int
-pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
-		     int argc, const char **argv)
+static int
+pam_listfile(pam_handle_t *pamh, int argc, const char **argv)
 {
     int retval = -1;
     int onerr = PAM_SERVICE_ERR;
@@ -353,36 +352,43 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
 }
 
 int
-pam_sm_setcred (pam_handle_t *pamh UNUSED, int flags UNUSED,
-		int argc UNUSED, const char **argv UNUSED)
+pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
+{
+    return pam_listfile(pamh, argc, argv);
+}
+
+int
+pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
+	       int argc UNUSED, const char **argv UNUSED)
 {
     return PAM_SUCCESS;
 }
 
 int
-pam_sm_acct_mgmt (pam_handle_t *pamh, int flags,
-		  int argc, const char **argv)
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
 {
-    return pam_sm_authenticate(pamh, flags, argc, argv);
+    return pam_listfile(pamh, argc, argv);
 }
 
 int
-pam_sm_open_session (pam_handle_t *pamh, int flags,
+pam_sm_open_session(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
+{
+    return pam_listfile(pamh, argc, argv);
+}
+
+int
+pam_sm_close_session(pam_handle_t *pamh, int flags UNUSED,
 		     int argc, const char **argv)
 {
-    return pam_sm_authenticate(pamh, flags, argc, argv);
+    return pam_listfile(pamh, argc, argv);
 }
 
 int
-pam_sm_close_session (pam_handle_t *pamh, int flags,
-		      int argc, const char **argv)
+pam_sm_chauthtok(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
 {
-    return pam_sm_authenticate(pamh, flags, argc, argv);
-}
-
-int
-pam_sm_chauthtok (pam_handle_t *pamh, int flags,
-		  int argc, const char **argv)
-{
-    return pam_sm_authenticate(pamh, flags, argc, argv);
+    return pam_listfile(pamh, argc, argv);
 }

--- a/modules/pam_localuser/pam_localuser.c
+++ b/modules/pam_localuser/pam_localuser.c
@@ -49,9 +49,8 @@
 #include <security/pam_ext.h>
 #include "pam_inline.h"
 
-int
-pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
-		    int argc, const char **argv)
+static int
+pam_localuser(pam_handle_t *pamh, int argc, const char **argv)
 {
 	int i;
 	int rc;
@@ -102,25 +101,36 @@ pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 int
-pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_localuser(pamh, argc, argv);
 }
 
 int
-pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_localuser(pamh, argc, argv);
 }
 
 int
-pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_open_session(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_localuser(pamh, argc, argv);
 }
 
 int
-pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_close_session(pam_handle_t *pamh, int flags UNUSED,
+		     int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_localuser(pamh, argc, argv);
+}
+
+int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
+{
+	return pam_localuser(pamh, argc, argv);
 }

--- a/modules/pam_sepermit/pam_sepermit.c
+++ b/modules/pam_sepermit/pam_sepermit.c
@@ -371,9 +371,8 @@ sepermit_match(pam_handle_t *pamh, const char *cfgfile, const char *user,
 		return -1;
 }
 
-int
-pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
-		    int argc, const char **argv)
+static int
+pam_sepermit(pam_handle_t *pamh, int argc, const char **argv)
 {
 	int i;
 	int rv;
@@ -460,8 +459,15 @@ pam_sm_setcred (pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 int
-pam_sm_acct_mgmt(pam_handle_t *pamh, int flags,
-		     int argc, const char **argv)
+pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_sepermit(pamh, argc, argv);
+}
+
+int
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
+{
+	return pam_sepermit(pamh, argc, argv);
 }

--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -445,9 +445,8 @@ evaluate(pam_handle_t *pamh, int debug,
 	return PAM_SERVICE_ERR;
 }
 
-int
-pam_sm_authenticate (pam_handle_t *pamh, int flags UNUSED,
-		     int argc, const char **argv)
+static int
+pam_succeed_if(pam_handle_t *pamh, int argc, const char **argv)
 {
 	const char *user;
 	struct passwd *pwd = NULL;
@@ -587,25 +586,36 @@ pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 int
-pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_succeed_if(pamh, argc, argv);
 }
 
 int
-pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_succeed_if(pamh, argc, argv);
 }
 
 int
-pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_open_session(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_succeed_if(pamh, argc, argv);
 }
 
 int
-pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_close_session(pam_handle_t *pamh, int flags UNUSED,
+		     int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_succeed_if(pamh, argc, argv);
+}
+
+int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
+{
+	return pam_succeed_if(pamh, argc, argv);
 }

--- a/modules/pam_usertype/pam_usertype.c
+++ b/modules/pam_usertype/pam_usertype.c
@@ -255,9 +255,8 @@ pam_usertype_evaluate(struct pam_usertype_opts *opts,
  * - use_uid: use user that runs application not that is being authenticate (same as in pam_succeed_if)
  * - audit: log unknown users to syslog
  */
-int
-pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
-                    int argc, const char **argv)
+static int
+pam_usertype(pam_handle_t *pamh, int argc, const char **argv)
 {
     struct pam_usertype_opts opts;
     uid_t uid = -1;
@@ -284,25 +283,36 @@ pam_sm_setcred(pam_handle_t *pamh UNUSED, int flags UNUSED,
 }
 
 int
-pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_usertype(pamh, argc, argv);
 }
 
 int
-pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_acct_mgmt(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_usertype(pamh, argc, argv);
 }
 
 int
-pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_open_session(pam_handle_t *pamh, int flags UNUSED,
+		    int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_usertype(pamh, argc, argv);
 }
 
 int
-pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+pam_sm_close_session(pam_handle_t *pamh, int flags UNUSED,
+		     int argc, const char **argv)
 {
-	return pam_sm_authenticate(pamh, flags, argc, argv);
+	return pam_usertype(pamh, argc, argv);
+}
+
+int
+pam_sm_chauthtok(pam_handle_t *pamh, int flags UNUSED,
+		 int argc, const char **argv)
+{
+	return pam_usertype(pamh, argc, argv);
 }


### PR DESCRIPTION
Calling an exported function from the module is unsafe as there is no guarantee that the function that will be actually called is the one that is provided by the module.
