### PR TITLE
libpam_internal: introduce pam_line

### DIFF
--- a/libpam/Makefile.am
+++ b/libpam/Makefile.am
@@ -3,7 +3,7 @@
 #
 
 AM_CFLAGS = -DDEFAULT_MODULE_PATH=\"$(SECUREDIR)/\" -DLIBPAM_COMPILE \
-	-DLOCALEDIR=\"$(localedir)\" \
+	-DLOCALEDIR=\"$(localedir)\" -I$(top_srcdir)/libpam_internal/include \
 	-I$(srcdir)/include $(LIBPRELUDE_CFLAGS) $(ECONF_CFLAGS) \
 	-DPAM_VERSION=\"$(VERSION)\" -DSYSCONFDIR=\"$(sysconfdir)\" \
 	$(WARN_CFLAGS)
@@ -18,7 +18,7 @@ include_HEADERS = include/security/_pam_compat.h \
 	include/security/pam_ext.h include/security/pam_modutil.h
 
 noinst_HEADERS = pam_prelude.h pam_private.h pam_tokens.h \
-		pam_modutil_private.h include/pam_assemble_line.h \
+		pam_modutil_private.h \
 		include/pam_cc_compat.h include/pam_inline.h \
 		include/test_assert.h
 

--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -18,7 +18,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include "pam_assemble_line.h"
+#include "pam_line.h"
 
 #define MODULE_CHUNK              4
 #define UNKNOWN_MODULE       "<*unknown module*>"
@@ -61,14 +61,14 @@ static int _pam_parse_conf_file(pam_handle_t *pamh, FILE *f
 #endif /* PAM_READ_BOTH_CONFS */
     )
 {
-    struct line_buffer buffer;
+    struct pam_line_buffer buffer;
     int x;                    /* read a line from the FILE *f ? */
 
-    _pam_buffer_init(&buffer);
+    _pam_line_buffer_init(&buffer);
     /*
      * read a line from the configuration (FILE *) f
      */
-    while ((x = _pam_assemble_line(f, &buffer, ' ')) > 0) {
+    while ((x = _pam_line_assemble(f, &buffer, ' ')) > 0) {
 	char *buf = buffer.assembled;
 	char *tok, *nexttok=NULL;
 	const char *this_service;

--- a/libpam_internal/Makefile.am
+++ b/libpam_internal/Makefile.am
@@ -1,6 +1,10 @@
 noinst_LTLIBRARIES = libpam_internal.la
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
+noinst_HEADERS = include/pam_line.h
+
+AM_CFLAGS = -I$(top_srcdir)/libpam_internal/include \
+	    -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
 
 libpam_internal_la_SOURCES = \
-	pam_debug.c
+	pam_debug.c \
+	pam_line.c

--- a/libpam_internal/include/pam_line.h
+++ b/libpam_internal/include/pam_line.h
@@ -1,0 +1,26 @@
+/* pam_line.h -- routine to parse configuration lines */
+
+#ifndef PAM_LINE_H
+#define PAM_LINE_H
+
+#include "pam_inline.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+struct pam_line_buffer {
+	char *assembled;
+	char *chunk;
+	size_t chunk_size;
+	size_t len;
+	size_t size;
+};
+
+void _pam_line_buffer_clear(struct pam_line_buffer *buffer);
+
+void _pam_line_buffer_init(struct pam_line_buffer *buffer);
+
+int _pam_line_assemble(FILE *f, struct pam_line_buffer *buffer, char repl);
+
+#endif /* PAM_LINE_H */

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -21,7 +21,8 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) \
+AM_CFLAGS = -I$(top_srcdir)/libpam_internal/include \
+	    -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) \
 	    -DSYSCONFDIR=\"$(sysconfdir)\" $(ECONF_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -31,7 +31,7 @@
 #include "pam_inline.h"
 
 #ifndef USE_ECONF
-#include "pam_assemble_line.h"
+#include "pam_line.h"
 #endif
 
 /* This little structure makes it easier to keep variables together */
@@ -316,9 +316,9 @@ econf_read_file(const pam_handle_t *pamh, const char *filename, const char *deli
 static int read_file(const pam_handle_t *pamh, const char*filename, char ***lines)
 {
     FILE *conf;
-    struct line_buffer buffer;
+    struct pam_line_buffer buffer;
 
-    _pam_buffer_init(&buffer);
+    _pam_line_buffer_init(&buffer);
 
     D(("Parsed file name is: %s", filename));
 
@@ -335,7 +335,7 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
       return PAM_BUF_ERR;
     }
     (*lines)[i] = 0;
-    while (_pam_assemble_line(conf, &buffer, '\0') > 0) {
+    while (_pam_line_assemble(conf, &buffer, '\0') > 0) {
       char *p = buffer.assembled;
       char **tmp = NULL;
       D(("Read line: %s", p));
@@ -344,7 +344,7 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
 	pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
 	(void) fclose(conf);
 	free_string_array(*lines);
-	_pam_buffer_clear(&buffer);
+	_pam_line_buffer_clear(&buffer);
 	return PAM_BUF_ERR;
       }
       *lines = tmp;
@@ -353,14 +353,14 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
         pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
         (void) fclose(conf);
         free_string_array(*lines);
-        _pam_buffer_clear(&buffer);
+        _pam_line_buffer_clear(&buffer);
         return PAM_BUF_ERR;
       }
       (*lines)[i] = 0;
     }
 
     (void) fclose(conf);
-    _pam_buffer_clear(&buffer);
+    _pam_line_buffer_clear(&buffer);
     return PAM_SUCCESS;
 }
 #endif


### PR DESCRIPTION
The pam_assemble_line function is renamed to pam_line_assemble and moved into libpam_internal so it can be shared across libpam and the pam_env module.

Applied renaming to all other relevant functions and data structures so it is easier to locate them in files.