### PR TITLE
modules: zero out crypt_r(3) data before usage

### DIFF
--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -127,9 +127,7 @@ compare_password(const char *newpass, const char *oldpass)
   char *outval;
   int retval;
 #ifdef HAVE_CRYPT_R
-  struct crypt_data output;
-
-  output.initialized = 0;
+  struct crypt_data output = { 0 };
 
   outval = crypt_r (newpass, oldpass, &output);
 #else

--- a/modules/pam_unix/bigcrypt.c
+++ b/modules/pam_unix/bigcrypt.c
@@ -67,12 +67,11 @@ char *bigcrypt(const char *key, const char *salt)
 		return NULL;
 	}
 #ifdef HAVE_CRYPT_R
-	cdata = malloc(sizeof(*cdata));
+	cdata = calloc(1, sizeof(*cdata));
 	if(!cdata) {
 		free(dec_c2_cryptbuf);
 		return NULL;
 	}
-	cdata->initialized = 0;
 #endif
 
 	/* fill KEYBUF_SIZE with key */

--- a/modules/pam_unix/bigcrypt.c
+++ b/modules/pam_unix/bigcrypt.c
@@ -109,6 +109,7 @@ char *bigcrypt(const char *key, const char *salt)
 		pam_overwrite_array(keybuf);
 		free(dec_c2_cryptbuf);
 #ifdef HAVE_CRYPT_R
+		pam_overwrite_object(cdata);
 		free(cdata);
 #endif
 		return NULL;

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -144,9 +144,8 @@ PAMH_ARG_DECL(int verify_pwd_hash,
 #endif
 #ifdef HAVE_CRYPT_R
 			struct crypt_data *cdata;
-			cdata = malloc(sizeof(*cdata));
+			cdata = calloc(1, sizeof(*cdata));
 			if (cdata != NULL) {
-				cdata->initialized = 0;
 				pp = x_strdup(crypt_r(p, hash, cdata));
 				pam_overwrite_object(cdata);
 				free(cdata);
@@ -503,9 +502,8 @@ PAMH_ARG_DECL(char * create_password_hash,
 #endif /* CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY */
 #ifdef HAVE_CRYPT_R
 	sp = NULL;
-	cdata = malloc(sizeof(*cdata));
+	cdata = calloc(1, sizeof(*cdata));
 	if (cdata != NULL) {
-		cdata->initialized = 0;
 		sp = crypt_r(password, salt, cdata);
 	}
 #else

--- a/modules/pam_userdb/pam_userdb.c
+++ b/modules/pam_userdb/pam_userdb.c
@@ -309,6 +309,7 @@ user_lookup (pam_handle_t *pamh, const char *database, const char *cryptmode,
 	        }
 	      }
 #ifdef HAVE_CRYPT_R
+	      pam_overwrite_object(cdata);
 	      free(cdata);
 #endif
 	    }

--- a/modules/pam_userdb/pam_userdb.c
+++ b/modules/pam_userdb/pam_userdb.c
@@ -287,11 +287,10 @@ user_lookup (pam_handle_t *pamh, const char *database, const char *cryptmode,
 	    } else {
 #ifdef HAVE_CRYPT_R
 	      struct crypt_data *cdata = NULL;
-	      cdata = malloc(sizeof(*cdata));
+	      cdata = calloc(1, sizeof(*cdata));
 	      if (cdata == NULL) {
 	        pam_syslog(pamh, LOG_CRIT, "malloc failed: struct crypt_data");
 	      } else {
-	        cdata->initialized = 0;
 	        cryptpw = crypt_r(pass, pwhash, cdata);
 	      }
 #else


### PR DESCRIPTION
The manual page of crypt_r(3) recommends to zero the entire data object.