### PR TITLE
Annotate declaration with format attribute

### DIFF
--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -86,7 +86,6 @@ typedef struct {
 } opwd;
 
 #ifdef HELPER_COMPILE
-PAM_FORMAT((printf, 2, 3))
 void
 helper_log_err(int err, const char *format, ...)
 {

--- a/modules/pam_pwhistory/opasswd.h
+++ b/modules/pam_pwhistory/opasswd.h
@@ -54,6 +54,7 @@
 
 #ifdef HELPER_COMPILE
 void
+PAM_FORMAT((printf, 2, 3))
 helper_log_err(int err, const char *format, ...);
 #endif
 

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -1132,7 +1132,6 @@ helper_verify_password(const char *name, const char *p, int nullok)
 }
 
 void
-PAM_FORMAT((printf, 2, 3))
 helper_log_err(int err, const char *format, ...)
 {
 	va_list args;

--- a/modules/pam_unix/passverify.h
+++ b/modules/pam_unix/passverify.h
@@ -37,6 +37,7 @@ save_old_password(pam_handle_t *pamh, const char *forwho, const char *oldpass,
 
 #ifdef HELPER_COMPILE
 void
+PAM_FORMAT((printf, 2, 3))
 helper_log_err(int err, const char *format,...);
 
 int


### PR DESCRIPTION
Instead of annotating the function definition with the format attribute
annotate the declaration, so the annotation is visible at call sites.