### PR TITLE
pam_shells: Initialize econf_file* variable to NULL

### DIFF
--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -81,7 +81,7 @@ static int perform_check(pam_handle_t *pamh)
     size_t size = 0;
     econf_err error;
     char **keys;
-    econf_file *key_file;
+    econf_file *key_file = NULL;
 
     error = econf_readDirsWithCallback(&key_file,
 				       VENDORDIR,


### PR DESCRIPTION
The next version of libeconf (0.7.0) depends on an initialized econf_file* variable because it will be used for settings options. See:
https://github.com/openSUSE/libeconf/blob/master/NEWS