### PR TITLE
build: add static_library targets for libpam, libpam_misc

### DIFF
--- a/libpam/meson.build
+++ b/libpam/meson.build
@@ -58,6 +58,21 @@ libpam = shared_library(
   install: true,
 )
 
+libpam = static_library(
+  'pam',
+  sources: libpam_src,
+  include_directories: [libpam_inc],
+  c_args: [
+    '-DDEFAULT_MODULE_PATH="@0@/"'.format(securedir),
+    '-DLIBPAM_COMPILE',
+  ],
+  dependencies: [libpam_internal_dep, libaudit, libeconf, libdl, libintl],
+  link_depends: libpam_link_deps,
+  link_args: libpam_link_args,
+  install: true,
+)
+
+
 libpam_dep = declare_dependency(
   include_directories: [libpam_inc],
   link_with: [libpam],

--- a/libpam_misc/meson.build
+++ b/libpam_misc/meson.build
@@ -25,6 +25,16 @@ libpam_misc = shared_library(
   install: true,
 )
 
+libpam_misc = static_library(
+  'pam_misc',
+  sources: libpam_misc_src,
+  include_directories: [libpam_misc_inc, libpamc_inc],
+  dependencies: [libpam_internal_dep, libpam_dep],
+  link_depends: libpam_misc_link_deps,
+  link_args: libpam_misc_link_args,
+  install: true,
+)
+
 libpam_misc_dep = declare_dependency(
   include_directories: [libpam_misc_inc],
   link_with: [libpam_misc],


### PR DESCRIPTION
Previously with Autotools, it was possible to build libpam and libpam_misc as static libraries. This was useful for Busybox to link against and Debian is also likely to need them (as part of libpam-dev).