### PR TITLE
pam_faillock: skip clearing user's failed attempt

### DIFF
--- a/modules/pam_faillock/pam_faillock.8.xml
+++ b/modules/pam_faillock/pam_faillock.8.xml
@@ -243,6 +243,14 @@
       user accounts allowing the adversary to infer that a particular account
       is not existing on a system.
     </para>
+    <para>
+      If the <option>auth</option> stack has not been run prior to the <option>account</option>
+      stack, the logic to reset the failed login counter is intentionally skipped. This prevents
+      automated services, such as <emphasis>crond</emphasis> or <emphasis>systemd-user</emphasis>,
+      which might only perform account management tasks, from inadvertently clearing a user's
+      failed attempt records. This ensures the faillock counter is only reset by a service that
+      performs a full, successful authentication.
+    </para>
   </refsect1>
 
   <refsect1 xml:id="pam_faillock-examples">

--- a/modules/pam_faillock/pam_faillock.c
+++ b/modules/pam_faillock/pam_faillock.c
@@ -62,6 +62,8 @@
 #define FAILLOCK_ACTION_AUTHSUCC 1
 #define FAILLOCK_ACTION_AUTHFAIL 2
 
+#define FAILLOCK_AUTH_EXECUTED   "pam_faillock:auth_executed"
+
 static int
 args_parse(pam_handle_t *pamh, int argc, const char **argv,
 		int flags, struct options *opts)
@@ -478,6 +480,10 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags,
 		goto err;
 	}
 
+	rv = pam_set_data(pamh, FAILLOCK_AUTH_EXECUTED, (void *)1, NULL);
+	if (rv != PAM_SUCCESS)
+		goto err;
+
 	if (!(opts.flags & FAILLOCK_FLAG_LOCAL_ONLY) ||
 		check_local_user (pamh, opts.user) != 0) {
 		switch (opts.action) {
@@ -531,6 +537,7 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags,
 	struct options opts;
 	int rv, fd = -1;
 	struct tally_data tallies;
+	const void *auth_flag;
 
 	memset(&tallies, 0, sizeof(tallies));
 
@@ -540,6 +547,12 @@ pam_sm_acct_mgmt(pam_handle_t *pamh, int flags,
 		goto err;
 
 	opts.action = FAILLOCK_ACTION_AUTHSUCC;
+
+	rv = pam_get_data(pamh, FAILLOCK_AUTH_EXECUTED, &auth_flag);
+	if (rv == PAM_NO_MODULE_DATA) {
+		rv = PAM_SUCCESS;
+		goto err;
+	}
 
 	if ((rv=get_pam_user(pamh, &opts)) != PAM_SUCCESS) {
 		goto err;


### PR DESCRIPTION
* modules/pam_faillock/pam_faillock.c: when `auth` stack isn't run skip
clearing the user's failed attempt record during `account` stack.

Automate services, like `crond` or `systemd-user`, skip the `auth` stack and directly invoke the `account` stack. Thus, they can clear the user's failed attempt records. When `ignore_services` option is used, if the calling service matches one of the specified names, `pam_faillock` simply skips the logic for resetting the failed login counter.

Resolves: https://issues.redhat.com/browse/RHEL-32294