### PR TITLE
pam_set_item: disallow setting service to NULL

### DIFF
--- a/libpam/pam_item.c
+++ b/libpam/pam_item.c
@@ -38,6 +38,12 @@ int pam_set_item (pam_handle_t *pamh, int item_type, const void *item)
     switch (item_type) {
 
     case PAM_SERVICE:
+	if (item == NULL) {
+	    pam_syslog(pamh, LOG_ERR,
+		       "pam_set_item: attempt to set service to NULL");
+	    retval = PAM_BAD_ITEM;
+	    break;
+	}
 	/* Setting handlers_loaded to 0 will cause the handlers
 	 * to be reloaded on the next call to a service module.
 	 */

--- a/tests/tst-pam_set_item.c
+++ b/tests/tst-pam_set_item.c
@@ -144,6 +144,16 @@ main (void)
 	}
     }
 
+  /* 5: try to set PAM_SERVICE to NULL  */
+  retval = pam_set_item (pamh, PAM_SERVICE, NULL);
+  if (retval != PAM_BAD_ITEM)
+    {
+      fprintf (stderr,
+	       "pam_set_item (pamh, PAM_SERVICE, NULL) returned %d\n",
+	       retval);
+      return 1;
+    }
+
   pam_end (pamh, 0);
 
   return 0;


### PR DESCRIPTION
This also prevents a possible segfault when pam_set_item tries to convert an empty service_name to lower case.