### PR TITLE
Improve NIS/YP build checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,9 +475,10 @@ fi
 AC_SUBST(LIBDB)
 
 AC_ARG_ENABLE([nis],
-        AS_HELP_STRING([--disable-nis], [Disable building NIS/YP support in pam_unix]))
+        AS_HELP_STRING([--disable-nis], [Disable building NIS/YP support in pam_unix]),
+        WITH_NIS=$enableval, WITH_NIS=check)
 
-AS_IF([test "x$enable_nis" != "xno"], [
+if test "$WITH_NIS" != "no" ; then
   old_CFLAGS=$CFLAGS
   old_CPPFLAGS=$CPPFLAGS
   old_LIBS=$LIBS
@@ -510,7 +511,7 @@ AS_IF([test "x$enable_nis" != "xno"], [
   CFLAGS="$old_CFLAGS"
   CPPFLAGS="$old_CPPFLAGS"
   LIBS="$old_LIBS"
-])
+fi
 
 AC_SUBST([NIS_CFLAGS])
 AC_SUBST([NIS_LIBS])
@@ -518,6 +519,8 @@ AM_CONDITIONAL([HAVE_NIS], [test "x$enable_nis" != "xno"])
 if test "x$enable_nis" != "xno" ; then
    AC_DEFINE([HAVE_NIS], 1,
 	     [Defines that NIS should be used])
+elif test "$WITH_NIS" = "yes" ; then
+    AC_MSG_ERROR([NIS/YP support not available])
 fi
 
 AC_ARG_ENABLE([usergroups],

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -380,7 +380,7 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 		}
 	}
 
-#if defined(HAVE_YP_GET_DEFAULT_DOMAIN) && defined (HAVE_YP_BIND) && defined (HAVE_YP_MATCH) && defined (HAVE_YP_UNBIND)
+#if defined(HAVE_NIS) && defined(HAVE_YP_GET_DEFAULT_DOMAIN) && defined (HAVE_YP_BIND) && defined (HAVE_YP_MATCH) && defined (HAVE_YP_UNBIND)
 	if (!matched && nis) {
 		char *userinfo = NULL, *domain = NULL;
 		int len = 0, i;


### PR DESCRIPTION
If NIS/YP headers are missing, do not enable NIS support.

One such scenario could be that libnsl library is installed without its development package. One distribution which separate between binaries and header files is Debian.

Should fix https://github.com/linux-pam/linux-pam/issues/772