### PR TITLE
pam_access: only consider FQDN for host matches

### DIFF
--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -73,8 +73,8 @@
       The third field, the <replaceable>origins</replaceable>
       field, should be a list of one or more tty names (for non-networked
       logins), X <varname>$DISPLAY</varname> values or PAM service
-      names (for non-networked logins without a tty), host names,
-      domain names (begin with "."), host addresses,
+      names (for non-networked logins without a tty), fully qualified host names
+      (end with "."), domain names (begin with "."), host addresses,
       internet network numbers (end with "."), internet network addresses
       with network mask (where network mask can be a decimal number or an
       internet address also), <emphasis>ALL</emphasis> (which always matches)


### PR DESCRIPTION
Since 23393bef92c1, every token in the origin field of the access.conf configuration may be considered a hostname. Some exceptions were made for keywords ALL and LOCAL, but that leaves open the possiblity of unintenionally matching any service or tty name as a hostname in the case of remote logins. There is currently no way to distinguish an origin that should only match a PAM_SERVICE or PAM_TTY enabling hosts named like ttyN or crond to bypass many pam_access configurations.

Require all hostname origins to be specified as a FQDN, ending with a ".". This way tty and service names will not be confused for unqualified hostnames.

Fixes: 23393bef92c1 (pam_access: handle hostnames in access.conf, 2022-02-24)

---

Fixes: #834