### PR TITLE
pam_inline.h: introduce pam_asprintf(), pam_snprintf(), and pam_sprintf() helpers

### DIFF
--- a/libpam/include/pam_cc_compat.h
+++ b/libpam/include/pam_cc_compat.h
@@ -21,6 +21,12 @@
 # define PAM_ATTRIBUTE_ALIGNED(arg)	/* empty */
 #endif
 
+#if PAM_GNUC_PREREQ(3, 0)
+# define PAM_ATTRIBUTE_MALLOC		__attribute__((__malloc__))
+#else
+# define PAM_ATTRIBUTE_MALLOC		/* empty */
+#endif
+
 #if PAM_GNUC_PREREQ(4, 6)
 # define DIAG_PUSH_IGNORE_CAST_QUAL					\
 	_Pragma("GCC diagnostic push");					\

--- a/libpam/include/pam_inline.h
+++ b/libpam/include/pam_inline.h
@@ -9,6 +9,8 @@
 #define PAM_INLINE_H
 
 #include "pam_cc_compat.h"
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -144,6 +146,39 @@ pam_drop_response(struct pam_response *reply, int replies)
 	}
 	free(reply);
 }
+
+static inline char * PAM_FORMAT((printf, 1, 2)) PAM_NONNULL((1)) PAM_ATTRIBUTE_MALLOC
+pam_asprintf(const char *fmt, ...)
+{
+	int rc;
+	char *res;
+	va_list ap;
+
+	va_start(ap, fmt);
+	rc = vasprintf(&res, fmt, ap);
+	va_end(ap);
+
+	return rc < 0 ? NULL : res;
+}
+
+static inline int PAM_FORMAT((printf, 3, 4)) PAM_NONNULL((3))
+pam_snprintf(char *str, size_t size, const char *fmt, ...)
+{
+	int rc;
+	va_list ap;
+
+	va_start(ap, fmt);
+	rc = vsnprintf(str, size, fmt, ap);
+	va_end(ap);
+
+	if (rc < 0 || (unsigned int) rc >= size)
+		return -1;
+	return rc;
+}
+
+#define pam_sprintf(str_, fmt_, ...)						\
+	pam_snprintf((str_), sizeof(str_) + PAM_MUST_BE_ARRAY(str_), (fmt_),	\
+		     ##__VA_ARGS__)
 
 
 static inline int

--- a/libpam/pam_audit.c
+++ b/libpam/pam_audit.c
@@ -8,6 +8,7 @@
 
 #include "pam_private.h"
 #include "pam_modutil_private.h"
+#include "pam_inline.h"
 
 #ifdef HAVE_LIBAUDIT
 #include <stdio.h>
@@ -37,7 +38,7 @@ _pam_audit_writelog(pam_handle_t *pamh, int audit_fd, int type,
       grantors_field = "";
   }
 
-  if (asprintf(&buf, "PAM:%s%s%s", message, grantors_field, grantors) >= 0) {
+  if ((buf = pam_asprintf("PAM:%s%s%s", message, grantors_field, grantors)) != NULL) {
       rc = audit_log_acct_message(audit_fd, type, NULL, buf,
 	(retval != PAM_USER_UNKNOWN && pamh->user) ? pamh->user : "?",
 	-1, pamh->rhost, NULL, pamh->tty, retval == PAM_SUCCESS);

--- a/libpam/pam_handlers.c
+++ b/libpam/pam_handlers.c
@@ -312,7 +312,7 @@ _pam_open_config_file(pam_handle_t *pamh
 	    return PAM_BUF_ERR;
 	}
     } else if (pamh->confdir != NULL) {
-        if (asprintf (&p, "%s/%s", pamh->confdir, service) < 0) {
+	if ((p = pam_asprintf("%s/%s", pamh->confdir, service)) == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "asprintf failed");
 	    return PAM_BUF_ERR;
 	}
@@ -332,7 +332,7 @@ _pam_open_config_file(pam_handle_t *pamh
 
     for (i = 0; i < PAM_ARRAY_SIZE(pamd_dirs); i++) {
 	DIAG_PUSH_IGNORE_FORMAT_NONLITERAL
-	if (asprintf (&p, pamd_dirs[i], service) < 0) {
+	if ((p = pam_asprintf(pamd_dirs[i], service)) == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "asprintf failed");
 	    return PAM_BUF_ERR;
 	}
@@ -648,10 +648,10 @@ _pam_load_module(pam_handle_t *pamh, const char *mod_path, int handler_type)
 	    size_t isa_len = strlen("$ISA");
 
 	    if (isa != NULL) {
-		char *mod_full_isa_path = NULL;
-		if (strlen(mod_path) >= INT_MAX ||
-			asprintf(&mod_full_isa_path, "%.*s%s%s",
-			(int)(isa - mod_path), mod_path, _PAM_ISA, isa + isa_len) < 0) {
+		char *mod_full_isa_path = strlen(mod_path) >= INT_MAX ? NULL :
+			pam_asprintf("%.*s%s%s", (int)(isa - mod_path),
+				     mod_path, _PAM_ISA, isa + isa_len);
+		if (mod_full_isa_path == NULL) {
 		    D(("couldn't get memory for mod_path"));
 		    pam_syslog(pamh, LOG_CRIT, "no memory for module path");
 		    success = PAM_ABORT;
@@ -722,8 +722,8 @@ static int _pam_add_handler(pam_handle_t *pamh
 	mod_path != NULL) {
 	if (mod_path[0] == '/') {
 	    mod = _pam_load_module(pamh, mod_path, handler_type);
-	} else if (asprintf(&mod_full_path, "%s%s",
-			     DEFAULT_MODULE_PATH, mod_path) >= 0) {
+	} else if ((mod_full_path = pam_asprintf("%s%s", DEFAULT_MODULE_PATH,
+						 mod_path)) != NULL) {
 	    mod = _pam_load_module(pamh, mod_full_path, handler_type);
 	    _pam_drop(mod_full_path);
 	} else {

--- a/libpam/pam_modutil_getgrnam.c
+++ b/libpam/pam_modutil_getgrnam.c
@@ -8,22 +8,13 @@
  */
 
 #include "pam_modutil_private.h"
+#include "pam_inline.h"
 
 #include <errno.h>
 #include <limits.h>
 #include <grp.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-static int intlen(int number)
-{
-    int len = 2;
-    while (number != 0) {
-        number /= 10;
-	len++;
-    }
-    return len;
-}
 
 struct group *
 pam_modutil_getgrnam(pam_handle_t *pamh, const char *group)
@@ -55,27 +46,25 @@ pam_modutil_getgrnam(pam_handle_t *pamh, const char *group)
 			    sizeof(struct group) + (char *) buffer,
 			    length, &result);
 	if (!status && (result == buffer)) {
-	    char *data_name;
 	    const void *ignore;
 	    int i;
 
-	    data_name = malloc(strlen("_pammodutil_getgrnam") + 1 +
-			       strlen(group) + 1 + intlen(INT_MAX) + 1);
-	    if ((pamh != NULL) && (data_name == NULL)) {
-	        D(("was unable to register the data item [%s]",
-	           pam_strerror(pamh, status)));
-		free(buffer);
-		return NULL;
-	    }
-
 	    if (pamh != NULL) {
 	        for (i = 0; i < INT_MAX; i++) {
-	            sprintf(data_name, "_pammodutil_getgrnam_%s_%d", group, i);
+	            char *data_name = pam_asprintf("_pammodutil_getgrnam_%s_%d",
+						   group, i);
+		    if (data_name == NULL) {
+			D(("was unable to register the data item [%s]",
+			   pam_strerror(pamh, status)));
+			free(buffer);
+			return NULL;
+		    }
 		    status = PAM_NO_MODULE_DATA;
 	            if (pam_get_data(pamh, data_name, &ignore) != PAM_SUCCESS) {
 		        status = pam_set_data(pamh, data_name,
 					      result, pam_modutil_cleanup);
 		    }
+		    free(data_name);
 		    if (status == PAM_SUCCESS) {
 		        break;
 		    }
@@ -83,8 +72,6 @@ pam_modutil_getgrnam(pam_handle_t *pamh, const char *group)
 	    } else {
 	        status = PAM_SUCCESS;
 	    }
-
-	    free(data_name);
 
 	    if (status == PAM_SUCCESS) {
 		D(("success"));

--- a/libpam/pam_modutil_getpwnam.c
+++ b/libpam/pam_modutil_getpwnam.c
@@ -8,22 +8,13 @@
  */
 
 #include "pam_modutil_private.h"
+#include "pam_inline.h"
 
 #include <errno.h>
 #include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-static int intlen(int number)
-{
-    int len = 2;
-    while (number != 0) {
-        number /= 10;
-	len++;
-    }
-    return len;
-}
 
 struct passwd *
 pam_modutil_getpwnam(pam_handle_t *pamh, const char *user)
@@ -55,27 +46,25 @@ pam_modutil_getpwnam(pam_handle_t *pamh, const char *user)
 			    sizeof(struct passwd) + (char *) buffer,
 			    length, &result);
 	if (!status && (result == buffer)) {
-	    char *data_name;
 	    const void *ignore;
 	    int i;
 
-	    data_name = malloc(strlen("_pammodutil_getpwnam") + 1 +
-			       strlen(user) + 1 + intlen(INT_MAX) + 1);
-	    if ((pamh != NULL) && (data_name == NULL)) {
-	        D(("was unable to register the data item [%s]",
-	           pam_strerror(pamh, status)));
-		free(buffer);
-		return NULL;
-	    }
-
 	    if (pamh != NULL) {
 	        for (i = 0; i < INT_MAX; i++) {
-	            sprintf(data_name, "_pammodutil_getpwnam_%s_%d", user, i);
+		    char *data_name = pam_asprintf("_pammodutil_getpwnam_%s_%d",
+						   user, i);
+		    if (data_name == NULL) {
+			D(("was unable to register the data item [%s]",
+			   pam_strerror(pamh, status)));
+			free(buffer);
+			return NULL;
+		    }
 		    status = PAM_NO_MODULE_DATA;
 	            if (pam_get_data(pamh, data_name, &ignore) != PAM_SUCCESS) {
 		        status = pam_set_data(pamh, data_name,
 					      result, pam_modutil_cleanup);
 		    }
+		    free(data_name);
 		    if (status == PAM_SUCCESS) {
 		        break;
 		    }
@@ -83,8 +72,6 @@ pam_modutil_getpwnam(pam_handle_t *pamh, const char *user)
 	    } else {
 	        status = PAM_SUCCESS;
 	    }
-
-	    free(data_name);
 
 	    if (status == PAM_SUCCESS) {
 		D(("success"));

--- a/libpam/pam_modutil_getpwuid.c
+++ b/libpam/pam_modutil_getpwuid.c
@@ -8,32 +8,13 @@
  */
 
 #include "pam_modutil_private.h"
+#include "pam_inline.h"
 
 #include <errno.h>
 #include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-static int intlen(int number)
-{
-    int len = 2;
-    while (number != 0) {
-        number /= 10;
-	len++;
-    }
-    return len;
-}
-
-static int longlen(long number)
-{
-    int len = 2;
-    while (number != 0) {
-        number /= 10;
-	len++;
-    }
-    return len;
-}
 
 struct passwd *
 pam_modutil_getpwuid(pam_handle_t *pamh, uid_t uid)
@@ -65,28 +46,25 @@ pam_modutil_getpwuid(pam_handle_t *pamh, uid_t uid)
 			    sizeof(struct passwd) + (char *) buffer,
 			    length, &result);
 	if (!status && (result == buffer)) {
-	    char *data_name;
 	    const void *ignore;
 	    int i;
 
-	    data_name = malloc(strlen("_pammodutil_getpwuid") + 1 +
-			       longlen((long) uid) + 1 + intlen(INT_MAX) + 1);
-	    if ((pamh != NULL) && (data_name == NULL)) {
-	        D(("was unable to register the data item [%s]",
-	           pam_strerror(pamh, status)));
-		free(buffer);
-		return NULL;
-	    }
-
 	    if (pamh != NULL) {
 	        for (i = 0; i < INT_MAX; i++) {
-	            sprintf(data_name, "_pammodutil_getpwuid_%ld_%d",
-			    (long) uid, i);
+		    char *data_name = pam_asprintf("_pammodutil_getpwuid_%ld_%d",
+						   (long) uid, i);
+		    if (data_name == NULL) {
+			D(("was unable to register the data item [%s]",
+			   pam_strerror(pamh, status)));
+			free(buffer);
+			return NULL;
+		    }
 		    status = PAM_NO_MODULE_DATA;
 	            if (pam_get_data(pamh, data_name, &ignore) != PAM_SUCCESS) {
 		        status = pam_set_data(pamh, data_name,
 					      result, pam_modutil_cleanup);
 		    }
+		    free(data_name);
 		    if (status == PAM_SUCCESS) {
 		        break;
 		    }
@@ -94,8 +72,6 @@ pam_modutil_getpwuid(pam_handle_t *pamh, uid_t uid)
 	    } else {
 	        status = PAM_SUCCESS;
 	    }
-
-	    free(data_name);
 
 	    if (status == PAM_SUCCESS) {
 		D(("success"));

--- a/libpam/pam_syslog.c
+++ b/libpam/pam_syslog.c
@@ -32,6 +32,7 @@
  */
 
 #include "pam_private.h"
+#include "pam_inline.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,9 +77,10 @@ pam_vsyslog (const pam_handle_t *pamh, int priority,
 
   if (pamh && pamh->mod_name)
     {
-      if (asprintf (&msgbuf1, "%s(%s:%s):", pamh->mod_name,
-		    pamh->service_name?pamh->service_name:"<unknown>",
-		    _pam_choice2str (pamh->choice)) < 0)
+      msgbuf1 = pam_asprintf("%s(%s:%s):", pamh->mod_name,
+		    pamh->service_name ? pamh->service_name : "<unknown>",
+		    _pam_choice2str (pamh->choice));
+      if (msgbuf1 == NULL)
 	{
 	  syslog (LOG_AUTHPRIV|LOG_ERR, "asprintf: %m");
 	  return;

--- a/libpam_internal/pam_econf.c
+++ b/libpam_internal/pam_econf.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <security/_pam_macros.h>
+#include "pam_inline.h"
 #include "pam_econf.h"
 
 econf_err pam_econf_readconfig(econf_file **key_file,
@@ -23,8 +24,9 @@ econf_err pam_econf_readconfig(econf_file **key_file,
 
 #ifdef HAVE_ECONF_READCONFIG
 
-    char *parsing_dirs = NULL;
-    if (asprintf(&parsing_dirs, "PARSING_DIRS=%s:%s", usr_conf_dir, etc_conf_dir) < 0) {
+    char *parsing_dirs =
+	pam_asprintf("PARSING_DIRS=%s:%s", usr_conf_dir, etc_conf_dir);
+    if (parsing_dirs == NULL) {
         ret = ECONF_NOMEM;
         parsing_dirs = NULL;
     }

--- a/libpam_misc/help_env.c
+++ b/libpam_misc/help_env.c
@@ -75,7 +75,7 @@ int pam_misc_setenv(pam_handle_t *pamh, const char *name
 	    return PAM_PERM_DENIED;          /* not allowed to overwrite */
 	}
     }
-    if (asprintf(&tmp, "%s=%s", name, value) >= 0) {
+    if ((tmp = pam_asprintf("%s=%s", name, value)) != NULL) {
 	D(("pam_putt()ing: %s", tmp));
 	retval = pam_putenv(pamh, tmp);
 	pam_overwrite_string(tmp);           /* purge */

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -11,8 +11,8 @@
 
 static int __pamc_exec_agent(pamc_handle_t pch, pamc_agent_t *agent)
 {
-    char *full_path;
-    int found_agent, length, reset_length, to_agent[2], from_agent[2];
+    char *full_path = NULL;
+    int found_agent, length, to_agent[2], from_agent[2];
     int return_code = PAM_BPC_FAIL;
 
     if (agent->id[agent->id_length] != '\0') {
@@ -27,16 +27,6 @@ static int __pamc_exec_agent(pamc_handle_t pch, pamc_agent_t *agent)
 	}
     }
 
-    /* enough memory for any path + this agent */
-    reset_length = 3 + pch->max_path + agent->id_length;
-    D(("reset_length = %d (3+%d+%d)",
-       reset_length, pch->max_path, agent->id_length));
-    full_path = malloc(reset_length);
-    if (full_path == NULL) {
-	D(("no memory for agent path"));
-	return PAM_BPC_FAIL;
-    }
-
     found_agent = 0;
     for (length=0; pch->agent_paths[length]; ++length) {
 	struct stat buf;
@@ -44,7 +34,10 @@ static int __pamc_exec_agent(pamc_handle_t pch, pamc_agent_t *agent)
 	D(("path: [%s]", pch->agent_paths[length]));
 	D(("agent id: [%s]", agent->id));
 
-	sprintf(full_path, "%s/%s", pch->agent_paths[length], agent->id);
+	if ((full_path = pam_asprintf("%s/%s", pch->agent_paths[length], agent->id)) == NULL) {
+	    D(("no memory for agent path"));
+	    return PAM_BPC_FAIL;
+	}
 
 	D(("looking for agent here: [%s]\n", full_path));
 	if (stat(full_path, &buf) == 0) {
@@ -52,6 +45,9 @@ static int __pamc_exec_agent(pamc_handle_t pch, pamc_agent_t *agent)
 	    found_agent = 1;
 	    break;
 	}
+
+	free(full_path);
+	full_path = NULL;
     }
 
     if (! found_agent) {

--- a/libpamc/pamc_load.c
+++ b/libpamc/pamc_load.c
@@ -144,7 +144,6 @@ close_the_agent:
     close(to_agent[1]);
 
 free_and_return:
-    pam_overwrite_n(full_path, reset_length);
     free(full_path);
 
     D(("returning %d", return_code));

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -648,8 +648,7 @@ user_name_or_uid_match(pam_handle_t *pamh, const char *tok,
 	return NO;
 
     char buf[sizeof(long long) * 3 + 1];
-    snprintf(buf, sizeof(buf), "%llu",
-	     zero_extend_signed_to_ull(item->user->pw_uid));
+    pam_sprintf(buf, "%llu", zero_extend_signed_to_ull(item->user->pw_uid));
     if (item->debug)
 	pam_syslog(pamh, LOG_DEBUG, "user_match: tok=%s, uid=%s", tok, buf);
 

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -217,24 +217,24 @@ econf_read_file(const pam_handle_t *pamh, const char *filename, const char *deli
       char *vendor_dir = NULL, *sysconf_dir;
       if (subpath != NULL && subpath[0] != '\0') {
 #ifdef VENDORDIR
-	if (asprintf(&vendor_dir, "%s%s/%s/", base_dir, VENDORDIR, subpath) < 0) {
+	if ((vendor_dir = pam_asprintf("%s%s/%s/", base_dir, VENDORDIR, subpath)) == NULL) {
 	  pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
 	  return PAM_BUF_ERR;
 	}
 #endif
-	if (asprintf(&sysconf_dir, "%s%s/%s/", base_dir, SYSCONFDIR, subpath) < 0) {
+	if ((sysconf_dir = pam_asprintf("%s%s/%s/", base_dir, SYSCONFDIR, subpath)) == NULL) {
 	  pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
 	  free(vendor_dir);
 	  return PAM_BUF_ERR;
 	}
       } else {
 #ifdef VENDORDIR
-	if (asprintf(&vendor_dir, "%s%s/", base_dir, VENDORDIR) < 0) {
+	if ((vendor_dir = pam_asprintf("%s%s/", base_dir, VENDORDIR)) == NULL) {
 	  pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
 	  return PAM_BUF_ERR;
 	}
 #endif
-	if (asprintf(&sysconf_dir, "%s%s/", base_dir, SYSCONFDIR) < 0) {
+	if ((sysconf_dir = pam_asprintf("%s%s/", base_dir, SYSCONFDIR)) == NULL) {
 	  pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
 	  free(vendor_dir);
 	  return PAM_BUF_ERR;
@@ -291,7 +291,7 @@ econf_read_file(const pam_handle_t *pamh, const char *filename, const char *deli
 		   econf_errString(error));
       } else {
         econf_unescnl(val);
-        if (asprintf(&(*lines)[n],"%s%c%s", keys[i], delim[0], val) < 0) {
+        if (((*lines)[n] = pam_asprintf("%s%c%s", keys[i], delim[0], val)) == NULL) {
 	  pam_syslog(pamh, LOG_ERR, "Cannot allocate memory.");
           econf_free(keys);
           econf_freeFile(key_file);
@@ -831,7 +831,7 @@ _define_var(pam_handle_t *pamh, int ctrl, VAR *var)
   int retval = PAM_SUCCESS;
 
   D(("Called."));
-  if (asprintf(&envvar, "%s=%s", var->name, var->value) < 0) {
+  if ((envvar = pam_asprintf("%s=%s", var->name, var->value)) == NULL) {
     pam_syslog(pamh, LOG_CRIT, "out of memory");
     return PAM_BUF_ERR;
   }
@@ -1073,7 +1073,7 @@ handle_env (pam_handle_t *pamh, int argc, const char **argv)
       pam_syslog(pamh, LOG_ERR, "No such user!?");
     }
     else {
-      if (asprintf(&envpath, "%s/%s", user_entry->pw_dir, user_env_file) < 0)
+      if ((envpath = pam_asprintf("%s/%s", user_entry->pw_dir, user_env_file)) == NULL)
 	{
 	  pam_syslog(pamh, LOG_CRIT, "Out of memory");
 	  return PAM_BUF_ERR;

--- a/modules/pam_exec/pam_exec.c
+++ b/modules/pam_exec/pam_exec.c
@@ -378,7 +378,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
       else if (logfile)
 	{
 	  time_t tm = time (NULL);
-	  char *buffer = NULL;
+	  char *buffer;
 
 	  close (STDOUT_FILENO);
 	  if ((i = open (logfile, O_CREAT|O_APPEND|O_WRONLY,
@@ -399,7 +399,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 		}
 	      close (i);
 	    }
-	  if (asprintf (&buffer, "*** %s", ctime (&tm)) > 0)
+	  if ((buffer = pam_asprintf ("*** %s", ctime (&tm))) != NULL)
 	    {
 	      pam_modutil_write (STDOUT_FILENO, buffer, strlen (buffer));
 	      free (buffer);
@@ -463,7 +463,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
 
         if (pam_get_item(pamh, env_items[i].item, &item) != PAM_SUCCESS || item == NULL)
           continue;
-        if (asprintf(&envstr, "%s=%s", env_items[i].name, (const char *)item) < 0)
+        if ((envstr = pam_asprintf("%s=%s", env_items[i].name, (const char *)item)) == NULL)
         {
           pam_syslog (pamh, LOG_CRIT, "prepare environment failed: %m");
           _exit (ENOMEM);
@@ -472,7 +472,7 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
         envlist[envlen] = NULL;
       }
 
-      if (asprintf(&envstr, "PAM_TYPE=%s", pam_type) < 0)
+      if ((envstr = pam_asprintf("PAM_TYPE=%s", pam_type)) == NULL)
         {
           pam_syslog (pamh, LOG_CRIT, "prepare environment failed: %m");
           _exit (ENOMEM);

--- a/modules/pam_faillock/faillock.c
+++ b/modules/pam_faillock/faillock.c
@@ -47,6 +47,7 @@
 #include <security/pam_modutil.h>
 
 #include "faillock.h"
+#include "pam_inline.h"
 
 #define ignore_return(x) if (1==((int)(x))) {;}
 
@@ -55,7 +56,7 @@ open_tally (const char *dir, const char *user, uid_t uid, int create)
 {
 	char *path;
 	int flags = O_RDWR;
-	int fd, r;
+	int fd;
 
 	if (dir == NULL || strstr(user, "../") != NULL)
 	/* just a defensive programming as the user must be a
@@ -63,10 +64,10 @@ open_tally (const char *dir, const char *user, uid_t uid, int create)
 	 */
 		return -1;
 	if (*dir && dir[strlen(dir) - 1] != '/')
-		r = asprintf(&path, "%s/%s", dir, user);
+		path = pam_asprintf("%s/%s", dir, user);
 	else
-		r = asprintf(&path, "%s%s", dir, user);
-	if (r < 0)
+		path = pam_asprintf("%s%s", dir, user);
+	if (path == NULL)
 		return -1;
 
 	if (create) {

--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -253,7 +253,7 @@ check_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 
 				(void)pam_get_item(pamh, PAM_TTY, &tty);
 				(void)pam_get_item(pamh, PAM_RHOST, &rhost);
-				snprintf(buf, sizeof(buf), "op=pam_faillock suid=%u ", opts->uid);
+				pam_sprintf(buf, "op=pam_faillock suid=%u ", opts->uid);
 				if (audit_log_user_message(audit_fd, AUDIT_RESP_ACCT_UNLOCK_TIMED, buf,
 							   rhost, NULL, tty, 1) <= 0)
 					pam_syslog(pamh, LOG_ERR,
@@ -372,7 +372,7 @@ write_tally(pam_handle_t *pamh, struct options *opts, struct tally_data *tallies
 			errno == EAFNOSUPPORT))
 			return PAM_SYSTEM_ERR;
 
-		snprintf(buf, sizeof(buf), "op=pam_faillock suid=%u ", opts->uid);
+		pam_sprintf(buf, "op=pam_faillock suid=%u ", opts->uid);
 		if (audit_log_user_message(audit_fd, AUDIT_ANOM_LOGIN_FAILURES, buf,
 					   NULL, NULL, NULL, 1) <= 0)
 			pam_syslog(pamh, LOG_ERR,

--- a/modules/pam_filter/pam_filter.c
+++ b/modules/pam_filter/pam_filter.c
@@ -28,6 +28,7 @@
 #include <security/pam_modules.h>
 #include <security/pam_ext.h>
 #include "pam_filter.h"
+#include "pam_inline.h"
 
 /* ------ some tokens used for convenience throughout this file ------- */
 
@@ -146,7 +147,7 @@ static int process_args(pam_handle_t *pamh
 	    return -1;
 	}
 
-	if (asprintf(&levp[1], "SERVICE=%s", (const char *) tmp) < 0) {
+	if ((levp[1] = pam_asprintf("SERVICE=%s", (const char *) tmp)) == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for service name");
 	    free(levp[0]);
 	    free(levp);
@@ -159,7 +160,7 @@ static int process_args(pam_handle_t *pamh
 	    user = "<unknown>";
 	}
 
-	if (asprintf(&levp[2], "USER=%s", user) < 0) {
+	if ((levp[2] = pam_asprintf("USER=%s", user)) == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for user's name");
 	    free(levp[1]);
 	    free(levp[0]);
@@ -169,7 +170,7 @@ static int process_args(pam_handle_t *pamh
 
 	/* the "USER" variable */
 
-	if (asprintf(&levp[3], "TYPE=%s", type) < 0) {
+	if ((levp[3] = pam_asprintf("TYPE=%s", type)) == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "no memory for type");
 	    free(levp[2]);
 	    free(levp[1]);

--- a/modules/pam_issue/pam_issue.c
+++ b/modules/pam_issue/pam_issue.c
@@ -308,8 +308,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags UNUSED,
 
     if (item != NULL) {
 	const char *cur_prompt = item;
-	char *new_prompt;
-	if (asprintf(&new_prompt, "%s%s", issue_prompt, cur_prompt) < 0) {
+	char *new_prompt = pam_asprintf("%s%s", issue_prompt, cur_prompt);
+	if (new_prompt == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "out of memory");
 	    retval = PAM_BUF_ERR;
 	    goto out;

--- a/modules/pam_issue/pam_issue.c
+++ b/modules/pam_issue/pam_issue.c
@@ -142,12 +142,12 @@ read_issue_quoted(pam_handle_t *pamh, FILE *fp, char **prompt)
 		    tm = localtime(&now);
 
 		    if (c == 'd')
-			snprintf (buf, sizeof buf, "%s %s %d  %d",
-				weekday[tm->tm_wday], month[tm->tm_mon],
-				tm->tm_mday, tm->tm_year + 1900);
+			pam_sprintf(buf, "%s %s %d  %d",
+				    weekday[tm->tm_wday], month[tm->tm_mon],
+				    tm->tm_mday, tm->tm_year + 1900);
 		    else
-			snprintf (buf, sizeof buf, "%02d:%02d:%02d",
-				tm->tm_hour, tm->tm_min, tm->tm_sec);
+			pam_sprintf(buf, "%02d:%02d:%02d",
+				    tm->tm_hour, tm->tm_min, tm->tm_sec);
 		}
 		break;
 	      case 'l':
@@ -205,10 +205,10 @@ read_issue_quoted(pam_handle_t *pamh, FILE *fp, char **prompt)
 		    endutent();
 #endif
 		    if (c == 'U')
-			snprintf (buf, sizeof buf, "%u %s", users,
-			          (users == 1) ? "user" : "users");
+			pam_sprintf(buf, "%u %s",
+				    users, (users == 1) ? "user" : "users");
 		    else
-			snprintf (buf, sizeof buf, "%u", users);
+			pam_sprintf(buf, "%u", users);
 		    break;
 		}
 	      default:

--- a/modules/pam_lastlog/pam_lastlog.c
+++ b/modules/pam_lastlog/pam_lastlog.c
@@ -329,8 +329,8 @@ last_login_read(pam_handle_t *pamh, int announce, int last_fd, uid_t uid, time_t
 	    if ((announce & LASTLOG_HOST)
 		&& (last_login.ll_host[0] != '\0')) {
 		/* TRANSLATORS: " from <host>" */
-		if (asprintf(&host, _(" from %.*s"), UT_HOSTSIZE,
-			     last_login.ll_host) < 0) {
+		if ((host = pam_asprintf(_(" from %.*s"), UT_HOSTSIZE,
+					 last_login.ll_host)) == NULL) {
 		    pam_syslog(pamh, LOG_CRIT, "out of memory");
 		    retval = PAM_BUF_ERR;
 		    goto cleanup;
@@ -341,8 +341,8 @@ last_login_read(pam_handle_t *pamh, int announce, int last_fd, uid_t uid, time_t
 	    if ((announce & LASTLOG_LINE)
 		&& (last_login.ll_line[0] != '\0')) {
 		/* TRANSLATORS: " on <terminal>" */
-		if (asprintf(&line, _(" on %.*s"), UT_LINESIZE,
-			     last_login.ll_line) < 0) {
+		if ((line = pam_asprintf(_(" on %.*s"), UT_LINESIZE,
+					 last_login.ll_line)) == NULL) {
 		    pam_syslog(pamh, LOG_CRIT, "out of memory");
 		    retval = PAM_BUF_ERR;
 		    goto cleanup;
@@ -598,8 +598,8 @@ last_login_failed(pam_handle_t *pamh, int announce, const char *user, time_t llt
 	if ((announce & LASTLOG_HOST)
 		&& (utuser.ut_host[0] != '\0')) {
 	    /* TRANSLATORS: " from <host>" */
-	    if (asprintf(&host, _(" from %.*s"), UT_HOSTSIZE,
-		    utuser.ut_host) < 0) {
+	    if ((host = pam_asprintf(_(" from %.*s"), UT_HOSTSIZE,
+				     utuser.ut_host)) == NULL) {
 		pam_syslog(pamh, LOG_CRIT, "out of memory");
 		retval = PAM_BUF_ERR;
 		goto cleanup;
@@ -610,8 +610,8 @@ last_login_failed(pam_handle_t *pamh, int announce, const char *user, time_t llt
 	if ((announce & LASTLOG_LINE)
 		&& (utuser.ut_line[0] != '\0')) {
 	    /* TRANSLATORS: " on <terminal>" */
-	    if (asprintf(&line, _(" on %.*s"), UT_LINESIZE,
-			utuser.ut_line) < 0) {
+	    if ((line = pam_asprintf(_(" on %.*s"), UT_LINESIZE,
+				     utuser.ut_line)) == NULL) {
 		pam_syslog(pamh, LOG_CRIT, "out of memory");
 		retval = PAM_BUF_ERR;
 		goto cleanup;
@@ -628,28 +628,26 @@ last_login_failed(pam_handle_t *pamh, int announce, const char *user, time_t llt
 
 	_pam_drop(line);
 #if defined HAVE_DNGETTEXT && defined ENABLE_NLS
-        retval = asprintf (&line, dngettext(PACKAGE,
+        line = pam_asprintf(dngettext(PACKAGE,
 		"There was %d failed login attempt since the last successful login.",
 		"There were %d failed login attempts since the last successful login.",
 		failed),
 	    failed);
 #else
 	if (failed == 1)
-	    retval = asprintf(&line,
+	    line = pam_asprintf(
 		_("There was %d failed login attempt since the last successful login."),
 		failed);
 	else
-	    retval = asprintf(&line,
+	    line = pam_asprintf(
 		/* TRANSLATORS: only used if dngettext is not supported */
 		_("There were %d failed login attempts since the last successful login."),
 		failed);
 #endif
-	if (retval >= 0)
+	if (line != NULL)
 		retval = pam_info(pamh, "%s", line);
-	else {
+	else
 		retval = PAM_BUF_ERR;
-		line = NULL;
-	}
     }
 
 cleanup:

--- a/modules/pam_mail/pam_mail.c
+++ b/modules/pam_mail/pam_mail.c
@@ -153,10 +153,9 @@ get_folder(pam_handle_t *pamh, int ctrl,
 
     retval = PAM_BUF_ERR;
     if (ctrl & PAM_HOME_MAIL) {
-	if (asprintf(&folder, MAIL_FILE_FORMAT, pwd->pw_dir, "", path) < 0)
+	if ((folder = pam_asprintf(MAIL_FILE_FORMAT, pwd->pw_dir, "", path)) == NULL)
 	    goto get_folder_cleanup;
     } else {
-	int rc;
 	size_t i;
 	char *hash;
 
@@ -169,10 +168,10 @@ get_folder(pam_handle_t *pamh, int ctrl,
 	}
 	hash[2 * i] = '\0';
 
-	rc = asprintf(&folder, MAIL_FILE_FORMAT, path, hash, pwd->pw_name);
+	folder = pam_asprintf(MAIL_FILE_FORMAT, path, hash, pwd->pw_name);
 	pam_overwrite_string(hash);
 	_pam_drop(hash);
-	if (rc < 0)
+	if (folder == NULL)
 	    goto get_folder_cleanup;
     }
     D(("folder=[%s]", folder));
@@ -206,7 +205,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
 	char *dir;
 	struct dirent **namelist;
 
-	if (asprintf(&dir, "%s/new", folder) < 0) {
+	if ((dir = pam_asprintf("%s/new", folder)) == NULL) {
 	    pam_syslog(pamh, LOG_CRIT, "out of memory");
 	    goto get_mail_status_cleanup;
 	}
@@ -227,7 +226,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
 	    _pam_drop(namelist[i]);
 	_pam_drop(namelist);
 	if (type == 0) {
-	    if (asprintf(&dir, "%s/cur", folder) < 0) {
+	    if ((dir = pam_asprintf("%s/cur", folder)) == NULL) {
 		pam_syslog(pamh, LOG_CRIT, "out of memory");
 		goto get_mail_status_cleanup;
 	    }
@@ -406,9 +405,9 @@ static int _do_mail(pam_handle_t *pamh, int flags, int argc,
     /* set the MAIL variable? */
 
     if (!(ctrl & PAM_NO_ENV) && est) {
-	char *tmp;
+	char *tmp = pam_asprintf(MAIL_ENV_FORMAT, folder);
 
-	if (asprintf(&tmp, MAIL_ENV_FORMAT, folder) < 0) {
+	if (tmp == NULL) {
 	    pam_syslog(pamh, LOG_CRIT,
 		       "no memory for " MAIL_ENV_NAME " variable");
 	    retval = PAM_BUF_ERR;

--- a/modules/pam_mkhomedir/mkhomedir_helper.c
+++ b/modules/pam_mkhomedir/mkhomedir_helper.c
@@ -25,6 +25,7 @@
 
 #include <security/pam_ext.h>
 #include <security/pam_modutil.h>
+#include "pam_inline.h"
 
 struct dir_spec {
    int fd;
@@ -61,7 +62,7 @@ fail:
 static int
 dir_spec_at(struct dir_spec *spec, struct dir_spec *parent, const char *path)
 {
-   if (asprintf(&spec->path, "%s/%s", parent->path, path) < 0)
+   if ((spec->path = pam_asprintf("%s/%s", parent->path, path)) == NULL)
       goto fail;
    spec->fd = openat(parent->fd, path, O_DIRECTORY | O_NOFOLLOW);
    if (spec->fd == -1)
@@ -94,10 +95,10 @@ copy_entry(struct dir_spec *parent, const struct passwd *pwd, mode_t dir_mode,
    int res;
    int retval = PAM_SESSION_ERR;
    struct stat st;
-   char *newsource = NULL;
+   char *newsource;
 
    /* Determine what kind of file it is. */
-   if (asprintf(&newsource, "%s/%s", source, dent->d_name) < 0)
+   if ((newsource = pam_asprintf("%s/%s", source, dent->d_name)) == NULL)
    {
       pam_syslog(NULL, LOG_CRIT, "asprintf failed for 'newsource'");
       retval = PAM_BUF_ERR;

--- a/modules/pam_mkhomedir/pam_mkhomedir.c
+++ b/modules/pam_mkhomedir/pam_mkhomedir.c
@@ -101,12 +101,8 @@ _pam_parse (const pam_handle_t *pamh, int flags, int argc, const char **argv,
 static char*
 _pam_conv_str_umask_to_homemode(const char *umask)
 {
-   unsigned int m = 0;
-   char tmp[5];
-
-   m = 0777 & ~strtoul(umask, NULL, 8);
-   (void) snprintf(tmp, sizeof(tmp), "0%o", m);
-   return strdup(tmp);
+   unsigned int m = 0777 & ~strtoul(umask, NULL, 8);
+   return pam_asprintf("%#o", m);
 }
 
 /* Do the actual work of creating a home dir */

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -122,18 +122,13 @@ static int pam_split_string(const pam_handle_t *pamh, char *arg, char delim,
 static char *join_dir_strings(const char *a_str, const char *b_str)
 {
     int has_sep;
-    int retval;
-    char *join_strp = NULL;
 
     if (a_str == NULL || b_str == NULL || strlen(a_str) == 0)
 	return NULL;
 
     has_sep = (a_str[strlen(a_str) - 1] == '/') || (b_str[0] == '/');
 
-    retval = asprintf(&join_strp, "%s%s%s", a_str,
-	(has_sep == 1) ? "" : "/", b_str);
-
-    return retval < 0 ? NULL : join_strp;
+    return pam_asprintf("%s%s%s", a_str, (has_sep == 1) ? "" : "/", b_str);
 }
 
 static int compare_strings(const void *a, const void *b)

--- a/modules/pam_motd/pam_motd.c
+++ b/modules/pam_motd/pam_motd.c
@@ -116,36 +116,24 @@ static int pam_split_string(const pam_handle_t *pamh, char *arg, char delim,
 }
 
 /* Join A_STR and B_STR, inserting a "/" between them if one is not already trailing
- * in A_STR or beginning B_STR. A pointer to a newly allocated string holding the
- * joined string is returned in STRP_OUT.
- * Returns -1 in case of error, or the number of bytes in the joined string in
- * case of success. */
-static int join_dir_strings(char **strp_out, const char *a_str, const char *b_str)
+ * in A_STR or beginning B_STR.
+ * Returns NULL in case of an error,
+ * or a newly allocated string holding the joined string in case of success. */
+static char *join_dir_strings(const char *a_str, const char *b_str)
 {
-    int has_sep = 0;
-    int retval = -1;
+    int has_sep;
+    int retval;
     char *join_strp = NULL;
 
-    if (strp_out == NULL || a_str == NULL || b_str == NULL) {
-	goto out;
-    }
-    if (strlen(a_str) == 0) {
-	goto out;
-    }
+    if (a_str == NULL || b_str == NULL || strlen(a_str) == 0)
+	return NULL;
 
     has_sep = (a_str[strlen(a_str) - 1] == '/') || (b_str[0] == '/');
 
     retval = asprintf(&join_strp, "%s%s%s", a_str,
 	(has_sep == 1) ? "" : "/", b_str);
 
-    if (retval < 0) {
-	goto out;
-    }
-
-    *strp_out = join_strp;
-
-  out:
-    return retval;
+    return retval < 0 ? NULL : join_strp;
 }
 
 static int compare_strings(const void *a, const void *b)
@@ -228,8 +216,8 @@ static void try_to_display_directories_with_overrides(pam_handle_t *pamh,
 		continue;             /* are good.             */
 	    case DT_UNKNOWN:   /* for file systems that do not provide */
 			       /* a filetype, we use lstat()           */
-		if (join_dir_strings(&fullpath, motd_dir_path_split[i],
-				     d[j]->d_name) <= 0)
+		if ((fullpath = join_dir_strings(motd_dir_path_split[i],
+						 d[j]->d_name)) == NULL)
 		    break;
 		rc = lstat(fullpath, &s);
 		_pam_drop(fullpath);  /* free the memory alloc'ed by join_dir_strings */
@@ -282,11 +270,11 @@ static void try_to_display_directories_with_overrides(pam_handle_t *pamh,
 	}
 
 	for (j = 0; j < num_motd_dirs; j++) {
-	    char *abs_path = NULL;
+	    char *abs_path;
 	    int fd;
 
-	    if (join_dir_strings(&abs_path, motd_dir_path_split[j],
-		    dirnames_all[i]) < 0 || abs_path == NULL) {
+	    if ((abs_path = join_dir_strings(motd_dir_path_split[j],
+					     dirnames_all[i])) == NULL) {
 		continue;
 	    }
 

--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -606,13 +606,12 @@ static int process_line(char *line, const char *home, const char *rhome,
     }
 
 #define COPY_STR(dst, src, apd)                                \
-	(snprintf((dst), sizeof(dst), "%s%s", (src), (apd)) != \
-		  (ssize_t) (strlen(src) + strlen(apd)))
+	pam_sprintf((dst), "%s%s", (src), (apd))
 
-    if (COPY_STR(poly->dir, dir, "")
-	|| COPY_STR(poly->rdir, rdir, "")
+    if (COPY_STR(poly->dir, dir, "") < 0
+	|| COPY_STR(poly->rdir, rdir, "") < 0
 	|| COPY_STR(poly->instance_prefix, instance_prefix,
-		    poly->method == TMPDIR ? "XXXXXX" : "")) {
+		    poly->method == TMPDIR ? "XXXXXX" : "") < 0) {
 	pam_syslog(idata->pamh, LOG_NOTICE, "Pathnames too long");
 	goto skipping;
     }
@@ -1165,7 +1164,7 @@ static int protect_mount(int dfd, const char *path, struct instance_data *idata)
 		return -1;
 	}
 
-	snprintf(tmpbuf, sizeof(tmpbuf), "/proc/self/fd/%d", dfd);
+	pam_sprintf(tmpbuf, "/proc/self/fd/%d", dfd);
 
 	if (idata->flags & PAMNS_DEBUG) {
 		pam_syslog(idata->pamh, LOG_INFO,

--- a/modules/pam_pwhistory/pam_pwhistory.c
+++ b/modules/pam_pwhistory/pam_pwhistory.c
@@ -143,8 +143,8 @@ run_save_helper(pam_handle_t *pamh, const char *user,
       args[2] = (char *)user;
       args[3] = (char *)((filename != NULL) ? filename : "");
       DIAG_POP_IGNORE_CAST_QUAL;
-      if (asprintf(&args[4], "%d", howmany) < 0 ||
-          asprintf(&args[5], "%d", debug) < 0)
+      if ((args[4] = pam_asprintf("%d", howmany)) == NULL ||
+          (args[5] = pam_asprintf("%d", debug)) == NULL)
         {
           pam_syslog(pamh, LOG_ERR, "asprintf: %m");
           _exit(PAM_SYSTEM_ERR);
@@ -230,7 +230,7 @@ run_check_helper(pam_handle_t *pamh, const char *user,
       args[2] = (char *)user;
       args[3] = (char *)((filename != NULL) ? filename : "");
       DIAG_POP_IGNORE_CAST_QUAL;
-      if (asprintf(&args[4], "%d", debug) < 0)
+      if ((args[4] = pam_asprintf("%d", debug)) == NULL)
         {
           pam_syslog(pamh, LOG_ERR, "asprintf: %m");
           _exit(PAM_SYSTEM_ERR);

--- a/modules/pam_securetty/pam_securetty.c
+++ b/modules/pam_securetty/pam_securetty.c
@@ -150,7 +150,7 @@ securetty_perform_check (pam_handle_t *pamh, int ctrl,
     }
 
     if (isdigit((unsigned char)uttyname[0])) {
-	snprintf(ptname, sizeof(ptname), "pts/%s", uttyname);
+	pam_sprintf(ptname, "pts/%s", uttyname);
     } else {
 	ptname[0] = '\0';
     }

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -98,10 +98,9 @@ send_audit_message(const pam_handle_t *pamh, int success, const char *default_co
 		pam_syslog(pamh, LOG_ERR, "Error translating selected context '%s'.", selected_context);
 		selected_raw = NULL;
 	}
-	if (asprintf(&msg, "op=pam_selinux default-context=%s selected-context=%s",
-		     default_raw ? default_raw : (default_context ? default_context : "?"),
-		     selected_raw ? selected_raw : (selected_context ? selected_context : "?")) < 0) {
-		msg = NULL; /* asprintf leaves msg in undefined state on failure */
+	if ((msg = pam_asprintf("op=pam_selinux default-context=%s selected-context=%s",
+				default_raw ? default_raw : (default_context ? default_context : "?"),
+				selected_raw ? selected_raw : (selected_context ? selected_context : "?"))) == NULL) {
 		pam_syslog(pamh, LOG_ERR, "Error allocating memory.");
 		goto fallback;
 	}
@@ -534,8 +533,7 @@ compute_tty_context(const pam_handle_t *pamh, module_data_t *data)
   }
 
   if (pam_str_skip_prefix(tty, "/dev/") == NULL) {
-    if (asprintf(&data->tty_path, "%s%s", "/dev/", tty) < 0)
-      data->tty_path = NULL;
+    data->tty_path = pam_asprintf("%s%s", "/dev/", tty);
   } else {
     data->tty_path = strdup(tty);
   }

--- a/modules/pam_selinux/pam_selinux.c
+++ b/modules/pam_selinux/pam_selinux.c
@@ -635,7 +635,7 @@ set_context(pam_handle_t *pamh, const module_data_t *data,
   if (verbose && !rc) {
     char msg[PATH_MAX];
 
-    snprintf(msg, sizeof(msg),
+    pam_sprintf(msg,
 	     _("Security context %s has been assigned."), data->exec_context);
     send_text(pamh, msg, debug);
   }
@@ -651,7 +651,7 @@ set_context(pam_handle_t *pamh, const module_data_t *data,
   if (verbose && !rc) {
     char msg[PATH_MAX];
 
-    snprintf(msg, sizeof(msg),
+    pam_sprintf(msg,
 	     _("Key creation context %s has been assigned."), data->exec_context);
     send_text(pamh, msg, debug);
   }

--- a/modules/pam_sepermit/pam_sepermit.c
+++ b/modules/pam_sepermit/pam_sepermit.c
@@ -248,7 +248,7 @@ sepermit_lock(pam_handle_t *pamh, const char *user, int debug)
 		return -1;
 	}
 
-	snprintf(buf, sizeof(buf), "%s/%d.lock", SEPERMIT_LOCKDIR, pw->pw_uid);
+	pam_sprintf(buf, "%s/%d.lock", SEPERMIT_LOCKDIR, pw->pw_uid);
 	int fd = open(buf, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		pam_syslog(pamh, LOG_ERR, "Unable to open lock file %s/%d.lock", SEPERMIT_LOCKDIR, pw->pw_uid);

--- a/modules/pam_sepermit/pam_sepermit.c
+++ b/modules/pam_sepermit/pam_sepermit.c
@@ -88,7 +88,7 @@ match_process_uid(pid_t pid, uid_t uid)
 	FILE *f;
 	int re = 0;
 
-	if (asprintf (&buf, PROC_BASE "/%d/status", pid) < 0)
+	if ((buf = pam_asprintf(PROC_BASE "/%d/status", pid)) == NULL)
 		return 0;
 	n = strlen(buf) + 1;
 	if (!(f = fopen (buf, "r"))) {

--- a/modules/pam_stress/pam_stress.c
+++ b/modules/pam_stress/pam_stress.c
@@ -455,8 +455,8 @@ int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 	       }
 	       pmsg[0] = &msg[0];
 	       msg[0].msg_style = PAM_TEXT_INFO;
-	       if (asprintf(&txt, "Changing STRESS password for %s.",
-			    (const char *)username) < 0) {
+	       if ((txt = pam_asprintf("Changing STRESS password for %s.",
+				       (const char *)username)) == NULL) {
 		    pam_syslog(pamh, LOG_CRIT, "out of memory");
 		    return PAM_BUF_ERR;
 	       }

--- a/modules/pam_succeed_if/pam_succeed_if.c
+++ b/modules/pam_succeed_if/pam_succeed_if.c
@@ -56,6 +56,7 @@
 #include <security/pam_modules.h>
 #include <security/pam_modutil.h>
 #include <security/pam_ext.h>
+#include "pam_inline.h"
 
 /* Basically, run cmp(atol(left), atol(right)), returning PAM_SUCCESS if
  * the function returns non-zero, PAM_AUTH_ERR if it returns zero, and
@@ -313,12 +314,10 @@ evaluate(pam_handle_t *pamh, int debug,
 	    (strcasecmp(left, "user") == 0)) {
 		left = user;
 	} else if (strcasecmp(left, "uid") == 0) {
-		snprintf(numstr, sizeof(numstr), "%lu",
-			(unsigned long) (*pwd)->pw_uid);
+		pam_sprintf(numstr, "%lu", (unsigned long) (*pwd)->pw_uid);
 		left = numstr;
 	} else if (strcasecmp(left, "gid") == 0) {
-		snprintf(numstr, sizeof(numstr), "%lu",
-			(unsigned long) (*pwd)->pw_gid);
+		pam_sprintf(numstr, "%lu", (unsigned long) (*pwd)->pw_gid);
 		left = numstr;
 	} else if (strcasecmp(left, "shell") == 0) {
 		left = (*pwd)->pw_shell;

--- a/modules/pam_timestamp/hmacfile.c
+++ b/modules/pam_timestamp/hmacfile.c
@@ -115,8 +115,7 @@ testvectors(void)
 		if (hmac != NULL) {
 			unsigned char *hmacc = hmac;
 			for (j = 0; j < hmac_len; j++) {
-				snprintf(hex, sizeof(hex), "%02x",
-					 hmacc[j] & 0xff);
+				pam_sprintf(hex, "%02x", hmacc[j] & 0xff);
 				if (strncasecmp(hex,
 						vectors[i].hmac + 2 * j,
 						2) != 0) {

--- a/modules/pam_timestamp/pam_timestamp.c
+++ b/modules/pam_timestamp/pam_timestamp.c
@@ -188,11 +188,11 @@ format_timestamp_name(char *path, size_t len,
 		      const char *user)
 {
 	if (strcmp(ruser, user) == 0) {
-		return snprintf(path, len, "%s/%s/%s", timestamp_dir,
-				ruser, tty);
+		return pam_snprintf(path, len, "%s/%s/%s", timestamp_dir,
+				    ruser, tty);
 	} else {
-		return snprintf(path, len, "%s/%s/%s:%s", timestamp_dir,
-				ruser, tty, user);
+		return pam_snprintf(path, len, "%s/%s/%s:%s", timestamp_dir,
+				    ruser, tty, user);
 	}
 }
 
@@ -371,7 +371,7 @@ get_timestamp_name(pam_handle_t *pamh, int argc, const char **argv,
 	}
 	/* Generate the name of the file used to cache auth results.  These
 	 * paths should jive with sudo's per-tty naming scheme. */
-	if (format_timestamp_name(path, len, tdir, tty, ruser, user) >= (int)len) {
+	if (format_timestamp_name(path, len, tdir, tty, ruser, user) < 0) {
 		return PAM_AUTH_ERR;
 	}
 	if (debug) {
@@ -850,7 +850,7 @@ main(int argc, char **argv)
 
 	/* Generate the name of the timestamp file. */
 	if (format_timestamp_name(path, sizeof(path), TIMESTAMPDIR,
-				  tty, user, target_user) >= (int) sizeof(path)) {
+				  tty, user, target_user) < 0) {
 		fprintf(stderr, "path too long\n");
 		return 4;
 	}

--- a/modules/pam_unix/md5_crypt.c
+++ b/modules/pam_unix/md5_crypt.c
@@ -142,8 +142,7 @@ char *MD5Name(crypt_md5)(const char *pw, const char *salt)
 	*p = '\0';
 
 	/* Now make the output string */
-	if (asprintf(&passwd, "%s%.*s$%s", magic, sl, sp, buf) < 0)
-		passwd = NULL;
+	passwd = pam_asprintf("%s%.*s$%s", magic, sl, sp, buf);
 
 	/* Don't leave anything around in vm they could use. */
 	pam_overwrite_array(buf);

--- a/modules/pam_unix/pam_unix_acct.c
+++ b/modules/pam_unix/pam_unix_acct.c
@@ -58,7 +58,7 @@
 #include <security/pam_modutil.h>
 
 #include "pam_i18n.h"
-#include "pam_cc_compat.h"
+#include "pam_inline.h"
 #include "support.h"
 #include "passverify.h"
 
@@ -266,7 +266,7 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
 				"password for user %s will expire in %d days",
 				uname, daysleft);
 #if defined HAVE_DNGETTEXT && defined ENABLE_NLS
-			snprintf (buf, sizeof (buf),
+			pam_sprintf(buf,
 				dngettext(PACKAGE,
 				  "Warning: your password will expire in %d day.",
 				  "Warning: your password will expire in %d days.",
@@ -274,11 +274,11 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
 				daysleft);
 #else
 			if (daysleft == 1)
-			    snprintf(buf, sizeof (buf),
+			    pam_sprintf(buf,
 				_("Warning: your password will expire in %d day."),
 				daysleft);
 			else
-			    snprintf(buf, sizeof (buf),
+			    pam_sprintf(buf,
 			    /* TRANSLATORS: only used if dngettext is not supported */
 				_("Warning: your password will expire in %d days."),
 				daysleft);

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -279,7 +279,7 @@ static int _unix_run_update_binary(pam_handle_t *pamh, unsigned long long ctrl, 
 	else
 		args[3] = "0";
 
-        snprintf(buffer, sizeof(buffer), "%d", remember);
+        pam_sprintf(buffer, "%d", remember);
         args[4] = buffer;
 
 	DIAG_PUSH_IGNORE_CAST_QUAL;

--- a/modules/pam_unix/pam_unix_sess.c
+++ b/modules/pam_unix/pam_unix_sess.c
@@ -52,6 +52,7 @@
 #include <security/pam_ext.h>
 #include <security/pam_modutil.h>
 
+#include "pam_inline.h"
 #include "support.h"
 
 /*
@@ -92,10 +93,10 @@ pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv)
 		char uid[32];
 		struct passwd *pwd = pam_modutil_getpwnam (pamh, user_name);
 		if (pwd == NULL) {
-			snprintf (uid, 32, "getpwnam error");
+			pam_sprintf(uid, "getpwnam error");
 		}
 		else {
-			snprintf (uid, 32, "%u", pwd->pw_uid);
+			pam_sprintf(uid, "%u", pwd->pw_uid);
 		}
 		pam_syslog(pamh, LOG_INFO, "session opened for user %s(uid=%s) by %s(uid=%lu)", user_name, uid, login_name, (unsigned long)getuid());
 	}

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -479,8 +479,7 @@ int _unix_getpwnam(pam_handle_t *pamh, const char *name,
 		(*ret)->pw_shell = strcpy(p, sshell);
 
 		_pam_drop(buf);
-		if (asprintf(&buf, "_pam_unix_getpwnam_%s", name) < 0) {
-			buf = NULL;
+		if ((buf = pam_asprintf("_pam_unix_getpwnam_%s", name)) == NULL) {
 			goto fail;
 		}
 
@@ -731,9 +730,8 @@ int _unix_verify_password(pam_handle_t * pamh, const char *name
 
 	retval = get_pwd_hash(pamh, name, &pwd, &salt);
 
-	if (asprintf(&data_name, "%s%s", FAIL_PREFIX, name) < 0) {
+	if ((data_name = pam_asprintf("%s%s", FAIL_PREFIX, name)) == NULL) {
 		pam_syslog(pamh, LOG_CRIT, "no memory for data-name");
-		data_name = NULL;
 	}
 
 	if (p != NULL && strlen(p) > PAM_MAX_RESP_SIZE) {

--- a/modules/pam_userdb/pam_userdb.c
+++ b/modules/pam_userdb/pam_userdb.c
@@ -242,9 +242,7 @@ user_lookup (pam_handle_t *pamh, const char *database, const char *cryptmode,
     memset(&key, 0, sizeof(key));
     memset(&data, 0, sizeof(data));
     if (ctrl & PAM_KEY_ONLY_ARG) {
-	if (asprintf(&key.dptr, "%s-%s", user, pass) < 0)
-	    key.dptr = NULL;
-	else
+	if ((key.dptr = pam_asprintf("%s-%s", user, pass)) != NULL)
 	    key.dsize = strlen(key.dptr);
     } else {
         key.dptr = strdup(user);

--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -238,7 +238,7 @@ check_acl(pam_handle_t *pamh,
 	char *path = NULL;
 	struct passwd *pwd;
 	FILE *fp = NULL;
-	int i, fd = -1, save_errno;
+	int fd = -1, save_errno;
 	struct stat st;
 	PAM_MODUTIL_DEF_PRIVS(privs);
 
@@ -251,8 +251,7 @@ check_acl(pam_handle_t *pamh,
 		return PAM_SESSION_ERR;
 	}
 	/* Figure out what that file is really named. */
-	i = asprintf(&path, "%s/.xauth/%s", pwd->pw_dir, sense);
-	if (i < 0) {
+	if ((path = pam_asprintf("%s/.xauth/%s", pwd->pw_dir, sense)) == NULL) {
 		pam_syslog(pamh, LOG_ERR,
 			   "cannot allocate path buffer for ~/.xauth/%s",
 			   sense);
@@ -508,8 +507,7 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 			retval = PAM_SESSION_ERR;
 			goto cleanup;
 		}
-	} else if (asprintf(&cookiefile, "%s/%s", rpwd->pw_dir, XAUTHDEF) < 0) {
-		cookiefile = NULL;
+	} else if ((cookiefile = pam_asprintf("%s/%s", rpwd->pw_dir, XAUTHDEF)) == NULL) {
 		retval = PAM_SESSION_ERR;
 		goto cleanup;
 	}
@@ -552,8 +550,9 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 
 				/* Append protocol and screen number to host. */
 				screen = display + strcspn(display, ":");
-				if (asprintf(&t, "%s/unix%s",
-					     hostname, screen) >= 0) {
+				if ((t = pam_asprintf("%s/unix%s",
+						      hostname,
+						      screen)) != NULL) {
 					if (debug) {
 						pam_syslog(pamh, LOG_DEBUG,
 							   "no key for `%s', "
@@ -595,9 +594,8 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 
 		/* Generate the environment variable
 		 * "XAUTHORITY=<homedir>/filename". */
-		if (asprintf(&xauthority, "%s=%s/%s",
-			     XAUTHENV, tpwd->pw_dir, XAUTHTMP) < 0) {
-			xauthority = NULL;
+		if ((xauthority = pam_asprintf("%s=%s/%s", XAUTHENV,
+					       tpwd->pw_dir, XAUTHTMP)) == NULL) {
 			if (debug) {
 				pam_syslog(pamh, LOG_DEBUG, "out of memory");
 			}
@@ -680,7 +678,7 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 		{
 		  char *d;
 
-		  if (asprintf(&d, "DISPLAY=%s", display) < 0)
+		  if ((d = pam_asprintf("DISPLAY=%s", display)) == NULL)
 		    {
 		      pam_syslog(pamh, LOG_CRIT, "out of memory");
 		      retval = PAM_SESSION_ERR;
@@ -697,7 +695,7 @@ pam_sm_open_session (pam_handle_t *pamh, int flags UNUSED,
 		if ((xauthlocalhostname = getenv("XAUTHLOCALHOSTNAME")) != NULL) {
 		  char *d;
 
-		  if (asprintf(&d, "XAUTHLOCALHOSTNAME=%s", xauthlocalhostname) < 0) {
+		  if ((d = pam_asprintf("XAUTHLOCALHOSTNAME=%s", xauthlocalhostname)) == NULL) {
 		    pam_syslog(pamh, LOG_CRIT, "out of memory");
 		    retval = PAM_SESSION_ERR;
 		    goto cleanup;


### PR DESCRIPTION
pam_asprintf() is essentially asprintf() with the following semantic difference: it returns the string itself instead of its length.

pam_snprintf() is essentially snprintf() with the following semantic difference: it returns -1 in case of truncation.

pam_sprintf() is essentially snprintf() but with a check that the buffer is an array, and with an automatically calculated buffer size.

Use of these helpers would make error checking simpler.