### PR TITLE
pam_unix: add support for pwaccessd (#902)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -264,6 +264,10 @@ foreach f: ['crypt_r']
   endif
 endforeach
 
+libpwaccess = dependency('libpwaccess', required: get_option('pwaccess'))
+if libpwaccess.found()
+  cdata.set('USE_PWACCESS', 1)
+endif
 
 libeconf = dependency('libeconf', version: '>= 0.5.0', required: get_option('econf'))
 if libeconf.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,8 @@ option('elogind', type: 'feature', value: 'auto',
        description: 'logind support in pam_issue, pam_limits, and pam_timestamp via elogind')
 option('openssl', type: 'feature', value: 'disabled',
        description: 'Use OpenSSL crypto libraries in pam_timestamp')
+option('pwaccess', type: 'feature', value: 'auto',
+       description: 'libpwaccess support in pam_unix')
 option('selinux', type: 'feature', value: 'auto',
        description: 'SELinux support')
 option('nis', type: 'feature', value: 'auto',

--- a/modules/module-meson.build
+++ b/modules/module-meson.build
@@ -431,7 +431,7 @@ if module == 'pam_unix'
              ],
     c_args: ['-DHELPER_COMPILE="unix_chkpwd"'],
     link_args: exe_link_args,
-    dependencies: [libpam_internal_dep, libpam_dep, libcrypt, libselinux, libaudit],
+    dependencies: [libpam_internal_dep, libpam_dep, libcrypt, libselinux, libaudit, libpwaccess],
     install: true,
     install_dir: sbindir,
   )
@@ -447,7 +447,7 @@ if module == 'pam_unix'
                ],
       c_args: ['-DHELPER_COMPILE="unix_update"'],
       link_args: exe_link_args,
-      dependencies: [libpam_internal_dep, libpam_dep, libcrypt, libselinux, libaudit],
+      dependencies: [libpam_internal_dep, libpam_dep, libcrypt, libselinux, libaudit, libpwaccess],
       install: true,
       install_dir: sbindir,
     )


### PR DESCRIPTION
[pwaccess](https://github.com/thkukuk/pwaccess) is a systemd socket activated service which provides passwd and shadow entries to root or the user of that entry to avoid having binaries owned by group shadow and/or setuid/setgid to do the authentication.

Reasons:
- avoid UID/GID shift with image based updates, so everything in /usr should be owned by root:root
- security, don't allow setuid/setgid binaries. Requested by:
  - systemd developers (https://github.com/linux-pam/linux-pam/issues/902)
  - our security team

Since with #912 pam_unix could behave different than today, I decided to only replace the `getspnam()` call in unix_chkpwd, so that unix_chkpwd does not need the setuid bit if pwaccessd is running. If not, unix_chkpwd will fallback to `getspnam()`. 

`pwaccess` itself got reviewed by our security team.