### PR TITLE
Set default fail delay to 0.5 seconds

### DIFF
--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -473,7 +473,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags,
 		goto err;
 
 	if (!(opts.flags & FAILLOCK_FLAG_NO_DELAY)) {
-		pam_fail_delay(pamh, 2000000);	/* 2 sec delay on failure */
+		pam_fail_delay(pamh, 500000);	/* 0.5 sec delay on failure */
 	}
 
 	if ((rv=get_pam_user(pamh, &opts)) != PAM_SUCCESS) {

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -721,7 +721,7 @@ int _unix_verify_password(pam_handle_t * pamh, const char *name
 
 	if (off(UNIX_NODELAY, ctrl)) {
 		D(("setting delay"));
-		(void) pam_fail_delay(pamh, 2000000);	/* 2 sec delay for on failure */
+		(void) pam_fail_delay(pamh, 500000);	/* 0.5 sec delay for on failure */
 	}
 
 	/* locate the entry for this user */


### PR DESCRIPTION
The default fail delay is 2 seconds (+/- 50% randomly). This is done to prevent brute force attacks, but unfortunately because isn't applied exponentially, it also greatly degrades the UX for legitimate users. Every typo is immediately met with an annoying 2 second delay.

A full fix would be to persist the login failure times and apply an exponential delay (this is what Windows does), however this is quite complicated due to PAM's architecture (see the `faillock` plugin for an example of this).

This simple fix greatly improves the UX at very minimal security cost. Any brute force attack that can tolerate a 0.5 second delay will also work with a 2 second delay. In other words a factor of 4 is nothing from an attacker's perspective, but makes a big difference from a legitimate user's perspective.

Fixes #778