### PR TITLE
pam_unix: do not allow comma as field separator

### DIFF
--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -351,14 +351,13 @@ static int check_old_password(const char *forwho, const char *newpass)
 		return PAM_ABORT;
 
 	for (; getline(&buf, &n, opwfile) != -1; pam_overwrite_n(buf, n)) {
-		if (!strncmp(buf, forwho, len) && (buf[len] == ':' ||
-			buf[len] == ',')) {
+		if (!strncmp(buf, forwho, len) && buf[len] == ':') {
 			char *sptr;
 			buf[strlen(buf) - 1] = '\0';
-			/* s_luser = */ strtok_r(buf, ":,", &sptr);
-			/* s_uid = */ strtok_r(NULL, ":,", &sptr);
-			/* s_npas = */ strtok_r(NULL, ":,", &sptr);
-			s_pas = strtok_r(NULL, ":,", &sptr);
+			/* s_luser = */ strtok_r(buf, ":", &sptr);
+			/* s_uid = */ strtok_r(NULL, ":", &sptr);
+			/* s_npas = */ strtok_r(NULL, ":", &sptr);
+			s_pas = strtok_r(NULL, ",", &sptr);
 			while (s_pas != NULL) {
 				char *md5pass = Goodcrypt_md5(newpass, s_pas);
 				if (md5pass == NULL || !strcmp(md5pass, s_pas)) {
@@ -366,7 +365,7 @@ static int check_old_password(const char *forwho, const char *newpass)
 					retval = PAM_AUTHTOK_ERR;
 					break;
 				}
-				s_pas = strtok_r(NULL, ":,", &sptr);
+				s_pas = strtok_r(NULL, ",", &sptr);
 				_pam_delete(md5pass);
 			}
 			break;

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -730,7 +730,7 @@ save_old_password(pam_handle_t *pamh, const char *forwho, const char *oldpass,
     }
 
     for (; getline(&buf, &bufsize, opwfile) != -1; pam_overwrite_n(buf, bufsize)) {
-	if (!strncmp(buf, forwho, len) && strchr(":,\n", buf[len]) != NULL) {
+	if (!strncmp(buf, forwho, len) && strchr(":\n", buf[len]) != NULL) {
 	    char *ep, *sptr = NULL;
 	    long value;
 	    found = 1;
@@ -752,7 +752,7 @@ save_old_password(pam_handle_t *pamh, const char *forwho, const char *oldpass,
 		found = 0;
 		continue;
 	    }
-	    s_pas = strtok_r(NULL, ":", &sptr);
+	    s_pas = strtok_r(NULL, "", &sptr);
 	    value = strtol(s_npas, &ep, 10);
 	    if (value < 0 || value >= INT_MAX || s_npas == ep || *ep != '\0')
 		npas = 0;


### PR DESCRIPTION
The opasswd file shall not use comma as a separator. Enforce colon just like pam_pwhistory does as well.

A comma can be part of a user name, although its usage is discouraged. If such a user exists, it could happen that stored passwords of another user are checked.

Potentially dangerous use of `,` separator spotted with @BenBE.

Proof of Concept:
1. Use `remember` option in /etc/pam.d/passwd:
```
password  required    pam_unix.so       shadow try_first_pass remember=10
```
2. Create `/etc/security/opasswd` file
```
install /dev/null -m 600 /etc/security/opasswd
```
3. Create user `a,b` and set its password three times (first two will be added to /etc/security/opasswd eventually)
```
useradd --badname a,b
passwd a,b           # e.g. "abc"
sudo -u a,b passwd   # e.g. "def"
sudo -u a,b passwd   # e.g. "123"
```
4. Create user `a` and set its password two times (first one passes because it's run by root)
```
useradd a
passwd a             # e.g. "abc"
sudo -u a passwd     # second password of a,b (in this example "def")
```

The user `a` cannot set the password `def` because it was already used by user `a,b`.