### PR TITLE
pam_succeed_if: handle long and illegal values

### DIFF
--- a/modules/pam_succeed_if/Makefile.am
+++ b/modules/pam_succeed_if/Makefile.am
@@ -12,7 +12,7 @@ dist_man_MANS = pam_succeed_if.8
 endif
 XMLS = README.xml pam_succeed_if.8.xml
 dist_check_SCRIPTS = tst-pam_succeed_if
-TESTS = $(dist_check_SCRIPTS)
+TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
 securelibdir = $(SECUREDIR)
 if HAVE_VENDORDIR
@@ -30,6 +30,9 @@ endif
 
 securelib_LTLIBRARIES = pam_succeed_if.la
 pam_succeed_if_la_LIBADD = $(top_builddir)/libpam/libpam.la
+
+check_PROGRAMS = tst-pam_succeed_if-retval
+tst_pam_succeed_if_retval_LDADD = $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -70,13 +70,13 @@ evaluate_num(const pam_handle_t *pamh, const char *left,
 
 	errno = 0;
 	l = strtoll(left, &p, 0);
-	if ((p == NULL) || (*p != '\0') || errno) {
+	if ((p == NULL) || (*p != '\0') || (p == left) || errno) {
 		pam_syslog(pamh, LOG_INFO, "\"%s\" is not a number", left);
 		ret = PAM_SERVICE_ERR;
 	}
 
 	r = strtoll(right, &p, 0);
-	if ((p == NULL) || (*p != '\0') || errno) {
+	if ((p == NULL) || (*p != '\0') || (p == right) || errno) {
 		pam_syslog(pamh, LOG_INFO, "\"%s\" is not a number", right);
 		ret = PAM_SERVICE_ERR;
 	}

--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -292,7 +292,7 @@ evaluate(pam_handle_t *pamh, int debug,
 	 const char *left, const char *qual, const char *right,
 	 struct passwd **pwd, const char *user)
 {
-	char buf[LINE_MAX] = "";
+	char numstr[sizeof(long) * 3 + 1] = "";
 	const char *attribute = left;
 	/* Get information about the user if needed. */
 	if ((*pwd == NULL) &&
@@ -311,54 +311,47 @@ evaluate(pam_handle_t *pamh, int debug,
 	if ((strcasecmp(left, "login") == 0) ||
 	    (strcasecmp(left, "name") == 0) ||
 	    (strcasecmp(left, "user") == 0)) {
-		snprintf(buf, sizeof(buf), "%s", user);
-		left = buf;
+		left = user;
 	} else if (strcasecmp(left, "uid") == 0) {
-		snprintf(buf, sizeof(buf), "%lu", (unsigned long) (*pwd)->pw_uid);
-		left = buf;
+		snprintf(numstr, sizeof(numstr), "%lu",
+			(unsigned long) (*pwd)->pw_uid);
+		left = numstr;
 	} else if (strcasecmp(left, "gid") == 0) {
-		snprintf(buf, sizeof(buf), "%lu", (unsigned long) (*pwd)->pw_gid);
-		left = buf;
+		snprintf(numstr, sizeof(numstr), "%lu",
+			(unsigned long) (*pwd)->pw_gid);
+		left = numstr;
 	} else if (strcasecmp(left, "shell") == 0) {
-		snprintf(buf, sizeof(buf), "%s", (*pwd)->pw_shell);
-		left = buf;
+		left = (*pwd)->pw_shell;
 	} else if ((strcasecmp(left, "home") == 0) ||
 	    (strcasecmp(left, "dir") == 0) ||
 	    (strcasecmp(left, "homedir") == 0)) {
-		snprintf(buf, sizeof(buf), "%s", (*pwd)->pw_dir);
-		left = buf;
+		left = (*pwd)->pw_dir;
 	} else if (strcasecmp(left, "service") == 0) {
 		const void *svc;
 		if (pam_get_item(pamh, PAM_SERVICE, &svc) != PAM_SUCCESS ||
 			svc == NULL)
 			svc = "";
-		snprintf(buf, sizeof(buf), "%s", (const char *)svc);
-		left = buf;
+		left = (const char *)svc;
 	} else if (strcasecmp(left, "ruser") == 0) {
 		const void *ruser;
 		if (pam_get_item(pamh, PAM_RUSER, &ruser) != PAM_SUCCESS ||
 			ruser == NULL)
 			ruser = "";
-		snprintf(buf, sizeof(buf), "%s", (const char *)ruser);
-		left = buf;
-		user = buf;
+		left = (const char *)ruser;
 	} else if (strcasecmp(left, "rhost") == 0) {
 		const void *rhost;
 		if (pam_get_item(pamh, PAM_RHOST, &rhost) != PAM_SUCCESS ||
 			rhost == NULL)
 			rhost = "";
-		snprintf(buf, sizeof(buf), "%s", (const char *)rhost);
-		left = buf;
+		left = (const char *)rhost;
 	} else if (strcasecmp(left, "tty") == 0) {
 		const void *tty;
 		if (pam_get_item(pamh, PAM_TTY, &tty) != PAM_SUCCESS ||
 			tty == NULL)
 			tty = "";
-		snprintf(buf, sizeof(buf), "%s", (const char *)tty);
-		left = buf;
-	}
-	/* If we have no idea what's going on, return an error. */
-	if (left != buf) {
+		left = (const char *)tty;
+	} else {
+		/* If we have no idea what's going on, return an error. */
 		pam_syslog(pamh, LOG_ERR, "unknown attribute \"%s\"", left);
 		return PAM_SERVICE_ERR;
 	}

--- a/modules/pam_succeed_if/tst-pam_succeed_if-retval.c
+++ b/modules/pam_succeed_if/tst-pam_succeed_if-retval.c
@@ -1,0 +1,87 @@
+/*
+ * Check pam_succeed_if return values.
+ *
+ * Copyright (c) 2020 Dmitry V. Levin <ldv@altlinux.org>
+ * Copyright (c) 2024 Tobias Stoeckmann <tobias@stoeckmann.org>
+ */
+
+#include "test_assert.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <security/pam_appl.h>
+
+#define MODULE_NAME "pam_succeed_if"
+#define TEST_NAME "tst-" MODULE_NAME "-retval"
+
+static const char service_file[] = TEST_NAME ".service";
+static const char user_name[] = "name";
+static struct pam_conv conv;
+
+int
+main(void)
+{
+	pam_handle_t *pamh = NULL;
+	FILE *fp;
+	char cwd[PATH_MAX];
+
+	ASSERT_NE(NULL, getcwd(cwd, sizeof(cwd)));
+
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "#%%PAM-1.0\n"
+			     "auth required %s/.libs/%s.so user = name\n"
+			     "account required %s/.libs/%s.so user notin a:b\n"
+			     "password required %s/.libs/%s.so user in x:name\n"
+			     "session required %s/.libs/%s.so rhost eq 0\n",
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, user_name, &conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+	ASSERT_EQ(PAM_SUCCESS, pam_set_item(pamh, PAM_RHOST, "0"));
+
+	ASSERT_EQ(PAM_SUCCESS, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	ASSERT_EQ(0, unlink(service_file));
+
+	/* test some illegal conditions */
+	ASSERT_NE(NULL, fp = fopen(service_file, "w"));
+	ASSERT_LT(0, fprintf(fp, "#%%PAM-1.0\n"
+			     "auth required %s/.libs/%s.so user eq name\n"
+			     "account required %s/.libs/%s.so user in a:b\n"
+			     "password required %s/.libs/%s.so user notin x:name\n"
+			     "session required %s/.libs/%s.so rhost eq []\n",
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME,
+			     cwd, MODULE_NAME));
+	ASSERT_EQ(0, fclose(fp));
+
+	ASSERT_EQ(PAM_SUCCESS,
+		  pam_start_confdir(service_file, user_name, &conv, ".", &pamh));
+	ASSERT_NE(NULL, pamh);
+
+	ASSERT_EQ(PAM_SERVICE_ERR, pam_authenticate(pamh, 0));
+	ASSERT_EQ(PAM_AUTH_ERR, pam_acct_mgmt(pamh, 0));
+	ASSERT_EQ(PAM_AUTH_ERR, pam_chauthtok(pamh, 0));
+	ASSERT_EQ(PAM_SERVICE_ERR, pam_open_session(pamh, 0));
+	ASSERT_EQ(PAM_SERVICE_ERR, pam_close_session(pamh, 0));
+	ASSERT_EQ(PAM_SUCCESS, pam_end(pamh, 0));
+	pamh = NULL;
+
+	ASSERT_EQ(0, unlink(service_file));
+
+	return 0;
+}


### PR DESCRIPTION
This PR prevents truncation of very long fields like user, rhost etc. These items can be set by pam_set_item and are therefor not purely related to the feature of arbitrarily long configuration lines.

Also empty strings should not be treated as the numerical value 0.

For easier testing and verification, I have added a new unit test file.