### PR TITLE
pam_limits: Add support for rttime (RLIMIT_RTTIME)

### DIFF
--- a/modules/pam_limits/limits.conf
+++ b/modules/pam_limits/limits.conf
@@ -46,6 +46,7 @@
 #        - msgqueue - max memory used by POSIX message queues (bytes)
 #        - nice - max nice priority allowed to raise to values: [-20, 19]
 #        - rtprio - max realtime priority
+#        - rttime - timeout for realtime tasks
 #
 #<domain>      <type>  <item>         <value>
 #

--- a/modules/pam_limits/limits.conf.5.xml
+++ b/modules/pam_limits/limits.conf.5.xml
@@ -266,6 +266,12 @@
                   (Linux 2.6.12 and higher)</para>
               </listitem>
             </varlistentry>
+            <varlistentry>
+              <term>rttime</term>
+              <listitem>
+                <para>Timeout for real-time tasks in microseconds (Linux 2.6.25 and higher)</para>
+              </listitem>
+            </varlistentry>
           </variablelist>
         </listitem>
       </varlistentry>

--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -231,6 +231,11 @@ rlimit2str (int i)
     return "rtprio";
     break;
 #endif
+#ifdef RLIMIT_RTTIME
+  case RLIMIT_RTTIME:
+    return "rttime";
+    break;
+#endif
   default:
     return "UNKNOWN";
     break;
@@ -676,6 +681,10 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 #ifdef RLIMIT_RTPRIO
     else if (strcmp(lim_item, "rtprio") == 0)
 	limit_item = RLIMIT_RTPRIO;
+#endif
+#ifdef RLIMIT_RTTIME
+    else if (strcmp(lim_item, "rttime") == 0)
+	limit_item = RLIMIT_RTTIME;
 #endif
     else if (strcmp(lim_item, "maxlogins") == 0) {
 	limit_item = LIMIT_LOGIN;


### PR DESCRIPTION
This adds support for the rttime (RLIMIT_RTTIME) limit in pam_limits. Updated documentation, man page, and pam_limits.conf comments accordingly.