### PR TITLE
pam_faildelay: fix compilation warnings on 32bit platforms

### DIFF
--- a/modules/pam_faildelay/pam_faildelay.c
+++ b/modules/pam_faildelay/pam_faildelay.c
@@ -101,7 +101,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
 	const char *val = pam_str_skip_prefix (argv[i], "delay=");
 	if (val != NULL) {
 	  delay = parse_delay (val);
-	  if (delay < 0 || delay > UINT_MAX)
+	  if (delay < 0 || (unsigned long) delay > UINT_MAX)
 	    {
 	      pam_syslog (pamh, LOG_ERR, "%s (%s) not valid", argv[i], val);
 	      return PAM_IGNORE;
@@ -120,7 +120,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
 	  return PAM_IGNORE;
 
 	delay = parse_delay (val);
-	if (delay < 0 || delay > UINT_MAX / S_TO_MICROS)
+	if (delay < 0 || (unsigned long) delay > UINT_MAX / S_TO_MICROS)
 	  {
 	    pam_syslog (pamh, LOG_ERR, "FAIL_DELAY=%s in %s not valid",
 			val, LOGIN_DEFS);


### PR DESCRIPTION
Fix the following warning reported by gcc on 32bit platforms:
```
  pam_faildelay.c: In function 'pam_sm_authenticate':
  pam_faildelay.c:104:34: error: comparison of integer expressions of different signedness: 'long int' and 'unsigned int' [-Werror=sign-compare]
    104 |           if (delay < 0 || delay > UINT_MAX)
        |                                  ^
  pam_faildelay.c:123:32: error: comparison of integer expressions of different signedness: 'long int' and 'unsigned int' [-Werror=sign-compare]
    123 |         if (delay < 0 || delay > UINT_MAX / S_TO_MICROS)
        |                                ^
```
* modules/pam_faildelay/pam_faildelay.c (pam_sm_authenticate): Cast "delay" to "unsigned long" in comparisons with unsigned int.

Fixes: dd87776d3683 ("pam_faildelay: validate parameter ranges")