### PR TITLE
pam_env: better syslog message for ignoring backslash at end of string

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -627,6 +627,11 @@ _expand_arg(pam_handle_t *pamh, char **value)
     if ('\\' == *orig) {
       ++orig;
       if ('$' != *orig && '@' != *orig && '\\' != *orig) {
+	if (!*orig) {
+	  D(("Ignoring backslash at end of string"));
+	  pam_syslog(pamh, LOG_ERR, "Ignoring backslash at end of string");
+	  break;
+	}
 	D(("Unrecognized escaped character: <%c> - ignoring", *orig));
 	pam_syslog(pamh, LOG_ERR,
 		   "Unrecognized escaped character: <%c> - ignoring",


### PR DESCRIPTION
bad line in `/etc/security/pam_env.conf`:
```
MYVAR DEFAULT="hello\"
```
syslog message before this commit:
```
pam_env(lightdm:setcred): Unrecognized escaped character: <
```
syslog message after this commit:
```
pam_env(lightdm:setcred): Ignoring backslash at end of string
```