### PR TITLE
doc: fix hrefs

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -12,9 +12,9 @@
       currently not complete.
     <p>
     <ul>
-      <li> <a href="Linux-PAM_SAG.html">The System Administrators' Guide</a>
-      <li> <a href="Linux-PAM_MWG.html">The Module Writers' Guide</a>
-      <li> <a href="Linux-PAM_ADG.html">The Application Developers' Guide</a>
+      <li> <a href="sag/html/Linux-PAM_SAG.html">The System Administrators' Guide</a>
+      <li> <a href="mwg/html/Linux-PAM_MWG.html">The Module Writers' Guide</a>
+      <li> <a href="adg/html/Linux-PAM_ADG.html">The Application Developers' Guide</a>
     </ul>
     <hr>
   </body>


### PR DESCRIPTION
Hi, I have no idea how should i build and open docs, but if I simply **make** it, the main [index.html](https://github.com/linux-pam/linux-pam/blob/master/doc/index.html) hrefs to wrong location.