### PR TITLE
modules: add pamc headers to the search path only when needed

### DIFF
--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS =  -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_canonicalize_user/Makefile.am
+++ b/modules/pam_canonicalize_user/Makefile.am
@@ -17,8 +17,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 
 securelib_LTLIBRARIES = pam_canonicalize_user.la
 pam_canonicalize_user_la_LIBADD = $(top_builddir)/libpam/libpam.la

--- a/modules/pam_debug/Makefile.am
+++ b/modules/pam_debug/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_deny/Makefile.am
+++ b/modules/pam_deny/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_echo/Makefile.am
+++ b/modules/pam_echo/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -21,8 +21,8 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS) -DSYSCONFDIR=\"$(sysconfdir)\" $(ECONF_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) \
+	    -DSYSCONFDIR=\"$(sysconfdir)\" $(ECONF_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_exec/Makefile.am
+++ b/modules/pam_exec/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_faildelay/Makefile.am
+++ b/modules/pam_faildelay/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_faillock/Makefile.am
+++ b/modules/pam_faillock/Makefile.am
@@ -26,8 +26,7 @@ endif
 
 noinst_HEADERS = faillock.h faillock_config.h
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 
 faillock_CFLAGS = $(AM_CFLAGS) @EXE_CFLAGS@
 

--- a/modules/pam_filter/Makefile.am
+++ b/modules/pam_filter/Makefile.am
@@ -23,8 +23,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_filter/upperLOWER/Makefile.am
+++ b/modules/pam_filter/upperLOWER/Makefile.am
@@ -7,7 +7,7 @@ CLEANFILES = *~
 securelibfilterdir = $(SECUREDIR)/pam_filter
 
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
+AM_CFLAGS = -I$(top_srcdir)/libpam/include \
 	-I$(srcdir)/.. @EXE_CFLAGS@ $(WARN_CFLAGS)
 AM_LDFLAGS = @EXE_LDFLAGS@
 LDADD = $(top_builddir)/libpam/libpam.la

--- a/modules/pam_ftp/Makefile.am
+++ b/modules/pam_ftp/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_issue/Makefile.am
+++ b/modules/pam_issue/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(LOGIND_CFLAGS) $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(LOGIND_CFLAGS) $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_keyinit/Makefile.am
+++ b/modules/pam_keyinit/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_lastlog/Makefile.am
+++ b/modules/pam_lastlog/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -22,7 +22,7 @@ secureconfdir = $(SCONFIGDIR)
 endif
 limits_conf_dir = $(SCONFIGDIR)/limits.d
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
+AM_CFLAGS = -I$(top_srcdir)/libpam/include \
 	    -DLIMITS_FILE_DIR=\"$(limits_conf_dir)\" \
 	    $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module

--- a/modules/pam_listfile/Makefile.am
+++ b/modules/pam_listfile/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_localuser/Makefile.am
+++ b/modules/pam_localuser/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_loginuid/Makefile.am
+++ b/modules/pam_loginuid/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_mail/Makefile.am
+++ b/modules/pam_mail/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_mkhomedir/Makefile.am
+++ b/modules/pam_mkhomedir/Makefile.am
@@ -22,7 +22,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
+AM_CFLAGS = -I$(top_srcdir)/libpam/include \
 	-DMKHOMEDIR_HELPER=\"$(sbindir)/mkhomedir_helper\" $(WARN_CFLAGS)
 
 securelib_LTLIBRARIES = pam_mkhomedir.la

--- a/modules/pam_motd/Makefile.am
+++ b/modules/pam_motd/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_namespace/Makefile.am
+++ b/modules/pam_namespace/Makefile.am
@@ -24,8 +24,7 @@ endif
 namespaceddir = $(SCONFIGDIR)/namespace.d
 servicedir = $(systemdunitdir)
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS =  -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_nologin/Makefile.am
+++ b/modules/pam_nologin/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_permit/Makefile.am
+++ b/modules/pam_permit/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_pwhistory/Makefile.am
+++ b/modules/pam_pwhistory/Makefile.am
@@ -30,8 +30,8 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS) -DPWHISTORY_HELPER=\"$(sbindir)/pwhistory_helper\"
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) \
+	-DPWHISTORY_HELPER=\"$(sbindir)/pwhistory_helper\"
 
 pam_pwhistory_la_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING

