### PR TITLE
pam_unix: remove NIS+ leftovers

### DIFF
--- a/modules/pam_unix/pam_unix_auth.c
+++ b/modules/pam_unix/pam_unix_auth.c
@@ -2,7 +2,6 @@
  * pam_unix authentication management
  *
  * Copyright Alexander O. Yuriev, 1996.  All rights reserved.
- * NIS+ support by Thorsten Kukuk <kukuk@weber.uni-paderborn.de>
  * Copyright Jan Rękorajski, 1999.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The Linux-NIS+ project is dead since about 25 years and was never finished. There is no working NIS+ client code out there for Linux, so let's remove the remaining code to simplify pam_unix.