### PR TITLE
pam_unix: do not overwrite the string returned by crypt_r

### DIFF
--- a/modules/pam_unix/bigcrypt.c
+++ b/modules/pam_unix/bigcrypt.c
@@ -116,7 +116,9 @@ char *bigcrypt(const char *key, const char *salt)
 	}
 	/* and place in the static area */
 	strncpy(cipher_ptr, tmp_ptr, 13);
+#ifndef HAVE_CRYPT_R
 	pam_overwrite_string(tmp_ptr);
+#endif
 	cipher_ptr += ESEGMENT_SIZE + SALT_SIZE;
 	plaintext_ptr += SEGMENT_SIZE;	/* first block of SEGMENT_SIZE */
 
@@ -149,7 +151,9 @@ char *bigcrypt(const char *key, const char *salt)
 
 			/* skip the salt for seg!=0 */
 			strncpy(cipher_ptr, (tmp_ptr + SALT_SIZE), ESEGMENT_SIZE);
+#ifndef HAVE_CRYPT_R
 			pam_overwrite_string(tmp_ptr);
+#endif
 
 			cipher_ptr += ESEGMENT_SIZE;
 			plaintext_ptr += SEGMENT_SIZE;

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -522,20 +522,20 @@ PAMH_ARG_DECL(char * create_password_hash,
 			   on(UNIX_BLOWFISH_PASS, ctrl) ? "blowfish" :
 			   on(UNIX_SHA256_PASS, ctrl) ? "sha256" :
 			   on(UNIX_SHA512_PASS, ctrl) ? "sha512" : algoid);
-		if(sp) {
-		   pam_overwrite_string(sp);
-		}
 #ifdef HAVE_CRYPT_R
 		pam_overwrite_object(cdata);
 		free(cdata);
+#else
+		pam_overwrite_string(sp);
 #endif
 		return NULL;
 	}
 	ret = strdup(sp);
-	pam_overwrite_string(sp);
 #ifdef HAVE_CRYPT_R
 	pam_overwrite_object(cdata);
 	free(cdata);
+#else
+	pam_overwrite_string(sp);
 #endif
 	return ret;
 }


### PR DESCRIPTION
Given that the crypt_data storage passed to crypt_r is cleared afterwards, there is no point to clear the string returned by crypt_r. This also fixes the issue with those crypt_r implementations that can return a pointer to read-only memory.

Resolves: https://github.com/linux-pam/linux-pam/issues/866