### PR TITLE
pam_unix: do not warn if password aging disabled

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -314,7 +314,6 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 	}
 	if (spent->sp_lstchg < 0) {
 		D(("password aging disabled"));
-		*daysleft = 0;
 		return PAM_SUCCESS;
 	}
 	if (curdays < spent->sp_lstchg) {


### PR DESCRIPTION
Later checks will print a warning if daysleft is 0. If password aging is disabled, leave daysleft at -1.

Fixes 9ebc14085a3ba253598cfaa0d3f0d76ea5ee8ccb.

Resolves https://github.com/linux-pam/linux-pam/issues/743