### PR TITLE
pam_env: fix check for buffer size (#975)

### DIFF
--- a/modules/pam_env/pam_env.c
+++ b/modules/pam_env/pam_env.c
@@ -550,7 +550,7 @@ _strbuf_reserve(struct string_buffer *buffer, size_t add)
   if (buffer->size == 0 && add < 64) {
     /* Start with 64 bytes if that's enough */
     s = 64;
-  } else if (buffer->size >= SIZE_MAX / 2 || buffer->size * 2 < add + 1) {
+  } else if (buffer->size >= SIZE_MAX / 2 || buffer->size * 2 < buffer->len + add + 1) {
     /* If doubling is not enough (or not possible), get as much as needed */
     s = buffer->len + add + 1;
   } else {


### PR DESCRIPTION
_strbuf_reserve() in modules/pam_env/pam_env.c can allocate insufficient space when doubling the buffer, since it ignores the already used buffer size.