### PR TITLE
modules: do not invoke getline(3) unnecessarily

### DIFF
--- a/modules/pam_listfile/pam_listfile.c
+++ b/modules/pam_listfile/pam_listfile.c
@@ -307,7 +307,7 @@ pam_listfile(pam_handle_t *pamh, int argc, const char **argv)
     assert(PAM_SUCCESS == 0);
     assert(PAM_AUTH_ERR != 0);
 #endif
-    while(getline(&aline,&n,inf) != -1 && retval) {
+    while(retval && getline(&aline,&n,inf) != -1) {
 	const char *a = aline;
 
 	aline[strcspn(aline, "\r\n")] = '\0';

--- a/modules/pam_securetty/pam_securetty.c
+++ b/modules/pam_securetty/pam_securetty.c
@@ -157,8 +157,7 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
 
     retval = 1;
 
-    while ((getline(&ttyfileline, &ttyfilelinelen, ttyfile) != -1)
-	   && retval) {
+    while (retval && getline(&ttyfileline, &ttyfilelinelen, ttyfile) != -1) {
 	ttyfileline[strcspn(ttyfileline, "\n")] = '\0';
 
 	retval = ( strcmp(ttyfileline, uttyname)


### PR DESCRIPTION
Replace
```
while (getline(...) != -1 && retval)
```
with
```
while (retval && getline(...) != -1)
```

* modules/pam_listfile/pam_listfile.c (pam_listfile): Do not invoke getline(3) when its result is going to be ignored.
* modules/pam_securetty/pam_securetty.c (securetty_perform_check): Likewise.