### PR TITLE
Replacing old econf_readDirs by econf_readConfig if available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -578,6 +578,31 @@ if test "$WITH_ECONF" = "check"; then
 elif test "$WITH_ECONF" = "yes"; then
   PKG_CHECK_MODULES([ECONF], [libeconf >= 0.5.0], [ECONF_CFLAGS="-DUSE_ECONF=1 $ECONF_CFLAGS"], [])
 fi
+if test -n "$ECONF_CFLAGS"; then
+  AC_MSG_CHECKING(for econf_readConfigWithCallback)
+  saved_CFLAGS=$CFLAGS
+  CFLAGS="$CFLAGS $ECONF_CFLAGS"
+  saved_LIBS=$LIBS
+  LIBS="$LIBS $ECONF_LIBS"
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[
+      #include <libeconf.h>
+      ]],
+      [[
+      econf_file *key_file = NULL;
+      econf_err error = ECONF_SUCCESS;
+      error = econf_newKeyFile_with_options(&key_file, "PYTHON_STYLE=1");
+      error = econf_readConfigWithCallback (&key_file, "foo", "/usr/lib", "test", "conf", "=", "#", NULL, NULL);
+      ]])],
+    [econf_readConfigWithCallback=yes], [econf_readConfigWithCallback=no])
+  AC_MSG_RESULT($econf_readConfigWithCallback)
+  if test "$econf_readConfigWithCallback" = yes; then
+    AC_DEFINE([HAVE_ECONF_READCONFIG], [1], [Define if econf_readConfigWithCallback is available])
+  fi
+  LIBS=$saved_LIBS
+  CFLAGS=$saved_CFLAGS
+fi
 AC_SUBST([ECONF_CFLAGS])
 AC_SUBST([ECONF_LIBS])
 

--- a/libpam/pam_modutil_searchkey.c
+++ b/libpam/pam_modutil_searchkey.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #ifdef USE_ECONF
-#include <libeconf.h>
+#include "pam_econf.h"
 #endif
 
 #ifdef USE_ECONF
@@ -29,10 +29,14 @@ econf_search_key (const char *name, const char *suffix, const char *key)
 {
 	econf_file *key_file = NULL;
 	char *val;
+	econf_err error;
 
-	if (econf_readDirs (&key_file, VENDORDIR, SYSCONFDIR, name, suffix,
-			    " \t", "#"))
-		return NULL;
+	error = pam_econf_readconfig (&key_file, VENDORDIR, SYSCONFDIR, name, suffix,
+				      " \t", "#", NULL, NULL);
+	if (error != ECONF_SUCCESS) {
+                econf_free (key_file);
+                return NULL;
+	}
 
 	if (econf_getStringValue (key_file, NULL, key, &val)) {
 		econf_free (key_file);

--- a/libpam_internal/Makefile.am
+++ b/libpam_internal/Makefile.am
@@ -1,10 +1,12 @@
 noinst_LTLIBRARIES = libpam_internal.la
 
-noinst_HEADERS = include/pam_line.h
+noinst_HEADERS = include/pam_line.h include/pam_econf.h
 
 AM_CFLAGS = -I$(top_srcdir)/libpam_internal/include \
-	    -I$(top_srcdir)/libpam/include $(WARN_CFLAGS)
+	    -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) \
+	    $(ECONF_CFLAGS)
 
 libpam_internal_la_SOURCES = \
 	pam_debug.c \
-	pam_line.c
+	pam_line.c \
+	pam_econf.c

--- a/libpam_internal/include/pam_econf.h
+++ b/libpam_internal/include/pam_econf.h
@@ -1,0 +1,22 @@
+/* pam_econf.h -- routines to parse configuration files with libeconf */
+
+#ifndef PAM_ECONF_H
+#define PAM_ECONF_H
+
+#ifdef USE_ECONF
+
+#include <libeconf.h>
+
+econf_err pam_econf_readconfig(econf_file **key_file,
+			       const char *usr_conf_dir,
+			       const char *etc_conf_dir,
+			       const char *config_name,
+			       const char *config_suffix,
+			       const char *delim,
+			       const char *comment,
+			       bool (*callback)(const char *filename, const void *data),
+			       const void *callback_data);
+
+#endif /* USE_ECONF */
+
+#endif /* PAM_ECONF_H */

--- a/libpam_internal/pam_econf.c
+++ b/libpam_internal/pam_econf.c
@@ -18,8 +18,31 @@ econf_err pam_econf_readconfig(econf_file **key_file,
 			       bool (*callback)(const char *filename, const void *data),
 			       const void *callback_data)
 {
-    econf_err ret;
+    econf_err ret = ECONF_SUCCESS;
     D(("Read configuration from directory %s and %s", etc_conf_dir, usr_conf_dir));
+
+#ifdef HAVE_ECONF_READCONFIG
+
+    char *parsing_dirs = NULL;
+    if (asprintf(&parsing_dirs, "PARSING_DIRS=%s:%s", usr_conf_dir, etc_conf_dir) < 0) {
+        ret = ECONF_NOMEM;
+        parsing_dirs = NULL;
+    }
+    if (ret == ECONF_SUCCESS)
+        ret = econf_newKeyFile_with_options(key_file, parsing_dirs);
+    if (ret == ECONF_SUCCESS)
+        ret = econf_readConfigWithCallback(key_file,
+					   NULL,
+					   usr_conf_dir,
+					   config_name,
+					   config_suffix,
+					   delim,
+					   comment,
+					   callback, callback_data);
+    free(parsing_dirs);
+
+#else
+
     ret = econf_readDirsWithCallback(key_file,
 				     usr_conf_dir,
 				     etc_conf_dir,
@@ -28,6 +51,9 @@ econf_err pam_econf_readconfig(econf_file **key_file,
 				     delim,
 				     comment,
 				     callback, callback_data);
+
+#endif
+
     return ret;
 }
 

--- a/libpam_internal/pam_econf.c
+++ b/libpam_internal/pam_econf.c
@@ -1,0 +1,34 @@
+/* pam_econf.c -- routines to parse configuration files with libeconf */
+
+#include "config.h"
+
+#ifdef USE_ECONF
+
+#include <stdio.h>
+#include <security/_pam_macros.h>
+#include "pam_econf.h"
+
+econf_err pam_econf_readconfig(econf_file **key_file,
+			       const char *usr_conf_dir,
+			       const char *etc_conf_dir,
+			       const char *config_name,
+			       const char *config_suffix,
+			       const char *delim,
+			       const char *comment,
+			       bool (*callback)(const char *filename, const void *data),
+			       const void *callback_data)
+{
+    econf_err ret;
+    D(("Read configuration from directory %s and %s", etc_conf_dir, usr_conf_dir));
+    ret = econf_readDirsWithCallback(key_file,
+				     usr_conf_dir,
+				     etc_conf_dir,
+				     config_name,
+				     config_suffix,
+				     delim,
+				     comment,
+				     callback, callback_data);
+    return ret;
+}
+
+#endif /* USE_ECONF */

--- a/modules/pam_env/Makefile.am
+++ b/modules/pam_env/Makefile.am
@@ -22,8 +22,9 @@ secureconfdir = $(SCONFIGDIR)
 endif
 
 AM_CFLAGS = -I$(top_srcdir)/libpam_internal/include \
-	    -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) \
-	    -DSYSCONFDIR=\"$(sysconfdir)\" $(ECONF_CFLAGS)
+	    -I$(top_srcdir)/libpam/include \
+	    -I$(top_srcdir)/libpam_internal/include \
+	    -DSYSCONFDIR=\"$(sysconfdir)\" $(WARN_CFLAGS) $(ECONF_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #ifdef USE_ECONF
-#include <libeconf.h>
+#include "pam_econf.h"
 #endif
 
 #include <security/pam_modules.h>
@@ -241,9 +241,8 @@ econf_read_file(const pam_handle_t *pamh, const char *filename, const char *deli
 	}
       }
 
