### PR TITLE
build: correctly set WITH_SELINUX conditional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -529,12 +529,12 @@ fi
 AC_ARG_ENABLE([selinux],
         AS_HELP_STRING([--disable-selinux],[do not use SELinux]),
         WITH_SELINUX=$enableval, WITH_SELINUX=yes)
-AM_CONDITIONAL([WITH_SELINUX], [test "$WITH_SELINUX" = "yes"])
 if test "$WITH_SELINUX" = "yes" ; then
   AC_CHECK_LIB([selinux],[getfilecon], LIBSELINUX="-lselinux", LIBSELINUX="")
 else
   LIBSELINUX=""
 fi
+AM_CONDITIONAL([WITH_SELINUX], [test -n "$LIBSELINUX"])
 AC_SUBST(LIBSELINUX)
 if test -n "$LIBSELINUX" ; then
     AC_DEFINE([WITH_SELINUX], 1, [Defined if SE Linux support is compiled in])


### PR DESCRIPTION
React on actual test if SELinux is available, not just if SELinux should be tested for.

Currently the supposedly disabled binaries are still installed even if SELinux is not available.

Fixes: cb9f88ba944d ("pam_unix: build unix_update only with SELinux enabled")

Reported here: https://wiki.linuxfromscratch.org/blfs/ticket/19142