### PR TITLE
Assorted static analyzer fixes

### DIFF
--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -255,6 +255,7 @@ check_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 				snprintf(buf, sizeof(buf), "op=pam_faillock suid=%u ", opts->uid);
 				audit_log_user_message(audit_fd, AUDIT_RESP_ACCT_UNLOCK_TIMED, buf,
 					rhost, NULL, tty, 1);
+				audit_close(audit_fd);
 			}
 #endif
 			opts->flags |= FAILLOCK_FLAG_UNLOCKED;

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -1462,6 +1462,9 @@ static int create_polydir(struct polydir_s *polyptr,
     if (rc == -1) {
             pam_syslog(idata->pamh, LOG_ERR,
                        "Error creating directory %s: %m", dir);
+#ifdef WITH_SELINUX
+            freecon(oldcon_raw);
+#endif
             return PAM_SESSION_ERR;
     }
 

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -1003,6 +1003,7 @@ static int form_context(const struct polydir_s *polyptr,
 		return rc;
 	}
 	/* Should never get here */
+	freecon(scon);
 	return PAM_SUCCESS;
 }
 #endif

--- a/modules/pam_rootok/pam_rootok.c
+++ b/modules/pam_rootok/pam_rootok.c
@@ -66,6 +66,7 @@ log_callback (int type UNUSED, const char *fmt, ...)
 	ret = vasprintf (&buf, fmt, ap);
 	va_end(ap);
 	if (ret < 0) {
+		audit_close(audit_fd);
 		return 0;
 	}
 	audit_log_user_avc_message(audit_fd, AUDIT_USER_AVC, buf, NULL, NULL,

--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -481,6 +481,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv)
 
 #ifdef WITH_OPENSSL
 		if (hmac_size(pamh, debug, &maclen)) {
+			close(fd);
 			return PAM_AUTH_ERR;
 		}
 #else


### PR DESCRIPTION
* modules/pam_faillock/pam_faillock.c: close file when it will not be
  used anymore.
* modules/pam_faillock/pam_faillock.c: close file when it will not be
  used anymore.
* modules/pam_timestamp/pam_timestamp.c: close file when an error is
  detected.
* modules/pam_namespace/pam_namespace.c: free SELinux context before
  returning.
* modules/pam_namespace/pam_namespace.c: free SELinux context when an
  error is detected.

```
Error: RESOURCE_LEAK (CWE-772):
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:247: open_fn: Returning handle opened by "audit_open".
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:247: var_assign: Assigning: "audit_fd" = handle returned from "audit_open()".
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:256: noescape: Resource "audit_fd" is not freed or pointed-to in "audit_log_user_message".
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:258: leaked_handle: Handle variable "audit_fd" going out of scope leaks the handle.
256|                                   audit_log_user_message(audit_fd, AUDIT_RESP_ACCT_UNLOCK_TIMED, buf,
257|                                           rhost, NULL, tty, 1);
258|->                         }
259|   #endif
260|                           opts->flags |= FAILLOCK_FLAG_UNLOCKED;

Error: RESOURCE_LEAK (CWE-772):
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:247: open_fn: Returning handle opened by "audit_open".
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:247: var_assign: Assigning: "audit_fd" = handle returned from "audit_open()".
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:256: noescape: Resource "audit_fd" is not freed or pointed-to in "audit_log_user_message".
Linux-PAM-1.6.0/modules/pam_faillock/pam_faillock.c:258: leaked_handle: Handle variable "audit_fd" going out of scope leaks the handle.
256|                                   audit_log_user_message(audit_fd, AUDIT_RESP_ACCT_UNLOCK_TIMED, buf,
257|                                           rhost, NULL, tty, 1);
258|->                         }
259|   #endif
260|                           opts->flags |= FAILLOCK_FLAG_UNLOCKED;

Error: RESOURCE_LEAK (CWE-772):
Linux-PAM-1.6.0/modules/pam_timestamp/pam_timestamp.c:450: open_fn: Returning handle opened by "open". [Note: The source code implementation of the function has been overridden by a user model.]
Linux-PAM-1.6.0/modules/pam_timestamp/pam_timestamp.c:450: var_assign: Assigning: "fd" = handle returned from "open(path, 131072)".
Linux-PAM-1.6.0/modules/pam_timestamp/pam_timestamp.c:460: noescape: Resource "fd" is not freed or pointed-to in "fstat".
Linux-PAM-1.6.0/modules/pam_timestamp/pam_timestamp.c:484: leaked_handle: Handle variable "fd" going out of scope leaks the handle.
482|   #ifdef WITH_OPENSSL
483|                   if (hmac_size(pamh, debug, &maclen)) {
484|->                         return PAM_AUTH_ERR;
485|                   }
486|   #else

Error: RESOURCE_LEAK (CWE-772):
Linux-PAM-1.6.0/modules/pam_namespace/pam_namespace.c:928: alloc_arg: "getexeccon" allocates memory that is stored into "scon".
Linux-PAM-1.6.0/modules/pam_namespace/pam_namespace.c:1004: leaked_storage: Variable "scon" going out of scope leaks the storage it points to.
1002|           }
1003|           /* Should never get here */
1004|->         return PAM_SUCCESS;
1005|   }
1006|   #endif

Error: RESOURCE_LEAK (CWE-772):
Linux-PAM-1.6.0/modules/pam_namespace/pam_namespace.c:1433: alloc_arg: "getfscreatecon_raw" allocates memory that is stored into "oldcon_raw".
Linux-PAM-1.6.0/modules/pam_namespace/pam_namespace.c:1462: leaked_storage: Variable "oldcon_raw" going out of scope leaks the storage it points to.
1460|               pam_syslog(idata->pamh, LOG_ERR,
1461|                          "Error creating directory %s: %m", dir);
1462|->             return PAM_SESSION_ERR;
1463|       }
1464|
```

Resolves: https://issues.redhat.com/browse/RHEL-36475