### PR TITLE
pam_namespace: remove unused strncat

### DIFF
--- a/modules/pam_namespace/pam_namespace.c
+++ b/modules/pam_namespace/pam_namespace.c
@@ -2498,7 +2498,6 @@ static int get_user_data(struct instance_data *idata)
     /* Fill in RUSER too */
     retval = pam_get_item(idata->pamh, PAM_RUSER, (void*) &user_name );
     if ( user_name != NULL && retval == PAM_SUCCESS && user_name[0] != '\0' ) {
-	strncat(idata->ruser, user_name, sizeof(idata->ruser) - 1);
 	pwd = pam_modutil_getpwnam(idata->pamh, user_name);
     } else {
 	pwd = pam_modutil_getpwuid(idata->pamh, getuid());


### PR DESCRIPTION
* modules/pam_namespace/pam_namespace.c (get_user_data): Remove unused strncat() of user_name into idata->ruser in the PAM_RUSER branch as the shared code path below unconditionally fills idata->ruser from pwd->pw_name.