### PR TITLE
pam_access: Support UID and GID in access.conf

### DIFF
--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -63,10 +63,10 @@
     <para>
       The second field, the
       <replaceable>users</replaceable>/<replaceable>group</replaceable>
-      field, should be a list of one or more login names, group names, or
+      field, should be a list of one or more login names, group names, uid, gid, or
       <emphasis>ALL</emphasis> (which always matches). To differentiate
       user entries from group entries, group entries should be written
-      with brackets, e.g. <emphasis>(group)</emphasis>.
+      with brackets, e.g. <emphasis>(group)</emphasis> or <emphasis>(gid)</emphasis>.
     </para>
 
     <para>
@@ -175,6 +175,12 @@
     </para>
     <para>-:root:ALL</para>
 
+    <para>
+      An user with uid <emphasis>1003</emphasis> and a group with gid
+      <emphasis>1000</emphasis> should be allowed to get access
+      from all other sources.
+    </para>
+    <para>+:(1000) 1003:ALL</para>
     <para>
       User <emphasis>foo</emphasis> and members of netgroup
       <emphasis>admins</emphasis> should be allowed to get access


### PR DESCRIPTION
Following up on #114, #186, and  #601.  It appears that the original author, @blueskycs2c, has been inactive for several years.  The change has been [rebased as requested](https://github.com/linux-pam/linux-pam/pull/186#issuecomment-1650565201) by @t8m and [addressed feedback as requested](https://github.com/linux-pam/linux-pam/pull/601#discussion_r1456570763) by @ldv-alt.