### PR TITLE
Support the target and override_home options for pam_mkhomedir

### DIFF
--- a/modules/pam_mkhomedir/mkhomedir_helper.8.xml
+++ b/modules/pam_mkhomedir/mkhomedir_helper.8.xml
@@ -28,6 +28,9 @@
         <replaceable>path-to-vendor-skel</replaceable>
       </arg>
       </arg>
+      <arg choice="opt" rep="norepeat">
+        <replaceable>target-dir</replaceable>
+      </arg>
       </arg>
       </arg>
     </cmdsynopsis>
@@ -48,7 +51,9 @@
       default value of <replaceable>path-to-skel</replaceable> is
       <emphasis>/etc/skel</emphasis>. The default value of
       <replaceable>home_mode</replaceable> is computed from the value of
-      <replaceable>umask</replaceable>.
+      <replaceable>umask</replaceable>.   If <replaceable>target-dir</replaceable>
+      is not specified, the home directory location from the user's password
+      entry is used.
     </para>
 
     <para>

--- a/modules/pam_mkhomedir/mkhomedir_helper.c
+++ b/modules/pam_mkhomedir/mkhomedir_helper.c
@@ -388,7 +388,7 @@ create_homedir_helper(const struct passwd *_pwd, mode_t home_mode,
 }
 
 static int
-make_parent_dirs(char *dir, int make)
+make_parent_dirs(const char *dir, int make)
 {
   int rc = PAM_SUCCESS;
   char *cp = strrchr(dir, '/');
@@ -423,9 +423,10 @@ main(int argc, char *argv[])
    char *eptr;
    unsigned long home_mode = 0;
    const char *vendordir = NULL;
+   const char *target_dir = NULL;
 
    if (argc < 2) {
-	fprintf(stderr, "Usage: %s <username> [<umask> [<skeldir> [<home_mode>]]]\n", argv[0]);
+	fprintf(stderr, "Usage: %s <username> [<umask> [<skeldir> [<home_mode> [<target_dir>] [<vendordir>]]]]\n", argv[0]);
 	return PAM_SESSION_ERR;
    }
 
@@ -457,24 +458,30 @@ main(int argc, char *argv[])
        }
    }
 
-   if (argc >= 6)
-      vendordir = argv[5];
-
    if (home_mode == 0)
       home_mode = 0777 & ~u_mask;
 
-   if (pwd->pw_dir[0] != '/') {
+    if (argc >= 6) {
+      target_dir = argv[5];
+   } else {
+      target_dir = pwd->pw_dir;
+    }
+
+   if (target_dir[0] != '/') {
       pam_syslog(NULL, LOG_ERR, "Relative user home directory %s", pwd->pw_dir);
       return PAM_SESSION_ERR;
    }
 
+   if (argc >= 7)
+   vendordir = argv[6];
+
    /* Stat the home directory, if something exists then we assume it is
       correct and return a success */
-   if (stat(pwd->pw_dir, &st) == 0)
+   if (stat(target_dir, &st) == 0)
 	return PAM_SUCCESS;
 
-   if (make_parent_dirs(pwd->pw_dir, 0) != PAM_SUCCESS)
+   if (make_parent_dirs(target_dir, 0) != PAM_SUCCESS)
 	return PAM_PERM_DENIED;
 
-   return create_homedir_helper(pwd, home_mode, skeldir, pwd->pw_dir, vendordir);
+   return create_homedir_helper(pwd, home_mode, skeldir, target_dir, vendordir);
 }

--- a/modules/pam_mkhomedir/mkhomedir_helper.c
+++ b/modules/pam_mkhomedir/mkhomedir_helper.c
@@ -473,7 +473,7 @@ main(int argc, char *argv[])
    }
 
    if (argc >= 7)
-   vendordir = argv[6];
+      vendordir = argv[6];
 
    /* Stat the home directory, if something exists then we assume it is
       correct and return a success */

