### PR TITLE
hurd: Replace use of Linuxish setfsuid/gid with setresuid/gid

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -164,6 +164,7 @@ check_headers = [
   'crypt.h',
   'paths.h',
   'sys/random.h',
+  'sys/fsuid.h',
 ]
 foreach h: check_headers
   if cc.has_header(h)


### PR DESCRIPTION
Instead of changing the fsuid/gid (which is Linuxish), we can use the posix-provided saved uid/gid to backup the effective uid/gid before overwriting it, and be able to restore it.