### PR TITLE
pam_namespace: fix error handling in secure_opendir()

### DIFF
--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -194,14 +194,18 @@ static int secure_opendir(const char *path, int opm, mode_t mode,
 			goto error;
 
 		if (fstat(dfd_next, &st) != 0) {
+			save_errno = errno;
 			close(dfd_next);
+			errno = save_errno;
 			goto error;
 		}
 
 		if ((flags & O_NOFOLLOW) && (opm & SECURE_OPENDIR_PROTECT)) {
 			/* we are inside user-owned dir - protect */
 			if (protect_mount(dfd_next, p, idata) == -1) {
+				save_errno = errno;
 				close(dfd_next);
+				errno = save_errno;
 				goto error;
 			}
 			/*
@@ -244,6 +248,7 @@ static int secure_opendir(const char *path, int opm, mode_t mode,
 			close(rv);
 			rv = -1;
 			errno = save_errno;
+			goto error;
 		}
 		/*
 		 * Reopen the directory to obtain a new descriptor after


### PR DESCRIPTION
Fix error handling in secure_opendir().

* Add missing `goto` to avoid ignoring failures of protect_mount(). Bug introduced in 475bd60c552b98c7eddb3270b0b4196847c0072e
* Add missing logic to propagate `errno` to the caller