--- a/modules/pam_mkhomedir/pam_mkhomedir.8.xml
+++ b/modules/pam_mkhomedir/pam_mkhomedir.8.xml
@@ -31,6 +31,12 @@
       <arg choice="opt" rep="norepeat">
         skel=<replaceable>skeldir</replaceable>
       </arg>
+      <arg choice="opt" rep="norepeat">
+        parent=<replaceable>parentdir</replaceable>
+      </arg>
+      <arg choice="opt" rep="norepeat">
+        override_home
+      </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -119,6 +125,33 @@
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term>
+          <option>parent=<replaceable>/path/to/parent/directory</replaceable></option>
+        </term>
+        <listitem>
+          <para>
+            Specify an alternative parent directory where home directories
+            will be created. When this option is used, the home directory
+            will be created as <filename><replaceable>parent</replaceable>/<replaceable>username</replaceable></filename>
+            instead of using the home directory from the user's password entry.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>override_home</option>
+        </term>
+        <listitem>
+          <para>
+            When this option is set, the module will set the HOME environment
+            variable to the location of the directory that the module manages.
+            This is useful when the home directory created by the module should
+            become the effective home directory for the session.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 
@@ -196,6 +229,20 @@
   session    required    pam_unix.so
   session    optional    pam_lastlog.so
   session    optional    pam_mail.so standard
+      </programlisting>
+    </para>
+
+    <para>
+      An example using the parent option to create home directories under /home/users:
+      <programlisting>
+  session    required    pam_mkhomedir.so parent=/home/users skel=/etc/skel/ umask=0022
+      </programlisting>
+    </para>
+
+    <para>
+      An example using the override_home option to set the HOME environment variable:
+      <programlisting>
+  session    required    pam_mkhomedir.so parent=/home/users override_home skel=/etc/skel/ umask=0022
       </programlisting>
     </para>
   </refsect1>

--- a/modules/pam_mkhomedir/pam_mkhomedir.c
+++ b/modules/pam_mkhomedir/pam_mkhomedir.c
@@ -54,8 +54,9 @@
 #include "pam_i18n.h"
 
 /* argument parsing */
-#define MKHOMEDIR_DEBUG      020	/* be verbose about things */
-#define MKHOMEDIR_QUIET      040	/* keep quiet about things */
+#define MKHOMEDIR_DEBUG         020	/* be verbose about things */
+#define MKHOMEDIR_QUIET         040	/* keep quiet about things */
+#define MKHOMEDIR_OVERRIDE_HOME 060 /* override the home directory */
 
 #define LOGIN_DEFS           "/etc/login.defs"
 #define UMASK_DEFAULT        "0022"
@@ -69,6 +70,7 @@ struct options_t {
   int ctrl;
   const char *umask;
   const char *skeldir;
+  const char *parent;
 };
 typedef struct options_t options_t;
 
