### PR TITLE
Prepare for 1.7.2 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,18 @@
 Linux-PAM NEWS -- history of user-visible changes.
 
+Release 1.7.2
+* build: enabled vendordir by default.
+* pam_access: fixed stack overflow with huge configuration files.
+* pam_env: enhanced error diagnostics when ignoring backslash at end of string.
+* pam_faillock: skip clearing user's failed attempt when auth stack is not run.
+* pam_mkhomedir: added support for vendordir skeleton directory.
+* pam_unix: added support for pwaccessd.
+* pam_unix: added support for PAM_CHANGE_EXPIRED_AUTHTOK.
+* pam_unix: fixed password expiration warnings for large day values.
+* pam_unix: hardened temporary file handling.
+* Multiple minor bug fixes, build fixes, portability fixes,
+  documentation improvements, and translation updates.
+
 Release 1.7.1
 * pam_access: do not resolve ttys or display variables as hostnames.
 * pam_access: added "nodns" option to disallow resolving of tokens as hostnames

--- a/doc/adg/Linux-PAM_ADG.xml
+++ b/doc/adg/Linux-PAM_ADG.xml
@@ -5,7 +5,7 @@
       <author><personname><firstname>Andrew G.</firstname><surname>Morgan</surname></personname><email>morgan@kernel.org</email></author>
       <author><personname><firstname>Thorsten</firstname><surname>Kukuk</surname></personname><email>kukuk@thkukuk.de</email></author>
     </authorgroup>
-    <releaseinfo>Version 1.7.1, June 2025</releaseinfo>
+    <releaseinfo>Version 1.7.2, January 2026</releaseinfo>
     <abstract>
       <para>
         This manual documents what an application developer needs to know

--- a/doc/mwg/Linux-PAM_MWG.xml
+++ b/doc/mwg/Linux-PAM_MWG.xml
@@ -5,7 +5,7 @@
       <author><personname><firstname>Andrew G.</firstname><surname>Morgan</surname></personname><email>morgan@kernel.org</email></author>
       <author><personname><firstname>Thorsten</firstname><surname>Kukuk</surname></personname><email>kukuk@thkukuk.de</email></author>
     </authorgroup>
-    <releaseinfo>Version 1.7.1, June 2025</releaseinfo>
+    <releaseinfo>Version 1.7.2, January 2026</releaseinfo>
     <abstract>
       <para>
         This manual documents what a programmer needs to know in order

--- a/doc/sag/Linux-PAM_SAG.xml
+++ b/doc/sag/Linux-PAM_SAG.xml
@@ -5,7 +5,7 @@
       <author><personname><firstname>Andrew G.</firstname><surname>Morgan</surname></personname><email>morgan@kernel.org</email></author>
       <author><personname><firstname>Thorsten</firstname><surname>Kukuk</surname></personname><email>kukuk@thkukuk.de</email></author>
     </authorgroup>
-    <releaseinfo>Version 1.7.1, June 2025</releaseinfo>
+    <releaseinfo>Version 1.7.2, January 2026</releaseinfo>
     <abstract>
       <para>
         This manual documents what a system-administrator needs to know about

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('Linux-PAM', 'c',
-        version: '1.7.1',
+        version: '1.7.2',
         license: 'BSD-3-Clause OR GPL-2.0-or-later',
         default_options: [
           'b_pie=true',

--- a/po/Linux-PAM.pot
+++ b/po/Linux-PAM.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Linux-PAM 1.7.1\n"
+"Project-Id-Version: Linux-PAM 1.7.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linux-pam/linux-pam/issues\n"
 "POT-Creation-Date: 2026-01-20 08:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
* meson.build: Raise project version to 1.7.2.
* po/meson.build: Likewise.
* po/Linux-PAM.pot (Project-Id-Version): Likewise.
* doc/adg/Linux-PAM_ADG.xml: Likewise.
* doc/mwg/Linux-PAM_MWG.xml: Likewise.
* doc/sag/Linux-PAM_SAG.xml: Likewise.
* NEWS: Update.

Resolves: https://github.com/linux-pam/linux-pam/issues/962