### PR TITLE
pam_env: install environment file in vendordir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,10 +83,12 @@ cdata.set('SCONFIGDIR', sconfigdir)
 vendordir = get_option('vendordir')
 if get_option('vendordir') == ''
   vendor_sconfigdir = sconfigdir
+  vendor_sysconfdir = sysconfdir
   stringparam_vendordir = []
   stringparam_profileconditions = 'without_vendordir'
 else
   vendor_sconfigdir = vendordir / 'security'
+  vendor_sysconfdir = vendordir
   cdata.set_quoted('VENDORDIR', vendordir)
   cdata.set_quoted('VENDOR_SCONFIG_DIR', vendor_sconfigdir)
   stringparam_vendordir = ['--stringparam', 'vendordir', vendordir]

--- a/modules/module-meson.build
+++ b/modules/module-meson.build
@@ -268,7 +268,7 @@ if module == 'pam_env'
   )
   install_data(
     'environment',
-    install_dir: sysconfdir,
+    install_dir: vendor_sysconfdir,
     install_tag: 'config',
   )
 endif


### PR DESCRIPTION
If vendordir is enabled, the distribution provided configuration files should be in below this directory and not in /etc.
This was already wrong in Makefile.am before, was forgotten when adding vendordir support for pam_env.