-      D(("Read configuration from directory %s and %s", vendor_dir, sysconf_dir));
-      error = econf_readDirs (&key_file, vendor_dir, sysconf_dir, name, suffix,
-			      delim, "#");
+      error = pam_econf_readconfig (&key_file, vendor_dir, sysconf_dir, name, suffix,
+				    delim, "#", NULL, NULL);
       free(vendor_dir);
       free(sysconf_dir);
       if (error != ECONF_SUCCESS) {

--- a/modules/pam_shells/Makefile.am
+++ b/modules/pam_shells/Makefile.am
@@ -21,14 +21,18 @@ else
 secureconfdir = $(SCONFIGDIR)
 endif
 
-AM_CFLAGS = -I$(top_srcdir)/libpam/include $(WARN_CFLAGS) $(ECONF_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/libpam/include \
+	    -I$(top_srcdir)/libpam_internal/include \
+	    $(WARN_CFLAGS) $(ECONF_CFLAGS)
 AM_LDFLAGS = -no-undefined -avoid-version -module
 if HAVE_VERSIONING
   AM_LDFLAGS += -Wl,--version-script=$(srcdir)/../modules.map
 endif
 
 securelib_LTLIBRARIES = pam_shells.la
-pam_shells_la_LIBADD = $(top_builddir)/libpam/libpam.la $(ECONF_LIBS)
+pam_shells_la_LIBADD = $(top_builddir)/libpam/libpam.la \
+		       $(top_builddir)/libpam_internal/libpam_internal.la \
+		       $(ECONF_LIBS)
 
 if ENABLE_REGENERATE_MAN
 dist_noinst_DATA = README

--- a/modules/pam_shells/pam_shells.c
+++ b/modules/pam_shells/pam_shells.c
@@ -19,7 +19,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #if defined (USE_ECONF)	&& defined (VENDORDIR)
-#include <libeconf.h>
+#include "pam_econf.h"
 #endif
 
 #include <security/pam_modules.h>
@@ -81,17 +81,17 @@ static int perform_check(pam_handle_t *pamh)
     size_t size = 0;
     econf_err error;
     char **keys;
-    econf_file *key_file;
+    econf_file *key_file = NULL;
 
-    error = econf_readDirsWithCallback(&key_file,
-				       VENDORDIR,
-				       ETCDIR,
-				       SHELLS,
-				       NULL,
-				       "", /* key only */
-				       "#", /* comment */
-				       check_file, pamh);
-    if (error) {
+    error = pam_econf_readconfig(&key_file,
+				 VENDORDIR,
+				 ETCDIR,
+				 SHELLS,
+				 NULL,
+				 "", /* key only */
+				 "#", /* comment */
+				 check_file, pamh);
+    if (error != ECONF_SUCCESS) {
 	pam_syslog(pamh, LOG_ERR,
 		   "Cannot parse shell files: %s",
 		   econf_errString(error));


### PR DESCRIPTION
econf_readConfig* calls are supporting the Linux Userspace API (UAPI) Group  chapter "Configuration Files Specification".
See: https://uapi-group.org/specifications/specs/configuration_files_specification/