### PR TITLE
Re-add check for crypt_checksalt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -246,7 +246,7 @@ if not libcrypt.found()
   libcrypt = cc.find_library('crypt')
 endif
 crypt_h = cdata.get('HAVE_CRYPT_H') == 1 ? '''#include <crypt.h>''' : '''#include <unistd.h>'''
-foreach f: ['crypt_r']
+foreach f: ['crypt_r', 'crypt_checksalt']
   if cc.has_function(f, prefix: crypt_h,
                      args: '-D_GNU_SOURCE',
                      dependencies: libcrypt)

--- a/modules/pam_unix/passverify.c
+++ b/modules/pam_unix/passverify.c
@@ -111,7 +111,7 @@ PAMH_ARG_DECL(int verify_pwd_hash,
 			 * Ok, we don't know the crypt algorithm, but maybe
 			 * libcrypt knows about it? We should try it.
 			 */
-#if defined(CRYPT_CHECKSALT_AVAILABLE) && CRYPT_CHECKSALT_AVAILABLE
+#ifdef HAVE_CRYPT_CHECKSALT
 			/* Get the status of the hash from checksalt */
 			int retval_checksalt = crypt_checksalt(hash);
 


### PR DESCRIPTION
At some point in time the check for crypt_checksalt() did go lost, re-add it for meson.