### PR TITLE
pam_access: Fix matching of fully qualified usernames

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -675,6 +675,18 @@ user_match (pam_handle_t *pamh, char *tok, struct login_info *item)
      * name of the user's primary group.
      */
 
+    /*
+     * Exact match for fully qualified username (user@domain) to prevent
+     * fully qualified usernames from being incorrectly parsed as user@host
+     * patterns.
+     */
+    if (strchr(string, '@') != NULL && strcasecmp(tok, string) == 0) {
+        if (item->debug)
+           pam_syslog (pamh, LOG_DEBUG,
+                       "user_match: exact match for fully qualified username '%s'", string);
+        return YES;
+    }
+
     /* Try to split on a pattern (@*[^@]+)(@+.*) */
     for (at = tok; *at == '@'; ++at);
 


### PR DESCRIPTION
When **use_fully_qualified_names** is enabled in SSSD (**True**), usernames contain @ symbols (e.g., user@example.com). In such situations, `pam_access` was incorrectly parsing these as user@host patterns, causing access to fail when **user@domain** is defined in `/etc/security/access.conf` file.

This patch adds an exact string match check before attempting to parse @ as a user@host separator, fixing access control for fully qualified usernames (user@domain).

  - fully_qualified group-based matching (**group@domain**) already worked, username matching now works too.
  - Backward compatible with existing **user@host** pattern functionality

Verified with RHEL 8.10.

Fixes: [979](https://github.com/linux-pam/linux-pam/issues/979)