### PR TITLE
pam_limits: reject malformed numeric values

### DIFF
--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -550,7 +550,6 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
     int int_value = 0;
     rlim_t rlimit_value = 0;
     char *endptr;
-    const char *value_orig = lim_value;
 
     if (ctrl & PAM_DEBUG_ARG)
 	 pam_syslog(pamh, LOG_DEBUG, "%s: processing %s %s %s for %s",
@@ -654,7 +653,7 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 		temp = strtol (lim_value, &endptr, 10);
 		temp = temp < INT_MAX ? temp : INT_MAX;
 		int_value = temp > INT_MIN ? temp : INT_MIN;
-		if (int_value == 0 && value_orig == endptr) {
+		if (int_value == 0 && lim_value == endptr) {
 			pam_syslog(pamh, LOG_DEBUG,
 				   "wrong limit value '%s' for limit type '%s'",
 				   lim_value, lim_type);
@@ -666,7 +665,7 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 #else
 		rlimit_value = strtoul (lim_value, &endptr, 10);
 #endif
-		if (rlimit_value == 0 && value_orig == endptr) {
+		if (*endptr != '\0' || *lim_value == '-') {
 			pam_syslog(pamh, LOG_DEBUG,
 				   "wrong limit value '%s' for limit type '%s'",
 				   lim_value, lim_type);


### PR DESCRIPTION
`endptr` pointing to the end of string ensures no extra characters follow digits in a number. For example, value "1024k" will be rejected.

Check for minus sign at the beginning of string ensures no negative value supplied. For example, "-2" will be rejected instead of being converted to unsigned representation.
Special values "-1" and "-" are handled earlier in another clause.

No checks for ULLONG_MAX result (ULONG_MAX for 32-bit file offsets) and ERANGE error performed. Valid numeric values greater than ULLONG_MAX, for example, "99999999999999999999", are converted to ULLONG_MAX and will be interpeted as RLIM_INFINITY by subsequent setrlimit().

`value_orig` removed as unused. `lim_value` isn't being modified anywhere.