### PR TITLE
libpam_misc: Use ECHOCTL in the terminal input

### DIFF
--- a/libpam_misc/misc_conv.c
+++ b/libpam_misc/misc_conv.c
@@ -145,9 +145,10 @@ static int read_string(int echo, const char *prompt, char **retstr)
 	    return -1;
 	}
 	memcpy(&term_tmp, &term_before, sizeof(term_tmp));
-	if (!echo) {
+	if (echo)
+	    term_tmp.c_lflag |= ICANON | ECHOCTL;
+	else
 	    term_tmp.c_lflag &= ~(ECHO);
-	}
 	have_term = 1;
 
 	/*


### PR DESCRIPTION
Use the canonical terminal mode (line mode) and set ECHOCTL to prevent cursor escape from the login prompt using arrows or escape sequences.

ICANON is the default in most cases anyway. ECHOCTL is default on tty, but for example not on pty, allowing cursor to escape.

Stanislav Brabec <sbrabec@suse.com>