### PR TITLE
pam_start.c: do not call bindtextdomain() unless nls is enabled

### DIFF
--- a/libpam/pam_start.c
+++ b/libpam/pam_start.c
@@ -25,7 +25,7 @@ static int _pam_start_internal (
     D(("called pam_start: [%s] [%s] [%p] [%p]"
        ,service_name, user, pam_conversation, pamh));
 
-#ifdef HAVE_BINDTEXTDOMAIN
+#if defined HAVE_BINDTEXTDOMAIN && defined ENABLE_NLS
     /* Bind text domain to pull in PAM translations for a case where
        linux-pam is installed to non-default prefix.
 


### PR DESCRIPTION
Call bindtextdomain() only when both the function is available and the build is configured with --enable-nls.

* libpam/pam_start.c (_pam_start_internal): Guard bindtextdomain() invocation with ENABLE_NLS.

Complements: v1.6.0~244 ("pam_start.c: call bindtextdomain() to expose Linux-PAM locales")
Resolves: https://github.com/linux-pam/linux-pam/pull/773