### PR TITLE
include stdint.h in pam_namespace.c

### DIFF
--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -34,6 +34,8 @@
 
 #define _ATFILE_SOURCE
 
+#include "config.h"
+#include <stdint.h>
 #include "pam_cc_compat.h"
 #include "pam_inline.h"
 #include "pam_namespace.h"


### PR DESCRIPTION
missing include causes compilation errors.

closes #733 