### PR TITLE
Prepare for 1.7.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,16 @@
 Linux-PAM NEWS -- history of user-visible changes.
 
+Release 1.7.0
+* build: changed build system from autotools to meson.
+* libpam_misc: use ECHOCTL in the terminal input
+* pam_access: support UID and GID in access.conf
+* pam_env: install environment file in vendordir if vendordir is enabled
+* pam_issue: only count class user if logind support is enabled
+* pam_limits: use systemd-logind instead of utmp if logind support is enabled
+* pam_unix: compare password hashes in constant time
+* Multiple minor bug fixes, build fixes, portability fixes,
+  documentation improvements, and translation updates.
+
 Release 1.6.1
 * build: fail if specified configure options cannot be satisfied.
 * pam_env: fixed --disable-econf --enable-vendordir support.

--- a/libpam/include/security/_pam_types.h
+++ b/libpam/include/security/_pam_types.h
@@ -22,7 +22,7 @@ typedef struct pam_handle pam_handle_t;
 /* Major and minor version number of the Linux-PAM package.  Use
    these macros to test for features in specific releases.  */
 #define __LINUX_PAM__ 1
-#define __LINUX_PAM_MINOR__ 0
+#define __LINUX_PAM_MINOR__ 7
 
 /* ----------------- The Linux-PAM return values ------------------ */
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('Linux-PAM', 'c',
-        version: '1.6.1',
+        version: '1.7.0',
         license: 'BSD-3-Clause OR GPL-2.0-or-later',
         default_options: [
           'b_pie=true',

--- a/po/Linux-PAM.pot
+++ b/po/Linux-PAM.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Linux-PAM 1.6.1\n"
+"Project-Id-Version: Linux-PAM 1.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linux-pam/linux-pam/issues\n"
 "POT-Creation-Date: 2024-10-13 20:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/po/meson.build
+++ b/po/meson.build
@@ -10,6 +10,6 @@ i18n.gettext(
   args: [
     '--copyright-holder=Linux-PAM Project',
     '--msgid-bugs-address=https://github.com/linux-pam/linux-pam/issues',
-    '--package-version=1.6.1',
+    '--package-version=1.7.0',
   ],
 )


### PR DESCRIPTION
* meson.build: Raise project version to 1.7.0.
* po/meson.build: Likewise.
* po/Linux-PAM.pot (Project-Id-Version): Likewise.
* libpam/include/security/_pam_types.h (__LINUX_PAM_MINOR__): Update.
* NEWS: Update.

Resolves: https://github.com/linux-pam/linux-pam/issues/844