### PR TITLE
meson: support elogind as a logind provider

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -318,9 +318,16 @@ else
   stringparam_profileconditions += ';no_openssl_hmac'
 endif
 
-
-libsystemd = dependency('libsystemd', version: '>= 254', required: get_option('logind'))
-cdata.set('USE_LOGIND', libsystemd.found() ? 1 : false)
+use_logind = get_option('logind')
+use_elogind = get_option('elogind').require(not use_logind.enabled()).disable_auto_if(use_logind.enabled())
+use_logind = use_logind.disable_auto_if(use_elogind.enabled())
+logind_dep = dependency('libsystemd', version: '>= 254', required: use_logind)
+cdata.set('USE_LIBSYSTEMD', logind_dep.found() ? 1 : false)
+if not logind_dep.found()
+  logind_dep = dependency('libelogind', version: '>= 254', required: use_elogind)
+  cdata.set('USE_LIBELOGIND', logind_dep.found() ? 1 : false)
+endif
+cdata.set('USE_LOGIND', logind_dep.found() ? 1 : false)
 
 systemdunitdir = get_option('systemdunitdir')
 if systemdunitdir == ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,7 +9,9 @@ option('audit', type: 'feature', value: 'auto',
 option('econf', type: 'feature', value: 'auto',
        description: 'libeconf support')
 option('logind', type: 'feature', value: 'auto',
-       description: 'logind support in pam_issue, pam_limits, and pam_timestamp')
+       description: 'logind support in pam_issue, pam_limits, and pam_timestamp via systemd')
+option('elogind', type: 'feature', value: 'auto',
+       description: 'logind support in pam_issue, pam_limits, and pam_timestamp via elogind')
 option('openssl', type: 'feature', value: 'disabled',
        description: 'Use OpenSSL crypto libraries in pam_timestamp')
 option('selinux', type: 'feature', value: 'auto',

--- a/modules/module-meson.build
+++ b/modules/module-meson.build
@@ -16,7 +16,7 @@ if module == 'pam_faillock'
   pam_module_deps += [libaudit]
 endif
 if module == 'pam_issue'
-  pam_module_deps += [libsystemd]
+  pam_module_deps += [logind_dep]
 endif
 if module == 'pam_keyinit'
   if not enable_pam_keyinit
@@ -32,7 +32,7 @@ endif
 if module == 'pam_limits'
   limits_conf_dir = sconfigdir / 'limits.d'
   pam_module_c_args += ['-DLIMITS_FILE_DIR="@0@"'.format(limits_conf_dir)]
-  pam_module_deps += [libsystemd]
+  pam_module_deps += [logind_dep]
 endif
 if module == 'pam_loginuid'
   pam_module_deps += [libaudit]
@@ -90,7 +90,7 @@ if module == 'pam_timestamp'
   else
     pam_module_src += ['hmacsha1.c', 'sha1.c']
   endif
-  pam_module_deps += [libcrypto, libsystemd]
+  pam_module_deps += [libcrypto, logind_dep]
 endif
 if module == 'pam_tty_audit'
   if cdata.get('HAVE_STRUCT_AUDIT_TTY_STATUS', 0) == 0
@@ -408,7 +408,7 @@ if module == 'pam_timestamp'
     'pam_timestamp_check',
     sources: ['pam_timestamp_check.c'],
     link_args: exe_link_args,
-    dependencies: [libpam_internal_dep, libpam_dep, libsystemd],
+    dependencies: [libpam_internal_dep, libpam_dep, logind_dep],
     install: true,
     install_dir: sbindir,
   )

--- a/modules/pam_issue/pam_issue.c
+++ b/modules/pam_issue/pam_issue.c
@@ -28,8 +28,10 @@
 #include <time.h>
 #include <syslog.h>
 
-#ifdef USE_LOGIND
+#ifdef USE_LIBSYSTEMD
 #include <systemd/sd-login.h>
+#elif defined(USE_LIBELOGIND)
+#include <elogind/sd-login.h>
 #else
 #include <utmp.h>
 #endif

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -36,8 +36,10 @@
 #include <sys/resource.h>
 #include <limits.h>
 #include <glob.h>
-#ifdef USE_LOGIND
+#ifdef USE_LIBSYSTEMD
 #include <systemd/sd-login.h>
+#elif defined(USE_LIBELOGIND)
+#include <elogind/sd-login.h>
 #else
 #include <utmp.h>
 #endif

--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -61,8 +61,10 @@
 #include "hmacsha1.h"
 #endif /* WITH_OPENSSL */
 
-#ifdef USE_LOGIND
+#ifdef USE_LIBSYSTEMD
 #include <systemd/sd-login.h>
+#elif defined(USE_LIBELOGIND)
+#include <elogind/sd-login.h>
 #else
 #include <utmp.h>
 #endif


### PR DESCRIPTION
The systemd functionality used here is also supported by elogind. Search for libelogind as well and use the appropriate headers.

Not sure what approach is wanted here. I opted to not change the semantics of the `logind` option and just search for both libraries.