### PR TITLE
pam_limits: improve 'wrong limit value' log message

### DIFF
--- a/modules/pam_limits/pam_limits.c
+++ b/modules/pam_limits/pam_limits.c
@@ -719,9 +719,9 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 		} else if (strcmp(lim_value, "1") == 0) {
 			int_value = 1;
 		} else {
-			pam_syslog(pamh, LOG_DEBUG,
-				   "wrong limit value '%s' for limit type '%s'",
-				   lim_value, lim_type);
+			pam_syslog(pamh, LOG_WARNING,
+				   "wrong limit value '%s' for limit item '%s' of type '%s'",
+				   lim_value, lim_item, lim_type);
 		}
 	} else if (limit_item != LIMIT_PRI
 #ifdef RLIMIT_NICE
@@ -742,9 +742,9 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 		temp = temp < INT_MAX ? temp : INT_MAX;
 		int_value = temp > INT_MIN ? temp : INT_MIN;
 		if (int_value == 0 && value_orig == endptr) {
-			pam_syslog(pamh, LOG_DEBUG,
-				   "wrong limit value '%s' for limit type '%s'",
-				   lim_value, lim_type);
+			pam_syslog(pamh, LOG_WARNING,
+				   "wrong limit value '%s' for limit item '%s' of type '%s'",
+				   lim_value, lim_item, lim_type);
             return;
 		}
 	} else {
@@ -754,9 +754,9 @@ process_limit (const pam_handle_t *pamh, int source, const char *lim_type,
 		rlimit_value = strtoul (lim_value, &endptr, 10);
 #endif
 		if (rlimit_value == 0 && value_orig == endptr) {
-			pam_syslog(pamh, LOG_DEBUG,
-				   "wrong limit value '%s' for limit type '%s'",
-				   lim_value, lim_type);
+			pam_syslog(pamh, LOG_WARNING,
+				   "wrong limit value '%s' for limit item '%s' of type '%s'",
+				   lim_value, lim_item, lim_type);
 			return;
 		}
 	}


### PR DESCRIPTION
## Problem

When `pam_limits` encounters an invalid value in `limits.conf`, it logs:

```
pam_limits(sshd:session): wrong limit value 'unlimited' for limit type 'soft'
pam_limits(sshd:session): wrong limit value 'unlimited' for limit type 'hard'
```

If the config has multiple resources all set to `unlimited` (a common hardening pattern), there is no way to tell from the log which resource triggered the error. The admin must manually audit each entry.

Reported in: #366

## Fix

Include the limit item name (`lim_item`) in the diagnostic message:

```
pam_limits(sshd:session): wrong limit value 'unlimited' for limit item 'sigpending' of type 'soft'
pam_limits(sshd:session): wrong limit value 'unlimited' for limit item 'msgqueue' of type 'hard'
```

`lim_item` is already a parameter of `process_limit()` — this is a pure log-message improvement with no logic change.

Also raise the log level from `LOG_DEBUG` to `LOG_WARNING`. A bad value in `limits.conf` silently drops that limit without applying it, which is an actionable configuration error that admins need to see without enabling debug mode. This matches the severity used for similar parse errors elsewhere in the same file (`invalid uid range` at line 1022, `invalid line … skipped` at line 1165, `cannot read settings` at line 982).

## Changes

One file, one function (`process_limit`), three identical syslog calls updated:

- Add `lim_item` as a `%s` argument to the format string (not as the format string itself — no format-string risk; compiler validates via `PAM_FORMAT((printf,3,4))`)
- `LOG_DEBUG` → `LOG_WARNING`

## Testing

The change is diagnostic-only (log messages). No logic paths, return codes, or data structures are modified. Existing tests continue to pass.