### PR TITLE
pam_namespace: use sed instead of awk in namespace.init

### DIFF
--- a/modules/pam_namespace/namespace.init
+++ b/modules/pam_namespace/namespace.init
@@ -15,7 +15,7 @@ if [ "$3" = 1 ]; then
                 gid=$(echo "$passwd" | cut -f4 -d":")
                 cp -rT /etc/skel "$homedir"
                 chown -R "$user":"$gid" "$homedir"
-                mask=$(awk '/^UMASK/{gsub("#.*$", "", $2); print $2; exit}' /etc/login.defs)
+                mask=$(sed -E -n 's/^UMASK[[:space:]]+([^#[:space:]]+).*/\1/p' /etc/login.defs)
                 mode=$(printf "%o" $((0777 & ~mask)))
                 chmod ${mode:-700} "$homedir"
                 [ -x /sbin/restorecon ] && /sbin/restorecon -R "$homedir"


### PR DESCRIPTION
Given that sed is considered a more lightweight dependency than awk, and since sed is used by pam_namespace_helper anyway, use sed instead of awk in namespace.init as well.

* modules/pam_namespace/namespace.init: Use sed instead of awk to obtain the UMASK value from /etc/login.defs.