### PR TITLE
treewide: remove unused defines

### DIFF
--- a/libpam/pam_modutil_searchkey.c
+++ b/libpam/pam_modutil_searchkey.c
@@ -17,8 +17,6 @@
 #include <libeconf.h>
 #endif
 
-#define BUF_SIZE 8192
-
 #ifdef USE_ECONF
 #define LOGIN_DEFS "/etc/login.defs"
 

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -57,9 +57,6 @@ typedef struct var {
 #define VENDOR_DEFAULT_CONF_FILE (VENDOR_SCONFIGDIR "/pam_env.conf")
 #endif
 
-#define BUF_SIZE 8192
-#define MAX_ENV  8192
-
 #define GOOD_LINE    0
 #define BAD_LINE     100       /* This must be > the largest PAM_* error code */
 

--- a/modules/pam_faillock/faillock_config.h
+++ b/modules/pam_faillock/faillock_config.h
@@ -56,7 +56,6 @@
 #define FAILLOCK_FLAG_LOCAL_ONLY	0x20
 #define FAILLOCK_FLAG_NO_DELAY		0x40
 
-#define FAILLOCK_CONF_MAX_LINELEN 	1023
 #define MAX_TIME_INTERVAL			604800 /* 7 days */
 
 struct options {

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -78,8 +78,6 @@
 
 #define DEFAULT_OLD_PASSWORDS_FILE SCONFIGDIR "/opasswd"
 
-#define DEFAULT_BUFLEN 4096
-
 typedef struct {
   char *user;
   char *uid;


### PR DESCRIPTION
These are leftovers from fgets usages.