### PR TITLE
pam_inline.h: Fix use of memset_explicit(3)

### DIFF
--- a/libpam/include/pam_inline.h
+++ b/libpam/include/pam_inline.h
@@ -82,7 +82,7 @@ pam_str_skip_icase_prefix_len(const char *str, const char *prefix, size_t prefix
 static inline void pam_overwrite_n(void *ptr, size_t len)
 {
 	if (ptr)
-		memset_explicit(ptr, len);
+		memset_explicit(ptr, '\0', len);
 }
 #elif defined HAVE_EXPLICIT_BZERO
 static inline void pam_overwrite_n(void *ptr, size_t len)


### PR DESCRIPTION
That function is being added to C23 with the same prototype as `memset(3)`:

    void* memset_explicit(void*, int, size_t);

Unlike `bzero(3)`, it accepts the fill byte as an argument.

Fixes: 19a292681789 ("libpam: introduce secure memory erasure helpers")