### PR TITLE
pam_unix: turn daysleft into long

### DIFF
--- a/modules/pam_unix/pam_unix_acct.c
+++ b/modules/pam_unix/pam_unix_acct.c
@@ -63,7 +63,7 @@
 #include "passverify.h"
 
 int _unix_run_verify_binary(pam_handle_t *pamh, unsigned long long ctrl,
-	const char *user, int *daysleft)
+	const char *user, long *daysleft)
 {
   int retval=0, child, fds[2];
   struct sigaction newsa, oldsa;
@@ -156,7 +156,7 @@ int _unix_run_verify_binary(pam_handle_t *pamh, unsigned long long ctrl,
         rc = pam_modutil_read(fds[0], buf, sizeof(buf) - 1);
 	if(rc > 0) {
 	      buf[rc] = '\0';
-	      if (sscanf(buf,"%d", daysleft) != 1 )
+	      if (sscanf(buf,"%ld", daysleft) != 1)
 	        retval = PAM_AUTH_ERR;
 	    }
 	else {
@@ -191,7 +191,8 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
 	unsigned long long ctrl;
 	const void *void_uname;
 	const char *uname;
-	int retval, daysleft = -1;
+	long daysleft = -1;
+	int retval;
 	char buf[256];
 
 	D(("called."));
@@ -263,24 +264,24 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
 	case PAM_SUCCESS:
 		if (daysleft >= 0) {
 			pam_syslog(pamh, LOG_DEBUG,
-				"password for user %s will expire in %d days",
+				"password for user %s will expire in %ld days",
 				uname, daysleft);
 #if defined HAVE_DNGETTEXT && defined ENABLE_NLS
 			pam_sprintf(buf,
 				dngettext(PACKAGE,
-				  "Warning: your password will expire in %d day.",
-				  "Warning: your password will expire in %d days.",
+				  "Warning: your password will expire in %ld day.",
+				  "Warning: your password will expire in %ld days.",
 				  daysleft),
 				daysleft);
 #else
 			if (daysleft == 1)
 			    pam_sprintf(buf,
-				_("Warning: your password will expire in %d day."),
+				_("Warning: your password will expire in %ld day."),
 				daysleft);
 			else
 			    pam_sprintf(buf,
 			    /* TRANSLATORS: only used if dngettext is not supported */
-				_("Warning: your password will expire in %d days."),
+				_("Warning: your password will expire in %ld days."),
 				daysleft);
 #endif
 			_make_remark(pamh, ctrl, PAM_TEXT_INFO, buf);

--- a/modules/pam_unix/pam_unix_passwd.c
+++ b/modules/pam_unix/pam_unix_passwd.c
@@ -510,7 +510,7 @@ static int _unix_verify_shadow(pam_handle_t *pamh, const char *user, unsigned lo
 {
 	struct passwd *pwent = NULL;	/* Password and shadow password */
 	struct spwd *spent = NULL;	/* file entries for the user */
-	int daysleft;
+	long daysleft;
 	int retval;
 
 	retval = get_account_info(pamh, user, &pwent, &spent);

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -284,23 +284,8 @@ PAMH_ARG_DECL(int get_pwd_hash,
 	return PAM_SUCCESS;
 }
 
-/*
- * invariant: 0 <= num1
- * invariant: 0 <= num2
- */
-static int
-subtract(long num1, long num2)
-{
-	long value = num1 - num2;
-	if (value < INT_MIN)
-		return INT_MIN;
-	if (value > INT_MAX)
-		return INT_MAX;
-	return (int)value;
-}
-
 PAMH_ARG_DECL(int check_shadow_expiry,
-	struct spwd *spent, int *daysleft)
+	struct spwd *spent, long *daysleft)
 {
 	long int curdays, passed;
 	*daysleft = -1;
@@ -331,7 +316,7 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 			long inact = spent->sp_max < LONG_MAX - spent->sp_inact ?
 			    spent->sp_max + spent->sp_inact : LONG_MAX;
 			if (passed >= inact) {
-				*daysleft = subtract(inact, passed);
+				*daysleft = inact - passed;
 				D(("authtok expired"));
 				return PAM_AUTHTOK_EXPIRED;
 			}
@@ -344,7 +329,7 @@ PAMH_ARG_DECL(int check_shadow_expiry,
 			long warn = spent->sp_warn > spent->sp_max ? -1 :
 			    spent->sp_max - spent->sp_warn;
 			if (passed >= warn) {
-				*daysleft = subtract(spent->sp_max, passed);
+				*daysleft = spent->sp_max - passed;
 				D(("warn before expiry"));
 			}
 		}

--- a/modules/pam_unix/passverify.h
+++ b/modules/pam_unix/passverify.h
@@ -73,7 +73,7 @@ PAMH_ARG_DECL(int get_pwd_hash,
 	const char *name, struct passwd **pwd, char **hash);
 
 PAMH_ARG_DECL(int check_shadow_expiry,
-	struct spwd *spent, int *daysleft);
+	struct spwd *spent, long *daysleft);
 
 PAMH_ARG_DECL(int unix_update_passwd,
 	const char *forwho, const char *towhat);

--- a/modules/pam_unix/support.c
+++ b/modules/pam_unix/support.c
@@ -648,7 +648,7 @@ _unix_blankpasswd (pam_handle_t *pamh, unsigned long long ctrl, const char *name
 {
 	struct passwd *pwd = NULL;
 	char *salt = NULL;
-	int daysleft;
+	long daysleft;
 	int retval;
 	int blank = 0;
 	int execloop;
@@ -863,7 +863,7 @@ int
 _unix_verify_user(pam_handle_t *pamh,
                   unsigned long long ctrl,
                   const char *name,
-                  int *daysleft)
+                  long *daysleft)
 {
     int retval;
     struct spwd *spent;

--- a/modules/pam_unix/support.h
+++ b/modules/pam_unix/support.h
@@ -174,9 +174,9 @@ extern int _unix_verify_password(pam_handle_t * pamh, const char *name,
 				 const char *p, unsigned long long ctrl);
 
 extern int _unix_verify_user(pam_handle_t *pamh, unsigned long long ctrl,
-                             const char *name, int *daysleft);
+                             const char *name, long *daysleft);
 
 extern int _unix_run_verify_binary(pam_handle_t *pamh,
 				   unsigned long long ctrl,
-				   const char *user, int *daysleft);
+				   const char *user, long *daysleft);
 #endif /* _PAM_UNIX_SUPPORT_H */

--- a/modules/pam_unix/unix_chkpwd.c
+++ b/modules/pam_unix/unix_chkpwd.c
@@ -41,7 +41,7 @@ static int _check_expiry(const char *uname)
 	struct spwd *spent;
 	struct passwd *pwent;
 	int retval;
-	int daysleft;
+	long daysleft;
 
 	retval = get_account_info(uname, &pwent, &spent);
 	if (retval != PAM_SUCCESS) {
@@ -56,7 +56,7 @@ static int _check_expiry(const char *uname)
 	}
 
 	retval = check_shadow_expiry(spent, &daysleft);
-	printf("%d\n", daysleft);
+	printf("%ld\n", daysleft);
 	return retval;
 }
 


### PR DESCRIPTION
The daysleft value could be larger than INT_MAX depending on system configuration (content of shadow file).

We already cover this case with a subtract function, but it's much easier to simply turn daysleft into a long. This simplifies the code and is even a no-op on 32 bit platforms (if subtract is optimized away).