### PR TITLE
pam_issue: fix potential memory leak when PAM_USER_PROMPT is set

### DIFF
--- a/modules/pam_issue/pam_issue.c
+++ b/modules/pam_issue/pam_issue.c
@@ -314,6 +314,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
 	    retval = PAM_BUF_ERR;
 	    goto out;
 	}
+	free(issue_prompt);
 	issue_prompt = new_prompt;
     }
 


### PR DESCRIPTION
* modules/pam_issue/pam_issue.c (pam_sm_authenticate): Free issue_prompt before assigning a new string.