### PR TITLE
pam_access: rework resolving of tokens as hostname

### DIFF
--- a/modules/pam_access/access.conf.5.xml
+++ b/modules/pam_access/access.conf.5.xml
@@ -233,6 +233,10 @@
       An IPv6 link local host address must contain the interface
       identifier. IPv6 link local network/netmask is not supported.
     </para>
+    <para>
+      Hostnames should be written as Fully-Qualified Host Name (FQHN) to avoid
+      confusion with device names or PAM service names.
+    </para>
   </refsect1>
 
   <refsect1 xml:id="access.conf-see_also">

--- a/modules/pam_access/pam_access.8.xml
+++ b/modules/pam_access/pam_access.8.xml
@@ -23,10 +23,13 @@
         debug
       </arg>
       <arg choice="opt" rep="norepeat">
+        noaudit
+      </arg>
+      <arg choice="opt" rep="norepeat">
         nodefgroup
       </arg>
       <arg choice="opt" rep="norepeat">
-        noaudit
+        nodns
       </arg>
       <arg choice="opt" rep="norepeat">
         quiet_log
@@ -134,6 +137,33 @@
 
       <varlistentry>
         <term>
+          nodefgroup
+        </term>
+        <listitem>
+          <para>
+            User tokens which are not enclosed in parentheses will not be
+	    matched against the group database. The backwards compatible default is
+            to try the group database match even for tokens not enclosed
+            in parentheses.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          nodns
+        </term>
+        <listitem>
+          <para>
+	    Do not try to resolve tokens as hostnames, only IPv4 and IPv6
+	    addresses will be resolved. Which means to allow login from a
+	    remote host, the IP addresses need to be specified in <filename>access.conf</filename>.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
           quiet_log
         </term>
         <listitem>
@@ -181,20 +211,6 @@
             with group information obtained from a Windows domain,
             where the default built-in groups "Domain Users",
             "Domain Admins" contain a space.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term>
-          nodefgroup
-        </term>
-        <listitem>
-          <para>
-            User tokens which are not enclosed in parentheses will not be
-	    matched against the group database. The backwards compatible default is
-            to try the group database match even for tokens not enclosed
-            in parentheses.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
* modules/pam_access/pam_access.c: separate resolving if IP addesses from hostnames. Don't resolve TTYs or display variables as hostname (#834). Add "nodns" option to disallow resolving of tokens as hostname.
* modules/pam_access/pam_access.8.xml: document nodns option
* modules/pam_access/access.conf.5.xml: document that hostnames should be written as FQHN.