### PR TITLE
pam_access_fixes

### DIFF
--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -79,17 +79,12 @@
       with network mask (where network mask can be a decimal number or an
       internet address also), <emphasis>ALL</emphasis> (which always matches)
       or <emphasis>LOCAL</emphasis>. The <emphasis>LOCAL</emphasis>
-      keyword matches if and only if
-      <citerefentry><refentrytitle>pam_get_item</refentrytitle><manvolnum>3</manvolnum></citerefentry>,
-      when called with an <parameter>item_type</parameter> of
-      <emphasis>PAM_RHOST</emphasis>, returns <code>NULL</code> or an
-      empty string (and therefore the
-      <replaceable>origins</replaceable> field is compared against the
-      return value of
-      <citerefentry><refentrytitle>pam_get_item</refentrytitle><manvolnum>3</manvolnum></citerefentry>
-      called with an <parameter>item_type</parameter> of
-      <emphasis>PAM_TTY</emphasis> or, absent that,
-      <emphasis>PAM_SERVICE</emphasis>).
+      keyword matches when the user connects without a network
+      connection (e.g., <emphasis>su</emphasis>,
+      <emphasis>login</emphasis>). A connection through the loopback
+      device (e.g., <command>ssh user@localhost</command>) is
+      considered a network connection, and thus, the
+      <emphasis>LOCAL</emphasis> keyword does not match.
     </para>
 
     <para>

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -306,6 +306,23 @@ isipaddr (const char *string, int *addr_type,
   return is_ip;
 }
 
+/* is_local_addr - checks if the IP address is local */
+static int
+is_local_addr (const char *string, int addr_type)
+{
+  if (addr_type == AF_INET) {
+    if (strcmp(string, "127.0.0.1") == 0) {
+      return YES;
+    }
+  } else if (addr_type == AF_INET6) {
+    if (strcmp(string, "::1") == 0) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
 
 /* are_addresses_equal - translate IP address strings to real IP
  * addresses and compare them to find out if they are equal.
@@ -327,9 +344,18 @@ are_addresses_equal (const char *ipaddr0, const char *ipaddr1,
   if (isipaddr (ipaddr1, &addr_type1, &addr1) == NO)
     return NO;
 
-  if (addr_type0 != addr_type1)
-    /* different address types */
+  if (addr_type0 != addr_type1) {
+    /* different address types, but there is still a possibility that they are
+     * both local addresses
+     */
+    int local1 = is_local_addr(ipaddr0, addr_type0);
+    int local2 = is_local_addr(ipaddr1, addr_type1);
+
+    if (local1 == YES && local2 == YES)
+      return YES;
+
     return NO;
+  }
 
   if (netmask != NULL) {
     /* Got a netmask, so normalize addresses? */


### PR DESCRIPTION
* modules/pam_access/pam_access.c: match the local address regardless of
  the IP version in use.
* modules/pam_access/access.conf.5.xml: `LOCAL` keyword behaviour
  explanation was focused on the development internals. Let's clarify it
  by rephrasing it to something a sysadmin can understand.

In some circumstances the `localhost` may be translated to IPv4 or IPv6,
but the configuration file only indicated the address for one of the two
versions. Since the originating value is set in `PAM_RHOST` and PAM has
no control over it, let's match the local addresses regardless of the IP
version in use.

Resolves: https://issues.redhat.com/browse/RHEL-23018
Resolves: https://issues.redhat.com/browse/RHEL-39943