### PR TITLE
libpam_misc: use size_t for sizes

### DIFF
--- a/libpam_misc/help_env.c
+++ b/libpam_misc/help_env.c
@@ -22,10 +22,10 @@
 
 char **pam_misc_drop_env(char **dump)
 {
-    int i;
+    size_t i;
 
     for (i=0; dump[i] != NULL; ++i) {
-	D(("dump[%d]=`%s'", i, dump[i]));
+	D(("dump[%zu]=`%s'", i, dump[i]));
 	pam_overwrite_string(dump[i]);
 	_pam_drop(dump[i]);
     }


### PR DESCRIPTION
Theoretically the int might overflow. Use a size_t to protect this function which might be called from an application, because it is exposed through pam_misc.h header.