@@ -79,6 +81,7 @@ _pam_parse (const pam_handle_t *pamh, int flags, int argc, const char **argv,
    opt->ctrl = 0;
    opt->umask = NULL;
    opt->skeldir = NULL;
+   opt->parent = NULL;
 
    /* does the application require quiet? */
    if ((flags & PAM_SILENT) == PAM_SILENT)
@@ -97,6 +100,10 @@ _pam_parse (const pam_handle_t *pamh, int flags, int argc, const char **argv,
 	 opt->umask = str;
       } else if ((str = pam_str_skip_prefix(*argv, "skel=")) != NULL) {
 	 opt->skeldir = str;
+      } else if ((str = pam_str_skip_prefix(*argv, "parent=")) != NULL) {
+    opt->parent = str;
+      } else if (!strcmp(*argv,"override_home")) {
+    opt->ctrl |= MKHOMEDIR_OVERRIDE_HOME;
       } else {
 	 pam_syslog(pamh, LOG_ERR, "unknown option: %s", *argv);
       }
@@ -172,8 +179,9 @@ create_homedir (pam_handle_t *pamh, options_t *opt,
 	args[2] = opt->umask ? opt->umask : UMASK_DEFAULT;
 	args[3] = opt->skeldir ? opt->skeldir : SKELDIR;
 	args[4] = login_homemode;
+	args[5] = dir;
 #ifdef VENDORDIR
-	args[5] = opt->skeldir ? NULL : VENDOR_SKELDIR;
+	args[6] = opt->skeldir ? NULL : VENDOR_SKELDIR;
 #endif
 
 	DIAG_PUSH_IGNORE_CAST_QUAL;
@@ -230,6 +238,8 @@ pam_sm_open_session (pam_handle_t *pamh, int flags, int argc,
    const void *user;
    const struct passwd *pwd;
    struct stat St;
+   char *homedir = NULL;
+   const char *target_dir;
 
    /* Parse the flag values */
    _pam_parse(pamh, flags, argc, argv, &opt);
@@ -251,17 +261,70 @@ pam_sm_open_session (pam_handle_t *pamh, int flags, int argc,
       return PAM_USER_UNKNOWN;
    }
 
+   /* Determine the target home directory */
+   if (opt.parent != NULL) {
+         /* Use parent directory option to construct home directory path */
+         size_t parent_len = strlen(opt.parent);
+         size_t user_len = strlen((const char *)user);
+
+         /* Allocate memory for parent + "/" + username + null terminator */
+         homedir = malloc(parent_len + 1 + user_len + 1);
+         if (homedir == NULL) {
+            pam_syslog(pamh, LOG_ERR, "Memory allocation failed.");
+            return PAM_BUF_ERR;
+         }
+
+         /* Construct the path: parent/username */
+         snprintf(homedir, parent_len + 1 + user_len + 1, "%s/%s", opt.parent, (const char *)user);
+         target_dir = homedir;
+
+         if (opt.ctrl & MKHOMEDIR_DEBUG) {
+            pam_syslog(pamh, LOG_DEBUG, "Using parent option: creating home directory %s", target_dir);
+         }
+      } else {
+         /* Use the home directory from the password entry */
+         target_dir = pwd->pw_dir;
+      }
+
+
    /* Stat the home directory, if something exists then we assume it is
       correct and return a success*/
-   if (stat(pwd->pw_dir, &St) == 0) {
+   if (stat(target_dir, &St) == 0) {
       if (opt.ctrl & MKHOMEDIR_DEBUG) {
           pam_syslog(pamh, LOG_DEBUG, "Home directory %s already exists.",
-              pwd->pw_dir);
+              target_dir);
       }
-      return PAM_SUCCESS;
+      retval = PAM_SUCCESS;
+   } else {
+      retval = create_homedir(pamh, &opt, user, target_dir);
    }
 
-   return create_homedir(pamh, &opt, user, pwd->pw_dir);
+    /* Set HOME environment variable if override_home option is enabled */
+   if (retval == PAM_SUCCESS && opt.ctrl & MKHOMEDIR_OVERRIDE_HOME) {
+      char *home_env;
+      size_t home_len = strlen("HOME=") + strlen(target_dir) + 1;
+
+      home_env = malloc(home_len);
+      if (home_env == NULL) {
+         pam_syslog(pamh, LOG_ERR, "Memory allocation failed for HOME environment variable");
+         retval = PAM_BUF_ERR;
+      } else {
+         snprintf(home_env, home_len, "HOME=%s", target_dir);
+         retval = pam_putenv(pamh, home_env);
+         if (retval != PAM_SUCCESS) {
+            pam_syslog(pamh, LOG_ERR, "Failed to set HOME environment variable to %s", target_dir);
+         } else if (opt.ctrl & MKHOMEDIR_DEBUG) {
+            pam_syslog(pamh, LOG_DEBUG, "Set HOME environment variable to %s", target_dir);
+         }
+         free(home_env);
+      }
+   }
+
+   if (homedir != NULL) {
+      free(homedir);
+   }
+
+   return retval;
 }
 
 /* Ignore */


### PR DESCRIPTION
Fixes #938

The parent option forces pam_mkhomedir to create home directories under an alternative parent directory, and the override_home option causes the HOME environment variable to point to the managed home directory.