### PR TITLE
meson_options: set default vendordir (#933)

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -87,7 +87,7 @@ option('xauth', type: 'string',
        description: 'Additional path to check for xauth when it is called from pam_xauth')
 option('randomdev', type: 'string',
        description: 'Random device to use instead of /dev/urandom')
-option('vendordir', type: 'string',
+option('vendordir', type: 'string', value: '/usr/share/pam',
        description: 'Distribution provided configuration files directory')
 
 option('pam_userdb', type: 'feature', value: 'auto',


### PR DESCRIPTION
If libeconf support is enabled and no vendordir is set, use /usr/share/pam as default.

The old behavior (disabled vendordir) can be archived with `meson setup build -Dvendordir=''`, but at runtime there should be no difference if people don't use `/usr/share/pam`.