### PR TITLE
pam_xauth: provide fallback HOST_NAME_MAX

### DIFF
--- a/modules/pam_xauth/pam_xauth.c
+++ b/modules/pam_xauth/pam_xauth.c
@@ -83,6 +83,10 @@ static const char * const xauthpaths[] = {
 	"/usr/bin/X11/xauth"
 };
 
+#ifndef HOST_NAME_MAX
+# define HOST_NAME_MAX 255
+#endif
+
 /* Run a given command (with a NULL-terminated argument list), feeding it the
  * given input on stdin, and storing any output it generates. */
 static int


### PR DESCRIPTION
Followup of commit 2e375aad04d047e12468f93300ad7e42a8a03ff3 for OSes that do not provide the optional `HOST_NAME_MAX`, in the same way as currently done in pam_echo.