### PR TITLE
libpam: fix build with --enable-read-both-confs

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -500,7 +500,7 @@ int _pam_init_handlers(pam_handle_t *pamh)
 
 		if (pamh->confdir == NULL
 		    && (f = fopen(PAM_CONFIG,"r")) != NULL) {
-		    retval = _pam_parse_conf_file(pamh, f, NULL, PAM_T_ANY, 0, 1);
+		    retval = _pam_parse_conf_file(pamh, f, NULL, PAM_T_ANY, 0, 0, 1);
 		    fclose(f);
 		} else
 #endif /* PAM_READ_BOTH_CONFS */


### PR DESCRIPTION
If configure option --enable-read-both-confs is used, the build fails with 1.6.0 due to missing stack level depth argument passed to _pam_parse_conf_file.

Solves https://github.com/linux-pam/linux-pam/issues/736.