### PR TITLE
meson.build: fix pam_namespace.service installation with custom prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -334,10 +334,13 @@ if systemdunitdir == ''
   systemdunitdir = prefixdir / 'lib' / 'systemd' / 'system'
   systemd = dependency('systemd', required: false)
   if systemd.found()
-    systemdunitdir = systemd.get_variable(
+    systemdsystemunitdir = systemd.get_variable(
       pkgconfig: 'systemdsystemunitdir',
       default_value: systemdunitdir,
     )
+    if systemdsystemunitdir.startswith(prefixdir / '')
+      systemdunitdir = systemdsystemunitdir
+    endif
   endif
 endif
 


### PR DESCRIPTION
When build is configured with a custom prefix, ignore the value of systemdsystemunitdir pkgconfig variable if it doesn't start with that custom prefix.

Resolves: https://github.com/linux-pam/linux-pam/issues/863