### PR TITLE
pam_faillock: silence compilation warning

### DIFF
--- a/modules/pam_faillock/main.c
+++ b/modules/pam_faillock/main.c
@@ -247,7 +247,8 @@ do_user(struct options *opts, const char *user)
 #ifdef HAVE_LIBAUDIT
 		}
 		if ((audit_fd=audit_open()) >= 0) {
-			audit_log_acct_message(audit_fd, AUDIT_USER_MGMT, NULL,
+			(void) !audit_log_acct_message(audit_fd,
+				AUDIT_USER_MGMT, NULL,
 				"faillock-reset", user,
 				pwd != NULL ? pwd->pw_uid : AUDIT_NO_ID,
 				NULL, NULL, NULL, rv == 0);


### PR DESCRIPTION
Since audit_log_acct_message() was decorated with warn_unused_result attribute, compilation of faillock helper produces the following diagnostics:

    main.c: In function 'do_user':
    main.c:250:25: warning: ignoring return value of 'audit_log_acct_message' declared with attribute 'warn_unused_result' [-Wunused-result]

Given that this helper has never been picky about audit, e.g. audit_open() errors do not affect its exit status, just silence this new warning.

* modules/pam_faillock/main.c [HAVE_LIBAUDIT] (do_user): Silence compilation warning.