--- a/modules/pam_rhosts/Makefile.am
+++ b/modules/pam_rhosts/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_rootok/Makefile.am
+++ b/modules/pam_rootok/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_securetty/Makefile.am
+++ b/modules/pam_securetty/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_selinux/Makefile.am
+++ b/modules/pam_selinux/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-I$(top_srcdir)/libpam_misc/include $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 
 pam_selinux_la_LDFLAGS = -no-undefined -avoid-version -module
 pam_selinux_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBSELINUX@ @LIBAUDIT@
@@ -32,6 +31,8 @@ endif
 
 securelib_LTLIBRARIES = pam_selinux.la
 noinst_PROGRAMS = pam_selinux_check
+pam_selinux_check_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/libpamc/include \
+			   -I$(top_srcdir)/libpam_misc/include
 pam_selinux_check_LDADD = $(top_builddir)/libpam/libpam.la \
 			  $(top_builddir)/libpam_misc/libpam_misc.la
 

--- a/modules/pam_sepermit/Makefile.am
+++ b/modules/pam_sepermit/Makefile.am
@@ -23,8 +23,7 @@ secureconfdir = $(SCONFIGDIR)
 endif
 sepermitlockdir = ${localstatedir}/run/sepermit
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	-I$(top_srcdir)/libpam_misc/include \
+AM_CFLAGS = -I$(top_srcdir)/libpam/include \
 	-D SEPERMIT_LOCKDIR=\"$(sepermitlockdir)\" $(WARN_CFLAGS)
 
 pam_sepermit_la_LIBADD = $(top_builddir)/libpam/libpam.la @LIBSELINUX@

--- a/modules/pam_setquota/Makefile.am
+++ b/modules/pam_setquota/Makefile.am
@@ -17,8 +17,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS) $(ECONF_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) $(ECONF_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_stress/Makefile.am
+++ b/modules/pam_stress/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_succeed_if/Makefile.am
+++ b/modules/pam_succeed_if/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	    $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_timestamp/Makefile.am
+++ b/modules/pam_timestamp/Makefile.am
@@ -24,8 +24,7 @@ endif
 
 noinst_HEADERS = hmacsha1.h sha1.h hmac_openssl_wrapper.h
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(LOGIND_CFLAGS) $(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(LOGIND_CFLAGS) $(WARN_CFLAGS)
 
 pam_timestamp_la_LDFLAGS = -no-undefined -avoid-version -module $(AM_LDFLAGS) $(CRYPTO_LIBS)
 pam_timestamp_la_LIBADD = $(top_builddir)/libpam/libpam.la $(SYSTEMD_LIBS)

--- a/modules/pam_tty_audit/Makefile.am
+++ b/modules/pam_tty_audit/Makefile.am
@@ -16,8 +16,7 @@ TESTS = $(dist_check_SCRIPTS)
 
 securelibdir = $(SECUREDIR)
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_umask/Makefile.am
+++ b/modules/pam_umask/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -29,7 +29,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
+AM_CFLAGS = -I$(top_srcdir)/libpam/include \
 	-DCHKPWD_HELPER=\"$(sbindir)/unix_chkpwd\" \
 	-DUPDATE_HELPER=\"$(sbindir)/unix_update\" \
 	@TIRPC_CFLAGS@ @NSL_CFLAGS@ $(WARN_CFLAGS)

--- a/modules/pam_userdb/Makefile.am
+++ b/modules/pam_userdb/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module @LIBDB@ @LIBCRYPT@
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_usertype/Makefile.am
+++ b/modules/pam_usertype/Makefile.am
@@ -22,8 +22,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_warn/Makefile.am
+++ b/modules/pam_warn/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_wheel/Makefile.am
+++ b/modules/pam_wheel/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_xauth/Makefile.am
+++ b/modules/pam_xauth/Makefile.am
@@ -21,8 +21,7 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include -I$(top_srcdir)/libpamc/include \
-	$(WARN_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map


### PR DESCRIPTION
The pam client library libpamc is only needed if libpam_misc is in use. But libpam_misc is only used by an SELinux helper binary.

Remove the libpamc includes from search path in all other cases.

No functional change, but spotted while experimenting with ideas how to properly handle `pam_assemble_line` and the debug features which are currently stored in header files.