### PR TITLE
ci: use matrix strategy to avoid code duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,25 @@ name: CI
 
 on: [push, pull_request]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   VERBOSE: 1
 
 jobs:
   whitespace-errors:
+    name: Check for whitespace errors
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: check
-      run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: check
+        run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
   build-check:
     runs-on: ubuntu-24.04
@@ -52,9 +61,10 @@ jobs:
       CC: ${{ matrix.cc }}
       TARGET: x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set environment variables
         env:


### PR DESCRIPTION
The CI workflow runs 53 jobs, 52 of which are identical except for environment variables. These 52 jobs can be combined into a single matrix-strategy job that encodes all the combinations of environment variables it should run with.

This should have no effect on the actual jobs that are run, but eliminates code duplication and makes the CI workflow simpler to maintain and update.

Additionally, some minor workflow cleanup and security and efficiency improvements (recommended by Zizmor: https://docs.zizmor.sh/):

* Update `actions/checkout` to latest version and pin it by commit hash: https://docs.zizmor.sh/audits/#unpinned-uses
* Set `persist-credentials: false` for `actions/checkout`: https://docs.zizmor.sh/audits/#artipacked
* Set `permissions: {}` at the workflow level to prevent unnecessarily granting overly broad default permissions to jobs:  https://docs.zizmor.sh/audits/#excessive-permissions
* Set concurrency limits so when a new CI run is started, any in-progress CI runs for the same PR, branch, or tag are canceled: https://docs.zizmor.sh/audits/#concurrency-limits
* Add job names: https://docs.zizmor.sh/audits/#anonymous-definition