### PR TITLE
pam_unix: fix diagnostic message in debug mode

### DIFF
--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -545,7 +545,7 @@ static int _pam_unix_approve_pass(pam_handle_t * pamh
 	const char *remark = NULL;
 	int retval = PAM_SUCCESS;
 
-	D(("&new=%p, &old=%p", pass_old, pass_new));
+	D(("&new=%p, &old=%p", pass_new, pass_old));
 	D(("new=[%s]", pass_new));
 	D(("old=[%s]", pass_old));
 


### PR DESCRIPTION
When configured using -Dpam-debug=true, _pam_unix_approve_pass prints
a diagnostic message with addresses of password strings.  Apparently,
since the times predating the git history of the project in this
diagnostic message the addresses of the old and new passwords were
mixed up.