### PR TITLE
pam_listfile: Few changes on the checks done on the configuration file

### DIFF
--- a/modules/pam_listfile/pam_listfile.8.xml
+++ b/modules/pam_listfile/pam_listfile.8.xml
@@ -126,7 +126,9 @@
           <listitem>
             <para>
               File containing one item per line. The file needs to be a plain
-              file and not world writable.
+              file and not world writable. It must be owned by the real user
+              (not the effective user) who has executed the application that
+              is using this PAM module.
             </para>
           </listitem>
 	</varlistentry>
@@ -137,8 +139,8 @@
           </term>
           <listitem>
             <para>
-              What to do if something weird happens like being unable to open
-              the file.
+              What to do if something weird happens like a problem while
+              opening the file. The default value is fail.
             </para>
           </listitem>
         </varlistentry>
@@ -162,8 +164,7 @@
           </term>
           <listitem>
             <para>
-              Do not treat service refusals or missing list files as
-              errors that need to be logged.
+              Do not treat service refusals as errors that need to be logged.
             </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
I have been using pam_listfile for a while and I was curious about some details of the implementation. While looking at the source code I found a couple of issues in the checks done on the configuration file that I thought could be improved:  

- Currently the file checks are done with lstat() and afterwards the file is open with open(). This has the potential issue of someone being able to replace the configuration file after the checks have been done. I made a check in which I point to a configuration file in /tmp and I added an artificial additional sleep() between the checks and the open() calls. In between a malicious user can change the configuration file, specially if the user has write permission in the directory.

- Check that the configuration file is owned by the user which runs the PAM application. For the typical usage in a Linux login this would mean root.

- Consistently return error code based on onerr parameter. According to the documentation the onerr parameter specifies what return code should be set if there is a problem with the configuration file.

This is my first PR to linux-pam, so apologies if it does not follow some standard practices of the project.