### PR TITLE
modules/pam_unix: fix snprintf argument type

### DIFF
--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -500,7 +500,7 @@ PAMH_ARG_DECL(char * create_password_hash,
 #else
 	sp = stpcpy(salt, algoid);
 	if (on(UNIX_ALGO_ROUNDS, ctrl)) {
-		sp += snprintf(sp, sizeof(salt) - (16 + 1 + (sp - salt)), "rounds=%u$", rounds);
+		sp += snprintf(sp, sizeof(salt) - (16 + 1 + (sp - salt)), "rounds=%i$", rounds);
 	}
 	crypt_make_salt(sp, 16);
 #endif /* CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY */


### PR DESCRIPTION
modules/pam_unix/passverify.c:503:9: warning: %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'. [invalidPrintfArgType_uint]
  sp += snprintf(sp, sizeof(salt) - (16 + 1 + (sp - salt)), "rounds=%u$", rounds);
