### PR TITLE
pam_start: Include <libintl.h> for bindtextdomain

### DIFF
--- a/libpam/pam_start.c
+++ b/libpam/pam_start.c
@@ -15,6 +15,10 @@
 #include <string.h>
 #include <syslog.h>
 
+#ifdef HAVE_BINDTEXTDOMAIN
+#include <libintl.h>
+#endif
+
 static int _pam_start_internal (
     const char *service_name,
     const char *user,


### PR DESCRIPTION
Fixes the following build error (RISCV64 platform using musl-1.2.4 libc with LLVM toolchain):
```
pam_start.c:39:2: error: call to undeclared function 'bindtextdomain'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   39 |         bindtextdomain(PACKAGE, LOCALEDIR);
      |         ^
1 error generated.
```