### PR TITLE
examples/tty_conv: fix potential out of bound write in readline()

### DIFF
--- a/examples/tty_conv.c
+++ b/examples/tty_conv.c
@@ -68,7 +68,7 @@ static char *readline(void)
     int i;
 
     flockfile(stdin);
-    for (i = 0; i < PAM_MAX_RESP_SIZE; i++)
+    for (i = 0; i < PAM_MAX_RESP_SIZE - 1; i++)
     {
         int ch = getchar_unlocked();
         if (ch == '\n' || ch == '\r' ||ch == EOF)


### PR DESCRIPTION
Found by Linux Verification Center (linuxtesting.org) with SVACE.
Reporter: Pavel Nekrasov ([p.nekrasov@fobos-nt.ru](mailto:p.nekrasov@fobos-nt.ru)).
Organization: Fobos-NT ([info@fobos-nt.ru](mailto:info@fobos-nt.ru)).