### PR TITLE
pam_userdb: don't return void result as int

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -372,6 +372,12 @@ else
       if have
         use_db = 'gdbm'
         cdata.set('HAVE_GDBM_H', 1)
+        if cc.compiles('''#include <gdbm.h>
+                       int db_close(void *dbm) {return gdbm_close(dbm);}''',
+                       args: '-D_GNU_SOURCE',
+                       name: 'gdbm_close returns int')
+          cdata.set('GDBM_CLOSE_RETURNS_INT', 1)
+        endif
       endif
     endif
   endif

--- a/modules/pam_userdb/pam_userdb.c
+++ b/modules/pam_userdb/pam_userdb.c
@@ -185,7 +185,12 @@ static int
 db_close(void *dbm)
 {
 #ifdef HAVE_GDBM_H
+# ifdef GDBM_CLOSE_RETURNS_INT
     return gdbm_close(dbm);
+# else
+    gdbm_close(dbm);
+    return 0;
+# endif
 #else
     dbm_close(dbm);
     return 0;


### PR DESCRIPTION
gdbm_close() returns void, so we cannot use that as return argument, if the calling function returns int.