### PR TITLE
pam_mkhomedir: Use vendordir when defined

### DIFF
--- a/modules/pam_mkhomedir/mkhomedir_helper.8.xml
+++ b/modules/pam_mkhomedir/mkhomedir_helper.8.xml
@@ -24,6 +24,9 @@
         <replaceable>path-to-skel</replaceable>
       <arg choice="opt" rep="norepeat">
         <replaceable>home_mode</replaceable>
+      <arg choice="opt" rep="norepeat">
+        <replaceable>path-to-vendor-skel</replaceable>
+      </arg>
       </arg>
       </arg>
       </arg>
@@ -46,6 +49,13 @@
       <emphasis>/etc/skel</emphasis>. The default value of
       <replaceable>home_mode</replaceable> is computed from the value of
       <replaceable>umask</replaceable>.
+    </para>
+
+    <para>
+      <replaceable>path-to-vendor-skel</replaceable> doesn't have default
+      value. When set to a <emphasis>path</emphasis>, home directory will be
+      populated by contents of <replaceable>path-to-skel</replaceable> first,
+      and then by contents of <emphasis>path</emphasis>.
     </para>
 
     <para>

--- a/modules/pam_mkhomedir/mkhomedir_helper.c
+++ b/modules/pam_mkhomedir/mkhomedir_helper.c
@@ -36,7 +36,7 @@ static unsigned long u_mask = 0022;
 static const char *skeldir = "/etc/skel";
 
 static int create_homedir(struct dir_spec *, const struct passwd *, mode_t,
-			  const char *, const char *);
+			  const char *, const char *, const char *);
 
 static int
 dir_spec_open(struct dir_spec *spec, const char *path)
