### PR TITLE
check_user: use pam_unix.so as example config

### DIFF
--- a/examples/check_user.c
+++ b/examples/check_user.c
@@ -6,8 +6,8 @@
 
   You need to add the following (or equivalent) to the /etc/pam.conf file.
   # check authorization
-  check   auth       required     pam_unix_auth.so
-  check   account    required     pam_unix_acct.so
+  check   auth       required     pam_unix.so
+  check   account    required     pam_unix.so
 */
 
 #include <security/pam_appl.h>


### PR DESCRIPTION
We don't have pam_unix_*.so anymore, so don't use them for example configs.
People really follow this...