### PR TITLE
doc: make PDF documentation optional

### DIFF
--- a/doc/guide-meson.build
+++ b/doc/guide-meson.build
@@ -56,35 +56,37 @@ custom_target(
 )
 
 
-fop = custom_target(
-  input: xml,
-  output: name + '.fop',
-  command: [
-    prog_xsltproc,
-    '-o', '@OUTPUT@',
-    '--nonet',
-    '--xinclude',
-    '--stringparam', 'generate.toc', 'book toc',
-    '--stringparam', 'section.autolabel', '1',
-    '--stringparam', 'section.label.includes.component.label', '1',
-    '--stringparam', 'toc.max.depth', toc_max_depth,
-    pdf_stylesheet,
-    '@INPUT@',
-  ],
-)
+if prog_fop.found()
+  fop = custom_target(
+    input: xml,
+    output: name + '.fop',
+    command: [
+      prog_xsltproc,
+      '-o', '@OUTPUT@',
+      '--nonet',
+      '--xinclude',
+      '--stringparam', 'generate.toc', 'book toc',
+      '--stringparam', 'section.autolabel', '1',
+      '--stringparam', 'section.label.includes.component.label', '1',
+      '--stringparam', 'toc.max.depth', toc_max_depth,
+      pdf_stylesheet,
+      '@INPUT@',
+    ],
+  )
 
-custom_target(
-  input: fop,
-  output: name + '.pdf',
-  command: [
-    prog_fop,
-    '@INPUT@',
-    '@OUTPUT@',
-  ],
-  install: true,
-  install_dir: pdfdir,
-  install_tag: 'doc',
-)
+  custom_target(
+    input: fop,
+    output: name + '.pdf',
+    command: [
+      prog_fop,
+      '@INPUT@',
+      '@OUTPUT@',
+    ],
+    install: true,
+    install_dir: pdfdir,
+    install_tag: 'doc',
+  )
+endif
 
 
 subdir('html')

--- a/meson.build
+++ b/meson.build
@@ -502,7 +502,7 @@ if enable_docs
   endif
   prog_fop = find_program(
     'fop',
-    required: feature_docs,
+    required: false,
     disabler: true,
   )
 


### PR DESCRIPTION
While building any documentation requires xsltproc, only the PDF documentation requires fop, which is dependency-heavy, and not always available (e.g. it is not included in RHEL).  This allows the HTML documentation to be built while skipping the PDFs.

/cc @ikerexxe 