### PR TITLE
treewide: replace 0 with NULL for pointers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,7 @@ try_cc_flags = [
   '-Wuninitialized',
   '-Wunused',
   '-Wwrite-strings',
+  '-Wzero-as-null-pointer-constant',
 ]
 add_project_arguments(
   cc.get_supported_arguments(try_cc_flags),

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -578,7 +578,7 @@ list_match(pam_handle_t *pamh, char *list, char *sptr,
      * the match is affected by any exceptions.
      */
 
-    for (tok = strtok_r(list, item->sep, &sptr); tok != 0;
+    for (tok = strtok_r(list, item->sep, &sptr); tok != NULL;
 	 tok = strtok_r(NULL, item->sep, &sptr)) {
 	if (strcasecmp(tok, "EXCEPT") == 0)	/* EXCEPT: give up */
 	    break;
@@ -590,7 +590,7 @@ list_match(pam_handle_t *pamh, char *list, char *sptr,
     if (match != NO) {
 	while ((tok = strtok_r(NULL, item->sep, &sptr)) && strcasecmp(tok, "EXCEPT"))
 	     /* VOID */ ;
-	if (tok == 0)
+	if (tok == NULL)
 	    return match;
 	if (list_match(pamh, NULL, sptr, item, match_fn) == NO)
 	    return YES; /* drop special meaning of ALL */

--- a/modules/pam_canonicalize_user/pam_canonicalize_user.c
+++ b/modules/pam_canonicalize_user/pam_canonicalize_user.c
@@ -48,7 +48,7 @@ pam_sm_authenticate(pam_handle_t *pamh UNUSED, int flags UNUSED,
 		    int argc UNUSED, const char **argv UNUSED)
 {
 	const char *user;
-	int rc = pam_get_user(pamh, &user, 0);
+	int rc = pam_get_user(pamh, &user, NULL);
 	if (rc != PAM_SUCCESS) {
 		pam_syslog(pamh, LOG_NOTICE, "cannot determine user name: %s",
 			   pam_strerror(pamh, rc));

--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -333,7 +333,7 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
       (void) fclose(conf);
       return PAM_BUF_ERR;
     }
-    (*lines)[i] = 0;
+    (*lines)[i] = NULL;
     while (_pam_line_assemble(conf, &buffer, '\0') > 0) {
       char *p = buffer.assembled;
       char **tmp = NULL;
@@ -355,7 +355,7 @@ static int read_file(const pam_handle_t *pamh, const char*filename, char ***line
         _pam_line_buffer_clear(&buffer);
         return PAM_BUF_ERR;
       }
-      (*lines)[i] = 0;
+      (*lines)[i] = NULL;
     }
 
     (void) fclose(conf);

--- a/modules/pam_mail/pam_mail.c
+++ b/modules/pam_mail/pam_mail.c
@@ -209,7 +209,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
 	    pam_syslog(pamh, LOG_CRIT, "out of memory");
 	    goto get_mail_status_cleanup;
 	}
-	i = scandir(dir, &namelist, 0, alphasort);
+	i = scandir(dir, &namelist, NULL, alphasort);
 	save_errno = errno;
 	pam_overwrite_string(dir);
 	_pam_drop(dir);
@@ -230,7 +230,7 @@ get_mail_status(pam_handle_t *pamh, int ctrl, const char *folder)
 		pam_syslog(pamh, LOG_CRIT, "out of memory");
 		goto get_mail_status_cleanup;
 	    }
-	    i = scandir(dir, &namelist, 0, alphasort);
+	    i = scandir(dir, &namelist, NULL, alphasort);
 	    save_errno = errno;
 	    pam_overwrite_string(dir);
 	    _pam_drop(dir);


### PR DESCRIPTION
Enable the compiler warning -Wzero-as-null-pointer-constant introduced in GCC 15 and also available on Clang and replace all found occurrences.