### PR TITLE
Avoid accessing null pointer

### DIFF
--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -730,14 +730,13 @@ static int _pam_add_handler(pam_handle_t *pamh
 	    pam_syslog(pamh, LOG_CRIT, "cannot malloc full mod path");
 	    return PAM_ABORT;
 	}
-
+    }
 	if (mod == NULL) {
 	    /* if we get here with NULL it means allocation error */
 	    return PAM_ABORT;
 	}
 
 	mod_type = mod->type;
-    }
 
     if (mod_path == NULL)
 	mod_path = UNKNOWN_MODULE;


### PR DESCRIPTION
If not satisfied  “ handler_type == PAM_HT_MODULE || handler_type == PAM_HT_SILENT_MODULE) &&
mod_path != NULL)”  this condition, mod is always NULL, then there may be unpredictable errors in   “ _pam_dlsym (mod->dl_handle, sym)”