### PR TITLE
pam_unix: add support for pwaccessd (#902)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -263,6 +263,10 @@ foreach f: ['crypt_r']
   endif
 endforeach
 
+libpwaccess = dependency('libpwaccess', required: get_option('pwaccess'))
+if libpwaccess.found()
+  cdata.set('USE_PWACCESS', 1)
+endif
 
 libeconf = dependency('libeconf', version: '>= 0.5.0', required: get_option('econf'))
 if libeconf.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,8 @@ option('elogind', type: 'feature', value: 'auto',
        description: 'logind support in pam_issue, pam_limits, and pam_timestamp via elogind')
 option('openssl', type: 'feature', value: 'disabled',
        description: 'Use OpenSSL crypto libraries in pam_timestamp')
+option('pwaccess', type: 'feature', value: 'auto',
+       description: 'libpwaccess support in pam_unix')
 option('selinux', type: 'feature', value: 'auto',
        description: 'SELinux support')
 option('nis', type: 'feature', value: 'auto',

--- a/modules/module-meson.build
+++ b/modules/module-meson.build
@@ -116,7 +116,7 @@ if module == 'pam_unix'
   endif
   pam_module_c_args += ['-DCHKPWD_HELPER="@0@"'.format(sbindir / 'unix_chkpwd'),
                         '-DUPDATE_HELPER="@0@"'.format(sbindir / 'unix_update')]
-  pam_module_deps += [libcrypt, libselinux, libtirpc, libnsl]
+  pam_module_deps += [libcrypt, libselinux, libtirpc, libnsl, libpwaccess]
 endif
 if module == 'pam_userdb'
   if not enable_pam_userdb

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -522,7 +522,11 @@ static int _unix_verify_shadow(pam_handle_t *pamh, const char *user, unsigned lo
 		return PAM_SUCCESS;
 
 	if (retval == PAM_UNIX_RUN_HELPER) {
-		retval = _unix_run_verify_binary(pamh, ctrl, user, &daysleft);
+#ifdef USE_PWACCESS
+	        retval = _unix_pwaccess_check_expired(pamh, user, &daysleft);
+		if (retval == PAM_SYSTEM_ERR) /* pwaccess not running */
+#endif
+			retval = _unix_run_verify_binary(pamh, ctrl, user, &daysleft);
 		if (retval == PAM_AUTH_ERR || retval == PAM_USER_UNKNOWN)
 			return retval;
 	}

--- a/modules/pam_unix/support.h
+++ b/modules/pam_unix/support.h
@@ -179,4 +179,6 @@ extern int _unix_verify_user(pam_handle_t *pamh, unsigned long long ctrl,
 extern int _unix_run_verify_binary(pam_handle_t *pamh,
 				   unsigned long long ctrl,
 				   const char *user, long *daysleft);
+extern int _unix_pwaccess_check_expired(pam_handle_t *pamh,
+					const char *user, long *daysleft);
 #endif /* _PAM_UNIX_SUPPORT_H */


### PR DESCRIPTION
[pwaccess](https://github.com/thkukuk/pwaccess) is a systemd socket activated service which provides passwd and shadow entries to root or the user of that entry to avoid having binaries owned by group shadow and/or setuid/setgid to do the authentication.
Currently it can replace `unix_chkpwd` and first PoC patches for `shadow` exists.

Reasons:
- avoid UID/GID shift with image based updates, so everything in /usr should be owned by root:root
- security, don't allow setuid/setgid binaries. Requested by:
  - systemd developers (https://github.com/linux-pam/linux-pam/issues/902)
  - our security team

The code is written in a way that `unix_ckpwd` is called as fallback if the service does not work.

`pwaccess` itself is currently under review of our security team.