### PR TITLE
pam_access: fix user_match() for fully qualified domain usernames

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -681,6 +681,16 @@ user_match (pam_handle_t *pamh, char *tok, struct login_info *item)
     if (tok[0] == '(' && tok[strlen(tok) - 1] == ')') {
       return (group_match (pamh, tok, string, item->debug));
     } else if ((at = strchr(at, '@')) != NULL) {
++    /* The token contains '@'. It could be a fully qualified domain
++     * username (user@domain) or the legacy user@host syntax.
++     * Try an exact match against the login name first so that
++     * "user@domain" tokens work when use_fully_qualified_names is
++     * enabled in SSSD / AD / IPA environments. */
++	
++    if (string_match(pamh, tok, string))
++        return YES;
++
++    /* Fall back to interpreting token as user@host */
         /* split user@host pattern */
 	if (item->hostname == NULL)
 	    return NO;

--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -681,16 +681,16 @@ user_match (pam_handle_t *pamh, char *tok, struct login_info *item)
     if (tok[0] == '(' && tok[strlen(tok) - 1] == ')') {
       return (group_match (pamh, tok, string, item->debug));
     } else if ((at = strchr(at, '@')) != NULL) {
-+    /* The token contains '@'. It could be a fully qualified domain
-+     * username (user@domain) or the legacy user@host syntax.
-+     * Try an exact match against the login name first so that
-+     * "user@domain" tokens work when use_fully_qualified_names is
-+     * enabled in SSSD / AD / IPA environments. */
-+	
-+    if (string_match(pamh, tok, string))
-+        return YES;
-+
-+    /* Fall back to interpreting token as user@host */
+    /* The token contains '@'. It could be a fully qualified domain
+     * username (user@domain) or the legacy user@host syntax.
+     * Try an exact match against the login name first so that
+     * "user@domain" tokens work when use_fully_qualified_names is
+     * enabled in SSSD / AD / IPA environments. */
+	
+    if (string_match(pamh, tok, string))
+        return YES;
+
+    /* Fall back to interpreting token as user@host */
         /* split user@host pattern */
 	if (item->hostname == NULL)
 	    return NO;


### PR DESCRIPTION
When a username contains '@' (e.g. "administrator@example.com"), the user_match() function incorrectly interprets it as the legacy"user@host" syntax  defined in access.conf(5). It splits the token at '@', then tries to match just "administrator" against the full username "administrator@example.com", which fails.

This is a problem for systems joined to Active Directory or IPA domains where SSSD is configured with use_fully_qualified_names=True, producing usernames in the "user@domain" format.

Fix this by attempting an exact string_match() of the full token (including '@') against the login username BEFORE falling back to the user@host split. If the token matches the username as-is, there is no need to parse it as user@host.

The user@host legacy behavior is preserved as a fallback.

Resolves: https://github.com/linux-pam/linux-pam/issues/979