### PR TITLE
doc: Fix grammar

### DIFF
--- a/doc/man/pam.3.xml
+++ b/doc/man/pam.3.xml
@@ -114,7 +114,7 @@
         <citerefentry>
           <refentrytitle>pam_open_session</refentrytitle><manvolnum>3</manvolnum>
         </citerefentry> function sets up a user session for a previously
-        successful authenticated user. The session should later be terminated
+        successfully authenticated user. The session should later be terminated
         with a call to
         <citerefentry>
           <refentrytitle>pam_close_session</refentrytitle><manvolnum>3</manvolnum>

--- a/doc/man/pam_close_session.3.xml
+++ b/doc/man/pam_close_session.3.xml
@@ -91,7 +91,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Session was successful terminated.
+             Session was successfully terminated.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_end.3.xml
+++ b/doc/man/pam_end.3.xml
@@ -83,7 +83,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Transaction was successful terminated.
+             Transaction was successfully terminated.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_fail_delay.3.xml
+++ b/doc/man/pam_fail_delay.3.xml
@@ -165,7 +165,7 @@ module #2:    pam_fail_delay (pamh, 4000000);
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-            Delay was successful adjusted.
+            Delay was successfully adjusted.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_get_data.3.xml
+++ b/doc/man/pam_get_data.3.xml
@@ -62,7 +62,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Data was successful retrieved.
+             Data was successfully retrieved.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_get_item.3.xml
+++ b/doc/man/pam_get_item.3.xml
@@ -101,7 +101,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Data was successful updated.
+             Data was successfully updated.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_get_user.3.xml
+++ b/doc/man/pam_get_user.3.xml
@@ -91,7 +91,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             User name was successful retrieved.
+             User name was successfully retrieved.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_info.3.xml
+++ b/doc/man/pam_info.3.xml
@@ -71,7 +71,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Transaction was successful created.
+             Transaction was successfully created.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_open_session.3.xml
+++ b/doc/man/pam_open_session.3.xml
@@ -30,7 +30,7 @@
     <title>DESCRIPTION</title>
     <para>
       The <function>pam_open_session</function> function sets up a
-      user session for a previously successful authenticated user.
+      user session for a previously successfully authenticated user.
       The session should later be terminated with a call to
       <citerefentry>
         <refentrytitle>pam_close_session</refentrytitle><manvolnum>3</manvolnum>
@@ -91,7 +91,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Session was successful created.
+             Session was successfully created.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_set_data.3.xml
+++ b/doc/man/pam_set_data.3.xml
@@ -141,7 +141,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Data was successful stored.
+             Data was successfully stored.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_set_item.3.xml
+++ b/doc/man/pam_set_item.3.xml
@@ -94,7 +94,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Data was successful updated.
+             Data was successfully updated.
           </para>
         </listitem>
       </varlistentry>

--- a/doc/man/pam_setcred.3.xml
+++ b/doc/man/pam_setcred.3.xml
@@ -131,7 +131,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Data was successful stored.
+             Data was successfully stored.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_echo/pam_echo.8.xml
+++ b/modules/pam_echo/pam_echo.8.xml
@@ -118,7 +118,7 @@
         <term>PAM_SUCCESS</term>
         <listitem>
            <para>
-             Message was successful printed.
+             Message was successfully printed.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_faildelay/pam_faildelay.8.xml
+++ b/modules/pam_faildelay/pam_faildelay.8.xml
@@ -79,7 +79,7 @@
         <term>PAM_IGNORE</term>
         <listitem>
            <para>
-            Delay was successful adjusted.
+            Delay was successfully adjusted.
           </para>
         </listitem>
       </varlistentry>

--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -91,8 +91,8 @@
     </para>
 
     <para>
-      The session component of this module logs when a user logins
-      or leave the system.
+      The session component of this module logs when a user logs in
+      or leaves the system.
     </para>
 
     <para>

--- a/modules/pam_unix/pam_unix.8.xml
+++ b/modules/pam_unix/pam_unix.8.xml
@@ -93,8 +93,8 @@
     </para>
 
     <para>
-      The session component of this module logs when a user logins
-      or leave the system.
+      The session component of this module logs when a user logs in
+      or leaves the system.
     </para>
 
     <para>


### PR DESCRIPTION
Use "successfully" as adverb.
Also fix grammar in pam_unix manual page.