### PR TITLE
Prepare for 1.6.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,46 @@
 Linux-PAM NEWS -- history of user-visible changes.
 
+Release 1.6.0
+* Added support of configuration files with arbitrarily long lines.
+* build: fixed build outside of the source tree.
+* libpam: added use of getrandom(2) as a source of randomness if available.
+* libpam: fixed calculation of fail delay with very long delays.
+* libpam: fixed potential infinite recursion with includes.
+* libpam: implemented string to number conversions validation when parsing
+  controls in configuration.
+* pam_access: added quiet_log option.
+* pam_access: fixed truncation of very long group names.
+* pam_canonicalize_user: new module to canonicalize user name.
+* pam_echo: fixed file handling to prevent overflows and short reads.
+* pam_env: added support of '\' character in environment variable values.
+* pam_exec: allowed expose_authtok for password PAM_TYPE.
+* pam_exec: fixed stack overflow with binary output of programs.
+* pam_faildelay: implemented parameter ranges validation.
+* pam_listfile: changed to treat \r and \n exactly the same in configuration.
+* pam_mkhomedir: hardened directory creation against timing attacks.
+  Please note that using *at functions leads to more open file handles
+  during creation.
+* pam_namespace: fixed potential local DoS (CVE-2024-22365).
+* pam_nologin: fixed file handling to prevent short reads.
+* pam_pwhistory: helper binary is now built only if SELinux support is enabled.
+* pam_pwhistory: implemented reliable usernames handling when remembering
+  passwords.
+* pam_shells: changed to allow shell entries with absolute paths only.
+* pam_succeed_if: fixed treating empty strings as numerical value 0.
+* pam_unix: added support of disabled password aging.
+* pam_unix: synchronized password aging with shadow.
+* pam_unix: implemented string to number conversions validation.
+* pam_unix: fixed truncation of very long user names.
+* pam_unix: corrected rounds retrieval for configured encryption method.
+* pam_unix: implemented reliable usernames handling when remembering passwords.
+* pam_unix: changed to always run the helper to obtain shadow password entries.
+* pam_unix: unix_update helper binary is now built only if SELinux support
+  is enabled.
+* pam_unix: added audit support to unix_update helper.
+* pam_userdb: added gdbm support.
+* Multiple minor bug fixes, portability fixes, documentation improvements,
+  and translation updates.
+
 Release 1.5.3
 * configure: added options to configure stylesheets.
 * configure: added --enable-logind option to use logind instead of utmp

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([Linux-PAM], [1.5.3], , [Linux-PAM])
+AC_INIT([Linux-PAM], [1.6.0], , [Linux-PAM])
 AC_CONFIG_SRCDIR([conf/pam_conv1/pam_conv_y.y])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Wno-portability])

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -1201,7 +1201,7 @@ static int protect_dir(const char *path, mode_t mode, int do_mkdir,
 	int dfd = AT_FDCWD;
 	int dfd_next;
 	int save_errno;
-	int flags = O_RDONLY;
+	int flags = O_RDONLY | O_DIRECTORY;
 	int rv = -1;
 	struct stat st;
 
@@ -1253,22 +1253,6 @@ static int protect_dir(const char *path, mode_t mode, int do_mkdir,
 			goto error;
 		}
 		rv = openat(dfd, dir, flags);
-	}
-
-	if (rv != -1) {
-		if (fstat(rv, &st) != 0) {
-			save_errno = errno;
-			close(rv);
-			rv = -1;
-			errno = save_errno;
-			goto error;
-		}
-		if (!S_ISDIR(st.st_mode)) {
-			close(rv);
-			errno = ENOTDIR;
-			rv = -1;
-			goto error;
-		}
 	}
 
 	if (flags & O_NOFOLLOW) {

--- a/po/Linux-PAM.pot
+++ b/po/Linux-PAM.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Linux-PAM 1.5.3\n"
+"Project-Id-Version: Linux-PAM 1.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linux-pam/linux-pam/issues\n"
 "POT-Creation-Date: 2024-01-16 21:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
* configure.ac (AC_INIT): Raise version to 1.6.0.
* po/Linux-PAM.pot (Project-Id-Version): Likewise.
* NEWS: Update.

Resolves: https://github.com/linux-pam/linux-pam/issues/690