### PR TITLE
configure.ac: fix typo in the help message for --enable-lastlog

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -770,7 +770,7 @@ esac
 
 AC_ARG_ENABLE([lastlog],
               [AS_HELP_STRING([--enable-lastlog],
-                              [do build pam_lastlog module])],
+                              [build pam_lastlog module])],
               [], [enable_lastlog=no])
 case "$enable_lastlog" in
   yes|check)


### PR DESCRIPTION
The "do" here is redundant.