### PR TITLE
pam_unix: fix regressions

### DIFF
--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -660,7 +660,6 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
 			 user);
 		return PAM_USER_UNKNOWN;
 	}
-	_pam_drop(pwd);
 
 	/*
 	 * This is not an AUTH module!

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -729,7 +729,7 @@ save_old_password(pam_handle_t *pamh, const char *forwho, const char *oldpass,
 	goto done;
     }
 
-    while (getline(&buf, &bufsize, opwfile) == -1) {
+    while (getline(&buf, &bufsize, opwfile) != -1) {
 	if (!strncmp(buf, forwho, len) && strchr(":,\n", buf[len]) != NULL) {
 	    char *ep, *sptr = NULL;
 	    long value;


### PR DESCRIPTION
The returned value stored in pwd from _unix_getpwnam is inserted into
pam handler through pam_set_data. Do not manually free the value.

Also check getline return value for != -1 instead of == -1.

Fixes 8f2ca5919b26843ef774ef0aeb9bf261dec943a0 and
73d009e9ea8edafc18c7fe3650b25dd6bdce88c1. No release affected.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>