### PR TITLE
pam_unix: make run chkpwd helper configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ cdata.set10('DEFAULT_USERGROUPS_SETTING', get_option('usergroups'))
 cdata.set('PAM_USERTYPE_UIDMIN', get_option('uidmin'))
 cdata.set('PAM_USERTYPE_OVERFLOW_UID', get_option('kernel-overflow-uid'))
 cdata.set('PAM_MISC_CONV_BUFSIZE', get_option('misc-conv-bufsize'))
+cdata.set('DIRECT_RUN_HELPER', get_option('direct_run_chkpwd_helper') ? 1 : false)
 
 cdata.set_quoted('_PAM_ISA',
   get_option('isadir') != '' ? get_option('isadir') : '../..' / fs.name(libdir) / 'security')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -99,3 +99,6 @@ option('pam_lastlog', type: 'feature', value: 'disabled',
        description: 'pam_lastlog module')
 option('pam_unix', type: 'feature', value: 'auto',
        description: 'pam_unix module')
+option('direct_run_chkpwd_helper', type: 'boolean', value: true,
+       description: 'Run unix_chkpwd helper to access password file, other than fallback of getspnam')
+

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -249,12 +249,18 @@ PAMH_ARG_DECL(int get_account_info,
 			*spwdent = getspnam(name);
 			if (*spwdent == NULL || (*spwdent)->sp_pwdp == NULL)
 				return PAM_AUTHINFO_UNAVAIL;
-#else
+#elif defined(DIRECT_RUN_HELPER)
 			/*
 			 * The helper has to be invoked to deal with
 			 * the shadow password file entry.
 			 */
 			return PAM_UNIX_RUN_HELPER;
+#else
+			*spwdent = pam_modutil_getspnam(pamh, name);
+			if (*spwdent == NULL) {
+				/* still a chance the user can authenticate */
+				return PAM_UNIX_RUN_HELPER;
+			}
 #endif
 		}
 	} else {


### PR DESCRIPTION
unix_chkpwd is a setuid binary to permit normal user to access password file, then it is used as fallback of getspnam for more and more case, like SELINUX, EACCESS. b3020da7d finally dropped getspnam and run the helper directly.

While it is generally good to run unix_chkpwd directly, the cost of it is relavtively high. Kernel has to fork a new process, then execve the process as follows. In case of storm authentication, lots of temporary process will be created and destoryed. this would take lots of CPU time and starve other critcal threads.

Instead of just run helper directly or run as fallback of getspnam, new option direct_run_chkpwd_helper(default to true) is introduced, user can chose to run it directly or as a fallback on demand.

```
strace -ff  ./xa_auth_test
execve("./xa_auth_test", ["./xa_auth_test"], 0x7fff9178fcc8 /* 19 vars
*/) = 0

[pid 2318322] setuid(0)                 = 0
[pid 2318322] execve("/usr/sbin/unix_chkpwd", ["/usr/sbin/unix_chkpwd",
"root", "nonull"], 0x7fb6bdbef010 /* 0 vars */) = 0

[pid 2318322] read(0, "TkqPvKP0n0Id\0", 513) = 13

[pid 2318324] execve("/usr/sbin/unix_chkpwd", ["/usr/sbin/unix_chkpwd",
"root", "chkexpiry"], 0x7fb6bdbef018 /* 0 vars */) = 0

rt_sigaction(SIGCHLD, {sa_handler=SIG_DFL, sa_mask=[],
sa_flags=SA_RESTORER, sa_restorer=0x7fb6bdc4dfd0}, NULL, 8 ) = 0
```