### PR TITLE
pam_pwhistory: parse opasswd lines verbatim

### DIFF
--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -169,23 +169,20 @@ check_old_pass, const char *user, const char *newpass, const char *filename, int
 
   while (!feof (oldpf))
     {
-      char *cp;
       ssize_t n = getline (&buf, &buflen, oldpf);
-
-      cp = buf;
 
       if (n < 1)
         break;
 
-      cp[strcspn(cp, "\n")] = '\0';
-      if (*cp == '\0')        /* ignore empty lines */
+      buf[strcspn(buf, "\n")] = '\0';
+      if (buf[0] == '\0')        /* ignore empty lines */
         continue;
 
-      if (strncmp (cp, user, strlen (user)) == 0 &&
-          cp[strlen (user)] == ':')
+      if (strncmp (buf, user, strlen (user)) == 0 &&
+          buf[strlen (user)] == ':')
         {
           /* We found the line we needed */
-	  if (parse_entry (cp, &entry) == 0)
+	  if (parse_entry (buf, &entry) == 0)
 	    {
 	      found = 1;
 	      break;
@@ -353,13 +350,12 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
   if (!do_create)
     while (!feof (oldpf))
       {
-	char *cp, *save;
+	char *save;
 	ssize_t n = getline (&buf, &buflen, oldpf);
 
 	if (n < 1)
 	  break;
 
-	cp = buf;
 	save = strdup (buf); /* Copy to write the original data back.  */
 	if (save == NULL)
           {
@@ -369,17 +365,17 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 	    goto error_opasswd;
           }
 
-	cp[strcspn(cp, "\n")] = '\0';
-	if (*cp == '\0')        /* ignore empty lines */
+	buf[strcspn(buf, "\n")] = '\0';
+	if (buf[0] == '\0')        /* ignore empty lines */
 	  goto write_old_data;
 
-	if (strncmp (cp, user, strlen (user)) == 0 &&
-	    cp[strlen (user)] == ':')
+	if (strncmp (buf, user, strlen (user)) == 0 &&
+	    buf[strlen (user)] == ':')
 	  {
 	    /* We found the line we needed */
 	    opwd entry;
 
-	    if (parse_entry (cp, &entry) == 0)
+	    if (parse_entry (buf, &entry) == 0)
 	      {
 		char *out = NULL;
 
@@ -388,9 +384,9 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 		/* Don't save the current password twice */
 		if (entry.old_passwords && entry.old_passwords[0] != '\0')
 		  {
-		    char *last = entry.old_passwords;
+		    char *cp = entry.old_passwords;
+		    char *last = cp;
 
-		    cp = entry.old_passwords;
 		    entry.count = 1;  /* Don't believe the count */
 		    while ((cp = strchr (cp, ',')) != NULL)
 		      {

--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -169,7 +169,7 @@ check_old_pass, const char *user, const char *newpass, const char *filename, int
 
   while (!feof (oldpf))
     {
-      char *cp, *tmp;
+      char *cp;
       ssize_t n = getline (&buf, &buflen, oldpf);
 
       cp = buf;
@@ -177,15 +177,9 @@ check_old_pass, const char *user, const char *newpass, const char *filename, int
       if (n < 1)
         break;
 
-      tmp = strchr (cp, '#');  /* remove comments */
-      if (tmp)
-        *tmp = '\0';
-      while (isspace ((unsigned char)*cp))    /* remove spaces and tabs */
-        ++cp;
+      cp[strcspn(cp, "\n")] = '\0';
       if (*cp == '\0')        /* ignore empty lines */
         continue;
-
-      cp[strcspn(cp, "\n")] = '\0';
 
       if (strncmp (cp, user, strlen (user)) == 0 &&
           cp[strlen (user)] == ':')
@@ -359,7 +353,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
   if (!do_create)
     while (!feof (oldpf))
       {
-	char *cp, *tmp, *save;
+	char *cp, *save;
 	ssize_t n = getline (&buf, &buflen, oldpf);
 
 	if (n < 1)
@@ -375,15 +369,9 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 	    goto error_opasswd;
           }
 
-	tmp = strchr (cp, '#');  /* remove comments */
-	if (tmp)
-	  *tmp = '\0';
-	while (isspace ((unsigned char)*cp))    /* remove spaces and tabs */
-	  ++cp;
+	cp[strcspn(cp, "\n")] = '\0';
 	if (*cp == '\0')        /* ignore empty lines */
 	  goto write_old_data;
-
-	cp[strcspn(cp, "\n")] = '\0';
 
 	if (strncmp (cp, user, strlen (user)) == 0 &&
 	    cp[strlen (user)] == ':')


### PR DESCRIPTION
Users may have a hash character in their name, which would be removed. This in turn effectively defeats the purpose of pam_pwhistory for the user.

Proof of Concept:
1. Use pam_pwhistory as suggested in its manual page in /etc/pam.d/passwd:
```
password     required       pam_pwhistory.so
password     required       pam_unix.so        use_authtok shadow
```
2. Create user `a#b` and set its password twice
```
useradd --badname a#b
passwd a#b             # e.g. "abc"
passwd a#b             # e.g. "def"
```
3. Try to use the first password again
```
passwd a#b             # first password (in this example "abc")
```

The password should not be accepted. Yet, every call adds a new line to /etc/security/opasswd instead, because the removal of comments makes the lines unparseable for pam_pwhistory.