### PR TITLE
Two build system tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -549,9 +549,11 @@ LOGIND_CFLAGS=
 SYSTEMD_LIBS=
 AC_ARG_ENABLE([logind],
   AS_HELP_STRING([--disable-logind], [Disable logind support]),
-  [WITH_LOGIND=$enableval], [WITH_LOGIND=yes])
-if test "$WITH_LOGIND" = "yes"; then
+  [WITH_LOGIND=$enableval], [WITH_LOGIND=check])
+if test "$WITH_LOGIND" = "check"; then
   PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 254], [LOGIND_CFLAGS="-DUSE_LOGIND=1 $SYSTEMD_CFLAGS"], [:])
+elif test "$WITH_LOGIND" = "yes"; then
+  PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 254], [LOGIND_CFLAGS="-DUSE_LOGIND=1 $SYSTEMD_CFLAGS"], [])
 fi
 AC_SUBST([LOGIND_CFLAGS])
 AC_SUBST([SYSTEMD_LIBS])

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,8 @@
 
 SUBDIRS = man specs sag adg mwg
 
-CLEANFILES = *~ custom-html.xsl custom-man.xsl
+CLEANFILES = *~
+DISTCLEANFILES = custom-html.xsl custom-man.xsl
 
 dist_html_DATA = index.html
 


### PR DESCRIPTION
* configure: require libsystemd on --enable-logind

  Fail if `--enable-logind` is specified while libsystemd cannot be found, so the feature is reliably enabled on success.

* doc: do not clean bootstrapped files

  The two files custom-html.xsl and custom-man.xsl are created at configure time.  Only delete them on `make distclean` instead of `make clean` to be able to re-generate manual pages afterwards.