### PR TITLE
pam_modutil_search_key: prevent possible null pointer dereference

### DIFF
--- a/libpam/pam_modutil_searchkey.c
+++ b/libpam/pam_modutil_searchkey.c
@@ -59,6 +59,9 @@ pam_modutil_search_key(pam_handle_t *pamh UNUSED,
 	size_t buflen = 0;
 	char *retval = NULL;
 
+	if (NULL == key)
+		return NULL;
+
 #ifdef USE_ECONF
 	if (strcmp (file_name, LOGIN_DEFS) == 0)
 		return econf_search_key ("login", ".defs", key);


### PR DESCRIPTION
Prevent a possible null pointer dereference in strcasecmp when key is NULL.