### PR TITLE
pam_pwhistory: build pwhistory_helper only with SELinux enabled

### DIFF
--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -9,10 +9,17 @@ MAINTAINERCLEANFILES = $(MANS) README
 EXTRA_DIST = $(XMLS)
 
 if HAVE_DOC
-dist_man_MANS = pam_pwhistory.8 pwhistory_helper.8 pwhistory.conf.5
+dist_man_MANS = pam_pwhistory.8 pwhistory.conf.5
+if WITH_SELINUX
+dist_man_MANS += pwhistory_helper.8
 endif
-XMLS = README.xml pam_pwhistory.8.xml pwhistory_helper.8.xml \
-  pwhistory.conf.5.xml
+endif
+
+XMLS = README.xml pam_pwhistory.8.xml pwhistory.conf.5.xml
+if WITH_SELINUX
+XMLS += pwhistory_helper.8.xml
+endif
+
 dist_check_SCRIPTS = tst-pam_pwhistory
 TESTS = $(dist_check_SCRIPTS) $(check_PROGRAMS)
 
@@ -40,11 +47,13 @@ pam_pwhistory_la_CFLAGS = $(AM_CFLAGS)
 pam_pwhistory_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@ @LIBSELINUX@
 pam_pwhistory_la_SOURCES = pam_pwhistory.c opasswd.c pwhistory_config.c
 
+if WITH_SELINUX
 sbin_PROGRAMS = pwhistory_helper
 pwhistory_helper_CFLAGS = $(AM_CFLAGS) -DHELPER_COMPILE=\"pwhistory_helper\" @EXE_CFLAGS@
 pwhistory_helper_SOURCES = pwhistory_helper.c opasswd.c
 pwhistory_helper_LDFLAGS = @EXE_LDFLAGS@
 pwhistory_helper_LDADD = $(top_builddir)/libpam/libpam.la @LIBCRYPT@
+endif
 
 check_PROGRAMS = tst-pam_pwhistory-retval
 tst_pam_pwhistory_retval_LDADD = $(top_builddir)/libpam/libpam.la

--- a/modules/pam_pwhistory/pam_pwhistory.c
+++ b/modules/pam_pwhistory/pam_pwhistory.c
@@ -112,6 +112,7 @@ parse_option (pam_handle_t *pamh, const char *argv, options_t *options)
     pam_syslog (pamh, LOG_ERR, "pam_pwhistory: unknown option: %s", argv);
 }
 
+#ifdef WITH_SELINUX
 static int
 run_save_helper(pam_handle_t *pamh, const char *user,
 		int howmany, const char *filename, int debug)
@@ -287,6 +288,7 @@ run_check_helper(pam_handle_t *pamh, const char *user,
 
   return retval;
 }
+#endif
 
 /* This module saves the current hashed password in /etc/security/opasswd
    and then compares the new password with all entries in this file. */
@@ -332,8 +334,10 @@ pam_sm_chauthtok (pam_handle_t *pamh, int flags, int argc, const char **argv)
 
   retval = save_old_pass (pamh, user, options.remember, options.filename, options.debug);
 
+#ifdef WITH_SELINUX
   if (retval == PAM_PWHISTORY_RUN_HELPER)
       retval = run_save_helper(pamh, user, options.remember, options.filename, options.debug);
+#endif
 
   if (retval != PAM_SUCCESS)
     return retval;
@@ -366,8 +370,10 @@ pam_sm_chauthtok (pam_handle_t *pamh, int flags, int argc, const char **argv)
 	pam_syslog (pamh, LOG_DEBUG, "check against old password file");
 
       retval = check_old_pass (pamh, user, newpass, options.filename, options.debug);
+#ifdef WITH_SELINUX
       if (retval == PAM_PWHISTORY_RUN_HELPER)
 	  retval = run_check_helper(pamh, user, newpass, options.filename, options.debug);
+#endif
 
       if (retval != PAM_SUCCESS)
 	{


### PR DESCRIPTION
Apply the same logic of pam_unix Makefile adjustment for pw_history as well. Reference commit is
cb9f88ba944d56c0b6c65be18500f7d56c9f514c.

The helper pwhistory_helper(8) is only called from code enabled when SELinux support is enabled.

CC @cgzones: It would be nice if you could review this PR.