### PR TITLE
pam_pwhistory: allow earlier passwords when remember count is reduced

### DIFF
--- a/modules/pam_pwhistory/opasswd.c
+++ b/modules/pam_pwhistory/opasswd.c
@@ -404,7 +404,7 @@ save_old_pass, const char *user, int howmany, const char *filename, int debug UN
 		      }
 
 		    /* compare the last password */
-		    if (strcmp (last, oldpass) == 0)
+		    if (strcmp (last, oldpass) == 0 && entry.count <= howmany)
 		      goto write_old_data;
 		  }
 		else


### PR DESCRIPTION
When current password already saved in opasswd and remember option is decreased, passwords older than the new limit should be allowed again.

Resolves: https://github.com/linux-pam/linux-pam/issues/987