### PR TITLE
Fix CHANGELOG encoding

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -296,7 +296,7 @@ bug report - outstanding bugs are listed here:
 * A Tru64 fix (given other stuff has already resolved this, it
   actually just a comment actually) from 'Eddie'. (Bug 418450 -
   agmorgan)
-* pam_handlers: BSD fix from Dag-Erling Smørgrav and Anton Berezin
+* pam_handlers: BSD fix from Dag-Erling SmÃ¸rgrav and Anton Berezin
   (Bug 486063 - agmorgan)
 * added the dynamic/* directory to the distribution. If you go in
   there after building the rest of the tree, you'll make a pam.so


### PR DESCRIPTION
Dag-Erling Smørgrav's name was encoded using some encoding other than UTF-8 (that line predates the UTF-8 consensus). This changes it to use UTF-8, so that it renders properly and so that editors that guess the file is UTF-8 do not get confused about it.