### PR TITLE
libpam_internal: supply debug functionality

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,8 @@
 
 AUTOMAKE_OPTIONS = 1.9 gnu dist-xz no-dist-gzip check-news
 
-SUBDIRS = libpam tests libpamc libpam_misc modules po conf xtests
+SUBDIRS = libpam_internal libpam tests libpamc libpam_misc modules po conf \
+	  xtests
 
 if HAVE_DOC
 SUBDIRS += doc

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ if test x"$enable_debug" = x"yes" ; then
    AC_DEFINE([PAM_DEBUG],,
 		[lots of stuff gets written to /var/run/pam-debug.log])
 fi
+AC_DEFINE([PAM_NO_HEADER_FUNCTIONS],1,[disable function bodies in headers])
 
 AC_ARG_ENABLE(docbook_rng,
 	AS_HELP_STRING([--enable-docbook-rng=FILE],[RNG file for checking XML files @<:@default=http://docbook.org/xml/5.0/rng/docbookxi.rng@:>@]),
@@ -777,8 +778,8 @@ AM_CONDITIONAL([COND_BUILD_PAM_USERDB], [test -n "$LIBDB"])
 
 dnl Files to be created from when we run configure
 AC_CONFIG_FILES([Makefile libpam/Makefile libpamc/Makefile libpamc/test/Makefile \
-	libpam_misc/Makefile conf/Makefile conf/pam_conv1/Makefile \
-	libpam/pam.pc libpam_misc/pam_misc.pc libpamc/pamc.pc \
+	libpam_internal/Makefile libpam_misc/Makefile conf/Makefile \
+	conf/pam_conv1/Makefile libpam/pam.pc libpam_misc/pam_misc.pc libpamc/pamc.pc \
 	po/Makefile.in \
 	Make.xml.rules \
 	modules/Makefile \

--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -23,7 +23,9 @@ noinst_HEADERS = pam_prelude.h pam_private.h pam_tokens.h \
 		include/test_assert.h
 
 libpam_la_LDFLAGS = -no-undefined -version-info 85:1:85
-libpam_la_LIBADD = @LIBAUDIT@ $(LIBPRELUDE_LIBS) $(ECONF_LIBS) @LIBDL@ @LTLIBINTL@
+libpam_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		   @LIBAUDIT@ $(LIBPRELUDE_LIBS) $(ECONF_LIBS) @LIBDL@ \
+		   @LTLIBINTL@
 
 if HAVE_VERSIONING
   libpam_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libpam.map

--- a/libpam/include/security/_pam_macros.h
+++ b/libpam/include/security/_pam_macros.h
@@ -94,11 +94,25 @@ do {                                              \
 #define _PAM_LOGFILE "/var/run/pam-debug.log"
 #endif
 
+#ifdef PAM_NO_HEADER_FUNCTIONS
+UNUSED
+extern void _pam_output_debug_info(const char *file, const char *fn
+				   , const int line);
+UNUSED
+PAM_FORMAT((printf, 1, 2))
+extern void _pam_output_debug(const char *format, ...);
+#else
+#ifdef PAM_DEBUG_C
+#define PAM_DEBUG_SCOPE
+#else
+#define PAM_DEBUG_SCOPE static
+#endif
+
 #ifdef UNUSED
 UNUSED
 #endif
-static void _pam_output_debug_info(const char *file, const char *fn
-				   , const int line)
+PAM_DEBUG_SCOPE void _pam_output_debug_info(const char *file, const char *fn
+					    , const int line)
 {
     FILE *logfile;
     int must_close = 1, fd;
@@ -127,7 +141,7 @@ static void _pam_output_debug_info(const char *file, const char *fn
 UNUSED
 #endif
 PAM_FORMAT((printf, 1, 2))
-static void _pam_output_debug(const char *format, ...)
+PAM_DEBUG_SCOPE void _pam_output_debug(const char *format, ...)
 {
     va_list args;
     FILE *logfile;
@@ -157,6 +171,8 @@ static void _pam_output_debug(const char *format, ...)
 
     va_end(args);
 }
+#undef PAM_DEBUG_SCOPE
+#endif
 
 #define D(x) do { \
     _pam_output_debug_info(__FILE__, __FUNCTION__, __LINE__); \

--- a/libpam_internal/Makefile.am
+++ b/libpam_internal/Makefile.am
@@ -1,0 +1,6 @@
+noinst_LTLIBRARIES = libpam_internal.la
+
+AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
+
+libpam_internal_la_SOURCES = \
+	pam_debug.c

--- a/libpam_internal/pam_debug.c
+++ b/libpam_internal/pam_debug.c
@@ -1,0 +1,21 @@
+/*
+ * This provides the necessary functions to do debugging in PAM.
+ * Cristian Gafton <gafton@redhat.com>
+ */
+
+#include "config.h"
+
+#ifdef PAM_DEBUG
+
+#include "security/_pam_macros.h"
+
+#undef PAM_MACROS_H
+#undef PAM_NO_HEADER_FUNCTIONS
+#define PAM_DEBUG_C 1
+#include "security/_pam_macros.h"
+
+#else
+
+extern int ISO_C_forbids_an_empty_translation_unit;
+
+#endif /* PAM_DEBUG */

--- a/libpam_misc/Makefile.am
+++ b/libpam_misc/Makefile.am
@@ -15,7 +15,8 @@ libpam_misc_la_LDFLAGS = -no-undefined -version-info 82:1:82
 if HAVE_VERSIONING
   libpam_misc_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libpam_misc.map
 endif
-libpam_misc_la_LIBADD = $(top_builddir)/libpam/libpam.la
+libpam_misc_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+			$(top_builddir)/libpam/libpam.la
 
 lib_LTLIBRARIES = libpam_misc.la
 

--- a/libpamc/Makefile.am
+++ b/libpamc/Makefile.am
@@ -18,6 +18,7 @@ libpamc_la_LDFLAGS = -no-undefined -version-info 82:1:82
 if HAVE_VERSIONING
   libpamc_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libpamc.map
 endif
+libpamc_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la
 
 lib_LTLIBRARIES = libpamc.la
 

--- a/modules/pam_access/Makefile.am
+++ b/modules/pam_access/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_access.la
-pam_access_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_access_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		       $(top_builddir)/libpam/libpam.la
 
 dist_secureconf_DATA = access.conf
 

--- a/modules/pam_debug/Makefile.am
+++ b/modules/pam_debug/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_debug.la
-pam_debug_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_debug_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		      $(top_builddir)/libpam/libpam.la
 
 check_PROGRAMS = tst-pam_debug-retval
 tst_pam_debug_retval_LDADD = $(top_builddir)/libpam/libpam.la

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -29,7 +29,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_env.la
-pam_env_la_LIBADD = $(top_builddir)/libpam/libpam.la $(ECONF_LIBS)
+pam_env_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		    $(top_builddir)/libpam/libpam.la $(ECONF_LIBS)
 
 check_PROGRAMS = tst-pam_env-retval
 tst_pam_env_retval_LDADD = $(top_builddir)/libpam/libpam.la

--- a/modules/pam_group/Makefile.am
+++ b/modules/pam_group/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_group.la
-pam_group_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_group_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		      $(top_builddir)/libpam/libpam.la
 
 dist_secureconf_DATA = group.conf
 

--- a/modules/pam_issue/Makefile.am
+++ b/modules/pam_issue/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_issue.la
-pam_issue_la_LIBADD = $(top_builddir)/libpam/libpam.la $(SYSTEMD_LIBS)
+pam_issue_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		      $(top_builddir)/libpam/libpam.la $(SYSTEMD_LIBS)
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_lastlog/Makefile.am
+++ b/modules/pam_lastlog/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_lastlog.la
-pam_lastlog_la_LIBADD = $(top_builddir)/libpam/libpam.la -lutil
+pam_lastlog_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+			$(top_builddir)/libpam/libpam.la -lutil
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_limits/Makefile.am
+++ b/modules/pam_limits/Makefile.am
@@ -31,7 +31,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_limits.la
-pam_limits_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_limits_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		       $(top_builddir)/libpam/libpam.la
 
 dist_secureconf_DATA = limits.conf
 

--- a/modules/pam_mail/Makefile.am
+++ b/modules/pam_mail/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_mail.la
-pam_mail_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_mail_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		     $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_mkhomedir/Makefile.am
+++ b/modules/pam_mkhomedir/Makefile.am
@@ -27,7 +27,8 @@ AM_CFLAGS = -I$(top_srcdir)/libpam/include \
 
 securelib_LTLIBRARIES = pam_mkhomedir.la
 pam_mkhomedir_la_SOURCES = pam_mkhomedir.c
-pam_mkhomedir_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_mkhomedir_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+			  $(top_builddir)/libpam/libpam.la
 pam_mkhomedir_la_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   pam_mkhomedir_la_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_motd/Makefile.am
+++ b/modules/pam_motd/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_motd.la
-pam_motd_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_motd_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		     $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_permit/Makefile.am
+++ b/modules/pam_permit/Makefile.am
@@ -28,7 +28,8 @@ if HAVE_VERSIONING
 endif
 
 securelib_LTLIBRARIES = pam_permit.la
-pam_permit_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_permit_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		       $(top_builddir)/libpam/libpam.la
 
 check_PROGRAMS = tst-pam_permit-retval
 tst_pam_permit_retval_LDADD = $(top_builddir)/libpam/libpam.la

--- a/modules/pam_stress/Makefile.am
+++ b/modules/pam_stress/Makefile.am
@@ -27,7 +27,8 @@ if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
 securelib_LTLIBRARIES = pam_stress.la
-pam_stress_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_stress_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		       $(top_builddir)/libpam/libpam.la
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_time/Makefile.am
+++ b/modules/pam_time/Makefile.am
@@ -26,7 +26,8 @@ AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
-pam_time_la_LIBADD = $(top_builddir)/libpam/libpam.la
+pam_time_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		     $(top_builddir)/libpam/libpam.la
 
 securelib_LTLIBRARIES = pam_time.la
 dist_secureconf_DATA = time.conf

--- a/modules/pam_unix/Makefile.am
+++ b/modules/pam_unix/Makefile.am
@@ -38,7 +38,8 @@ pam_unix_la_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   pam_unix_la_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
-pam_unix_la_LIBADD = $(top_builddir)/libpam/libpam.la \
+pam_unix_la_LIBADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+	$(top_builddir)/libpam/libpam.la \
 	@LIBCRYPT@ @LIBSELINUX@ @TIRPC_LIBS@ @NSL_LIBS@
 
 securelib_LTLIBRARIES = pam_unix.la
@@ -61,20 +62,22 @@ endif
 
 bigcrypt_SOURCES = bigcrypt.c bigcrypt_main.c
 bigcrypt_CFLAGS = $(AM_CFLAGS)
-bigcrypt_LDADD = @LIBCRYPT@
+bigcrypt_LDADD = $(top_builddir)/libpam_internal/libpam_internal.la @LIBCRYPT@
 
 unix_chkpwd_SOURCES = unix_chkpwd.c audit.c md5_good.c md5_broken.c bigcrypt.c \
 	passverify.c
 unix_chkpwd_CFLAGS = $(AM_CFLAGS) @EXE_CFLAGS@ -DHELPER_COMPILE=\"unix_chkpwd\"
 unix_chkpwd_LDFLAGS = @EXE_LDFLAGS@
-unix_chkpwd_LDADD = @LIBCRYPT@ @LIBSELINUX@ @LIBAUDIT@
+unix_chkpwd_LDADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		    @LIBCRYPT@ @LIBSELINUX@ @LIBAUDIT@
 
 if WITH_SELINUX
 unix_update_SOURCES = unix_update.c audit.c md5_good.c md5_broken.c bigcrypt.c \
 	passverify.c
 unix_update_CFLAGS = $(AM_CFLAGS) @EXE_CFLAGS@ -DHELPER_COMPILE=\"unix_update\"
 unix_update_LDFLAGS = @EXE_LDFLAGS@
-unix_update_LDADD = @LIBCRYPT@ @LIBSELINUX@ @LIBAUDIT@
+unix_update_LDADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+		    @LIBCRYPT@ @LIBSELINUX@ @LIBAUDIT@
 endif
 
 if ENABLE_REGENERATE_MAN

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,8 @@
 
 AM_CFLAGS = -DLIBPAM_COMPILE -I$(top_srcdir)/libpam/include \
 		-I$(top_srcdir)/libpam $(WARN_CFLAGS)
-LDADD = $(top_builddir)/libpam/libpam.la
+LDADD = $(top_builddir)/libpam_internal/libpam_internal.la \
+	$(top_builddir)/libpam/libpam.la
 
 CLEANFILES = *~
 
@@ -18,4 +19,4 @@ EXTRA_DIST = confdir
 
 check_PROGRAMS = ${TESTS} tst-dlopen
 
-tst_dlopen_LDADD = -ldl
+tst_dlopen_LDADD = $(top_builddir)/libpam_internal/libpam_internal.la -ldl


### PR DESCRIPTION
Move function bodies from headers into dedicated object files stored in libpam_internal. This library won't be installed.

Keep the debug function body in header, even though disabled when building Linux-PAM, to stay API compatible with previous versions.