@@ -88,7 +88,7 @@ dir_spec_close(struct dir_spec *spec)
 
 static int
 copy_entry(struct dir_spec *parent, const struct passwd *pwd, mode_t dir_mode,
-	   const char *source, struct dirent *dent)
+	   const char *source, struct dirent *dent, const char *vendordir)
 {
    char remark[BUFSIZ];
    int srcfd = -1, destfd = -1;
@@ -96,6 +96,7 @@ copy_entry(struct dir_spec *parent, const struct passwd *pwd, mode_t dir_mode,
    int retval = PAM_SESSION_ERR;
    struct stat st;
    char *newsource;
+   char *newvendordir = NULL;
 
    /* Determine what kind of file it is. */
    if ((newsource = pam_asprintf("%s/%s", source, dent->d_name)) == NULL)
@@ -114,8 +115,23 @@ copy_entry(struct dir_spec *parent, const struct passwd *pwd, mode_t dir_mode,
    /* If it's a directory, recurse. */
    if (S_ISDIR(st.st_mode))
    {
+      if (vendordir != NULL)
+      {
+         if ((newvendordir = pam_asprintf("%s/%s", vendordir, dent->d_name)) == NULL)
+         {
+            pam_syslog(NULL, LOG_CRIT, "asprintf failed for 'newvendordir'");
+            retval = PAM_BUF_ERR;
+            goto go_out;
+         }
+         if (lstat(newvendordir, &st) != 0)
+         {
+            free(newvendordir);
+            newvendordir = NULL;
+         }
+      }
+
       retval = create_homedir(parent, pwd, dir_mode & (~u_mask), newsource,
-			      dent->d_name);
+			      dent->d_name, newvendordir);
       goto go_out;
    }
 
@@ -259,19 +275,22 @@ copy_entry(struct dir_spec *parent, const struct passwd *pwd, mode_t dir_mode,
       close(destfd);
 
    free(newsource);
-
+   free(newvendordir);
    return retval;
 }
 
 /* Do the actual work of creating a home dir */
 static int
 create_homedir(struct dir_spec *parent, const struct passwd *pwd,
-	       mode_t dir_mode, const char *source, const char *dest)
+	       mode_t dir_mode, const char *source, const char *dest,
+	       const char *vendordir)
 {
    DIR *d = NULL;
    struct dirent *dent;
    struct dir_spec base;
    int retval = PAM_SESSION_ERR;
+   const char *sourcedirs[] = {source, vendordir};
+   unsigned int idx = 0;
 
    /* Create the new directory */
    if (mkdirat(parent->fd, dest, 0700))
@@ -289,32 +308,35 @@ create_homedir(struct dir_spec *parent, const struct passwd *pwd,
       goto go_out;
    }
 
-   /* See if we need to copy the skel dir over. */
-   if ((source == NULL) || (strlen(source) == 0))
+   /* Scan source directories */
+   for (idx = 0; idx < PAM_ARRAY_SIZE(sourcedirs); idx++)
    {
-      retval = PAM_SUCCESS;
-      goto go_out;
-   }
+      /* See if we need to copy the source skel dir over. */
+      if ((sourcedirs[idx] == NULL) || strlen(sourcedirs[idx]) == 0)
+            continue;
+      d = opendir(sourcedirs[idx]);
+      if (d == NULL)
+      {
+         pam_syslog(NULL, LOG_DEBUG, "unable to read directory %s: %m",
+                    sourcedirs[idx]);
+         retval = PAM_PERM_DENIED;
+         goto go_out;
+      }
 
-   /* Scan the directory */
-   d = opendir(source);
-   if (d == NULL)
-   {
-      pam_syslog(NULL, LOG_DEBUG, "unable to read directory %s: %m", source);
-      retval = PAM_PERM_DENIED;
-      goto go_out;
-   }
+      for (dent = readdir(d); dent != NULL; dent = readdir(d))
+      {
+         /* Skip some files.. */
+         if (strcmp(dent->d_name,".") == 0 ||
+             strcmp(dent->d_name,"..") == 0)
+            continue;
 
-   for (dent = readdir(d); dent != NULL; dent = readdir(d))
-   {
-      /* Skip some files.. */
-      if (strcmp(dent->d_name,".") == 0 ||
-	  strcmp(dent->d_name,"..") == 0)
-	 continue;
-
-      retval = copy_entry(&base, pwd, dir_mode, source, dent);
-      if (retval != PAM_SUCCESS)
-	 goto go_out;
+         retval = copy_entry(&base, pwd, dir_mode, sourcedirs[idx], dent,
+                             sourcedirs[idx] == vendordir ? NULL : vendordir);
+         if (retval != PAM_SUCCESS)
+            goto go_out;
+      }
+      closedir(d);
+      d = NULL;
    }
 
    retval = PAM_SUCCESS;
@@ -340,7 +362,8 @@ create_homedir(struct dir_spec *parent, const struct passwd *pwd,
 
 static int
 create_homedir_helper(const struct passwd *_pwd, mode_t home_mode,
-		      const char *_skeldir, const char *_homedir)
+		      const char *_skeldir, const char *_homedir,
+		      const char *_vendordir)
 {
    int retval = PAM_SESSION_ERR;
    struct dir_spec base;
@@ -357,7 +380,7 @@ create_homedir_helper(const struct passwd *_pwd, mode_t home_mode,
    }
    *cp = '/';
 
-   retval = create_homedir(&base, _pwd, home_mode, _skeldir, cp + 1);
+   retval = create_homedir(&base, _pwd, home_mode, _skeldir, cp + 1, _vendordir);
 
  go_out:
    dir_spec_close(&base);
@@ -399,6 +422,7 @@ main(int argc, char *argv[])
    struct stat st;
    char *eptr;
    unsigned long home_mode = 0;
+   const char *vendordir = NULL;
 
    if (argc < 2) {
 	fprintf(stderr, "Usage: %s <username> [<umask> [<skeldir> [<home_mode>]]]\n", argv[0]);
@@ -433,6 +457,9 @@ main(int argc, char *argv[])
        }
    }
 
+   if (argc >= 6)
+      vendordir = argv[5];
+
    if (home_mode == 0)
       home_mode = 0777 & ~u_mask;
 
@@ -449,5 +476,5 @@ main(int argc, char *argv[])
    if (make_parent_dirs(pwd->pw_dir, 0) != PAM_SUCCESS)
 	return PAM_PERM_DENIED;
 
-   return create_homedir_helper(pwd, home_mode, skeldir, pwd->pw_dir);
+   return create_homedir_helper(pwd, home_mode, skeldir, pwd->pw_dir, vendordir);
 }

--- a/modules/pam_mkhomedir/pam_mkhomedir.8.xml
+++ b/modules/pam_mkhomedir/pam_mkhomedir.8.xml
@@ -46,6 +46,12 @@
       <filename>/etc/skel/</filename>) is used to copy default files
       and also sets a umask for the creation.
     </para>
+
+    <para condition="with_vendordir">
+      <emphasis>%vendordir%/skel</emphasis> will also be used unless
+      <replaceable>skel</replaceable> option is specified.
+    </para>
+
     <para>
       The new users home directory will not be removed after logout
       of the user.


### PR DESCRIPTION
* With the configuration split between /etc and vendordir, mkhomedir should take care of the skeleton directory from the distribution-provided configuration.
* When default skel dir is chosen, take files from both location and preferring those from /etc/skel.
* Add pam_mkhomedir.h to store macros and unified includes.