### PR TITLE
Build padout as native binary

### DIFF
--- a/doc/specs/meson.build
+++ b/doc/specs/meson.build
@@ -15,6 +15,7 @@ parse_l = custom_target(
 
 padout = executable(
   'padout',
+  native: true,
   sources: [parse_l, parse_y],
   include_directories: [libpam_inc],
   c_args: [


### PR DESCRIPTION
Fixes: https://github.com/linux-pam/linux-pam/issues/850

Add 'native : true' to build config of padout.

Changes to be committed:
	modified:   doc/specs/meson.build