### PR TITLE
Define missing HAVE_YP_* to fix nis (passwd)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -477,6 +477,8 @@ if enable_pam_unix
           enable_nis = false
           libnsl = null_dep
           break
+        else
+          cdata.set('HAVE_' + f.to_upper(), 1)
         endif
       endforeach
     endif


### PR DESCRIPTION
File modules/pam_unix/support.c contains the line

#if defined(HAVE_NIS) && defined(HAVE_YP_GET_DEFAULT_DOMAIN) && defined (HAVE_YP_BIND) && defined (HAVE_YP_MATCH) && defined (HAVE_YP_UNBIND)

but the macros HAVE_YP_* are never defined. This causes "passwd" to fail for nis users, because the code following this line is not executed.

This commit fixes this problem. These macros was defined until version 1.6.1 by configure, but was not migrated to meson.

It fixes https://bugzilla.redhat.com/show_bug.cgi?id=2363005 .